### PR TITLE
Editing Updates

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/Editor.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/Editor.scala
@@ -3,7 +3,6 @@
 
 package lucuma.odb.api.model
 
-import cats.{Applicative, ApplicativeError}
 import cats.data.State
 
 trait Editor[I, T] {
@@ -11,14 +10,5 @@ trait Editor[I, T] {
   def id: I
 
   def editor: ValidatedInput[State[T, Unit]]
-
-  def edit(t: T): ValidatedInput[T] =
-    editor.map(_.runS(t).value)
-
-  def validateOrError[F[_]: Applicative](implicit M: ApplicativeError[F, Throwable]): F[State[T, Unit]] =
-    editor.fold(
-      err => M.raiseError[State[T, Unit]](InputError.Exception(err)),
-      st  => implicitly[Applicative[F]].pure(st)
-    )
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/TopLevelModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/TopLevelModel.scala
@@ -18,14 +18,17 @@ trait TopLevelModel[I, T] {
 
   def existence: Lens[T, Existence]
 
-  def existenceEditor(i: I, s: Existence): Editor[I, T] =
-    new Editor[I, T] {
-      override def id: I =
-        i
+  def existenceEditor(s: Existence): State[T, Unit] =
+    (existence := Some(s)).void
 
-      override def editor: ValidatedInput[State[T, Unit]] =
-        ((existence := Some(s)).void).validNec
-    }
+//  def existenceEditor(i: I, s: Existence): Editor[I, T] =
+//    new Editor[I, T] {
+//      override def id: I =
+//        i
+//
+//      override def editor: ValidatedInput[State[T, Unit]] =
+//        ((existence := Some(s)).void).validNec
+//    }
 }
 
 object TopLevelModel {

--- a/modules/core/src/main/scala/lucuma/odb/api/model/TopLevelModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/TopLevelModel.scala
@@ -21,14 +21,6 @@ trait TopLevelModel[I, T] {
   def existenceEditor(s: Existence): State[T, Unit] =
     (existence := Some(s)).void
 
-//  def existenceEditor(i: I, s: Existence): Editor[I, T] =
-//    new Editor[I, T] {
-//      override def id: I =
-//        i
-//
-//      override def editor: ValidatedInput[State[T, Unit]] =
-//        ((existence := Some(s)).void).validNec
-//    }
 }
 
 object TopLevelModel {

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TopLevelRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TopLevelRepo.scala
@@ -3,11 +3,12 @@
 
 package lucuma.odb.api.repo
 
-import lucuma.odb.api.model.{Event, Existence, InputError, TopLevelModel}
+import lucuma.odb.api.model.{Editor, Event, Existence, InputError, TopLevelModel, ValidatedInput}
 import lucuma.odb.api.model.syntax.toplevel._
+import lucuma.odb.api.model.syntax.validatedinput._
 import lucuma.core.util.Gid
 import cats.{FunctorFilter, Monad, MonadError}
-import cats.data.{EitherNec, State}
+import cats.data._
 import cats.effect.concurrent.Ref
 import cats.syntax.apply._
 import cats.syntax.applicative._
@@ -15,6 +16,7 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.functorFilter._
 import cats.syntax.option._
+import cats.syntax.validated._
 import cats.kernel.BoundedEnumerable
 import monocle.Lens
 import monocle.function.At
@@ -36,27 +38,68 @@ trait TopLevelRepo[F[_], I, T] {
 
   def selectAllWhere(f: Tables => T => Boolean, includeDeleted: Boolean = false): F[List[T]]
 
-  def edit(id: I, s: State[T, Unit]): F[Option[T]]
+  /**
+   * Edits the top-level item identified by the given `Editor`.
+   * @param editor editor instance
+   * @return updated item
+   */
+  def edit(editor: Editor[I, T]): F[T] =
+    edit(editor.id, editor.editor, _ => Nil)
 
-  def editSub[U <: T](id: I, s: State[U, Unit])(f: PartialFunction[T, U]): F[Option[U]]
+  /**
+   * Edits the top-level item identified by the given id and editor
+   *
+   * @param id id of the top level item
+   * @param editor state program that edits the associated top-level item, or else
+   *          any input validation errors
+   * @param checks additional checks that require accessing database tables
+   * @return updated item, but raises an error and does nothing if any checks
+   *         fail
+   */
+  def edit(
+    id:     I,
+    editor: ValidatedInput[State[T, Unit]],
+    checks: Tables => List[InputError]
+  ): F[T] =
+    editSub[T](id, editor, checks)(unlift(_.some))
 
-  def delete(id: I): F[Option[T]]
+  /**
+   * Edits a top-level item identified by the given id, assuming it is of type
+   * `U <: T`.
+   *
+   * @param id id of the top level item (of type T)
+   * @param editor state program that edits the associated top-level item, or else
+   *               any input validation errors
+   * @param checks additional checks that require accessing database tables
+   * @param f a partial function defined when the item is of type U
+   * @return updated item, but raises an error and does nothing if any checks
+   *         fail
+   */
+  def editSub[U <: T](
+    id:     I,
+    editor: ValidatedInput[State[U, Unit]],
+    checks: Tables => List[InputError]
+  )(
+    f: PartialFunction[T, U]
+  ): F[U]
 
-  def undelete(id: I): F[Option[T]]
+  def delete(id: I): F[T]
+
+  def undelete(id: I): F[T]
 
 }
 
 /**
  *
  */
-abstract class TopLevelRepoBase[F[_], I: Gid, T: TopLevelModel[I, ?]](
+abstract class TopLevelRepoBase[F[_]: Monad, I: Gid, T: TopLevelModel[I, ?]](
   tablesRef:    Ref[F, Tables],
   eventService: EventService[F],
   idLens:       Lens[Tables, I],
   mapLens:      Lens[Tables, SortedMap[I, T]],
   created:      T => Long => Event.Created[T],
   edited:       (T, T) => Long => Event.Edited[T]
-)(implicit F: Monad[F], M: MonadError[F, Throwable]) extends TopLevelRepo[F, I, T] {
+)(implicit M: MonadError[F, Throwable]) extends TopLevelRepo[F, I, T] {
 
   def nextId: F[I] =
     tablesRef.modifyState(idLens.mod(BoundedEnumerable[I].cycleNext))
@@ -109,39 +152,48 @@ abstract class TopLevelRepoBase[F[_], I: Gid, T: TopLevelModel[I, ?]](
     } yield u
   }
 
-  override def editSub[U <: T](id: I, s: State[U, Unit])(f: PartialFunction[T, U]): F[Option[U]] = {
+  override def editSub[U <: T](
+    id:     I,
+    editor: ValidatedInput[State[U, Unit]],
+    checks: Tables => List[InputError]
+  )(
+    f: PartialFunction[T, U]
+  ): F[U] = {
 
-    val doUpdate: F[Option[(U, U)]] =
+    val lensT = focusOn(id)
+
+    val lens: Lens[Tables, Option[U]] =
+      Lens[Tables, Option[U]](lensT.get(_).flatMap(f.unapply))(ou => lensT.set(ou))
+
+    val doUpdate: F[(U, U)] =
       tablesRef.modify { oldTables =>
-        val lensT = focusOn(id)
 
-        val lens: Lens[Tables, Option[U]] =
-          Lens[Tables, Option[U]](lensT.get(_).flatMap(f.unapply))(ou => lensT.set(ou))
+        val item   = lens.get(oldTables).toValidNec(InputError.missingReference("id", Gid[I].show(id)))
+        val errors = NonEmptyChain.fromSeq(checks(oldTables))
+        val result = (item, editor, errors.toInvalid(())).mapN { (oldU, state, _) =>
+          (oldU, state.runS(oldU).value)
+        }
 
-        val oldU      = lens.get(oldTables)
-        val newTables = lens.modify(_.map(u => s.runS(u).value))(oldTables)
-        val newU      = lens.get(newTables)
+        val tables = result.fold(_ => oldTables, { case (_, newU) => lens.set(Some(newU))(oldTables) })
 
-        (newTables, (oldU, newU).mapN((o, n) => (o, n)))
-      }
+        (tables, result)
+      }.flatMap(_.liftTo[F])
 
     for {
       u <- doUpdate
-      _ <- u.fold(F.unit) { case (o, n) => eventService.publish(edited(o, n)) }
-    } yield u.map(_._2)
+      (o, n) = u
+      _ <- eventService.publish(edited(o, n))
+    } yield n
 
   }
 
-  override def edit(id: I, s: State[T, Unit]): F[Option[T]] =
-    editSub[T](id, s)(unlift(_.some))
+  private def setExistence(id: I, newState: Existence): F[T] =
+    edit(id, TopLevelModel[I, T].existenceEditor(newState).validNec, _ => Nil)
 
-  private def setExistence(id: I, newState: Existence): F[Option[T]] =
-    edit(id, TopLevelModel[I, T].existenceEditor(newState))
-
-  def delete(id: I): F[Option[T]] =
+  def delete(id: I): F[T] =
     setExistence(id, Existence.Deleted)
 
-  def undelete(id: I): F[Option[T]] =
+  def undelete(id: I): F[T] =
     setExistence(id, Existence.Present)
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -4,12 +4,9 @@
 package lucuma.odb.api.schema
 
 import lucuma.odb.api.model.ObservationModel
-import lucuma.odb.api.model.syntax.validatedinput._
 import lucuma.odb.api.repo.OdbRepo
 
 import cats.effect.Effect
-import cats.syntax.functor._
-import cats.syntax.flatMap._
 import sangria.macros.derive._
 import sangria.marshalling.circe._
 import sangria.schema._
@@ -58,21 +55,15 @@ trait ObservationMutation {
   def update[F[_]: Effect]: Field[OdbRepo[F], Unit] =
     Field(
       name      = "updateObservation",
-      fieldType = OptionType(ObservationType[F]),
+      fieldType = ObservationType[F],
       arguments = List(ArgumentObservationEdit),
-      resolve   = c => c.observation { r =>
-        val ed = c.arg(ArgumentObservationEdit)
-        for {
-          s <- ed.editor.liftTo[F]
-          o <- r.edit(ed.id, s)
-        } yield o
-      }
+      resolve   = c => c.observation(_.edit(c.arg(ArgumentObservationEdit)))
     )
 
   def delete[F[_]: Effect]: Field[OdbRepo[F], Unit] =
     Field(
       name      = "deleteObservation",
-      fieldType = OptionType(ObservationType[F]),
+      fieldType = ObservationType[F],
       arguments = List(ObservationIdArgument),
       resolve   = c => c.observation(_.delete(c.observationId))
     )
@@ -80,7 +71,7 @@ trait ObservationMutation {
   def undelete[F[_]: Effect]: Field[OdbRepo[F], Unit] =
     Field(
       name      = "undeleteObservation",
-      fieldType = OptionType(ObservationType[F]),
+      fieldType = ObservationType[F],
       arguments = List(ObservationIdArgument),
       resolve   = c => c.observation(_.undelete(c.observationId))
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
@@ -12,13 +12,10 @@ import lucuma.odb.api.model.{
   RightAscensionModel,
   TargetModel
 }
-import lucuma.odb.api.model.syntax.validatedinput._
 import lucuma.odb.api.repo.OdbRepo
 import lucuma.odb.api.schema.syntax.`enum`._
 import lucuma.core.math.VelocityAxis
 import cats.effect.Effect
-import cats.syntax.flatMap._
-import cats.syntax.functor._
 import sangria.macros.derive._
 import sangria.marshalling.circe._
 import sangria.schema._
@@ -182,21 +179,15 @@ trait TargetMutation extends TargetScalars {
   def updateSidereal[F[_]: Effect]: Field[OdbRepo[F], Unit] =
     Field(
       name      = "updateSiderealTarget",
-      fieldType = OptionType(TargetType[F]),
+      fieldType = TargetType[F],
       arguments = List(ArgumentTargetEditSidereal),
-      resolve   = c => c.target { r =>
-        val ed = c.arg(ArgumentTargetEditSidereal)
-        for {
-          s <- ed.editor.liftTo[F]
-          t <- r.edit(ed.id, s)
-        } yield t
-      }
+      resolve   = c => c.target(_.edit(c.arg(ArgumentTargetEditSidereal)))
     )
 
   def delete[F[_]: Effect]: Field[OdbRepo[F], Unit] =
     Field(
       name      = "deleteTarget",
-      fieldType = OptionType(TargetType[F]),
+      fieldType = TargetType[F],
       arguments = List(TargetIdArgument),
       resolve   = c => c.target(_.delete(c.targetId))
     )
@@ -204,7 +195,7 @@ trait TargetMutation extends TargetScalars {
   def undelete[F[_]: Effect]: Field[OdbRepo[F], Unit] =
     Field(
       name      = "undeleteTarget",
-      fieldType = OptionType(TargetType[F]),
+      fieldType = TargetType[F],
       arguments = List(TargetIdArgument),
       resolve   = c => c.target(_.undelete(c.targetId))
     )


### PR DESCRIPTION
Adds some potential for verification to editing and uses it for default asterism editing.  The asterism is associated with targets, but previously the target references were taken without verifying that they refer to actual targets.  Now a lookup is performed and the edit fails with an error if any targets are not found.