### PR TITLE
Pid-matching subscriptions

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SubscriptionType.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SubscriptionType.scala
@@ -6,8 +6,8 @@ package lucuma.odb.api.schema
 import lucuma.odb.api.model.Event
 import lucuma.odb.api.model.{AsterismModel, ObservationModel, ProgramModel, TargetModel}
 import lucuma.odb.api.repo.OdbRepo
-import cats.Eq
-import cats.syntax.eq._
+import cats.syntax.applicative._
+import cats.syntax.functor._
 import cats.effect.{ConcurrentEffect, Effect}
 import _root_.fs2.Stream
 import lucuma.odb.api.model.AsterismModel.{AsterismCreatedEvent, AsterismEditedEvent}
@@ -23,10 +23,7 @@ import scala.reflect.ClassTag
 
 object SubscriptionType {
 
-  import AsterismSchema.AsterismIdArgument
-  import ObservationSchema.ObservationIdArgument
   import ProgramSchema.ProgramIdArgument
-  import TargetSchema.TargetIdArgument
 
   implicit def asterismType[F[_]: Effect]: InterfaceType[OdbRepo[F], AsterismModel] =
     AsterismSchema.AsterismType[F]
@@ -95,7 +92,7 @@ object SubscriptionType {
     tpe:       ObjectType[OdbRepo[F], E],
     arguments: List[Argument[_]]
   )(
-    predicate: (Context[OdbRepo[F], Unit], E) => Boolean
+    predicate: (Context[OdbRepo[F], Unit], E) => F[Boolean]
   ): Field[OdbRepo[F], Unit] = {
 
     implicit val subStream: SubscriptionStream[Stream[F, *]] =
@@ -113,46 +110,90 @@ object SubscriptionType {
             case event if tpe.valClass.isAssignableFrom(event.getClass) =>
               event.asInstanceOf[E]
           }
-          .filter(e => predicate(c, e))
+          .evalFilter(e => predicate(c, e))
           .map(event => Action[OdbRepo[F], E](event))
       }
     )
   }
 
-  def createdField[F[_]: ConcurrentEffect, T: OutputType, E <: Event.Created[T]: ClassTag](
+  // Produces a function from (context, event) to F[Boolean] that is true when
+  // the event is associated with the program id provided as an argument to the
+  // subscription field.
+  private def pidMatcher[F[_]: ConcurrentEffect, E](
+    pidsExtractor: (Context[OdbRepo[F], Unit], E) => F[Set[ProgramModel.Id]]
+  ): (Context[OdbRepo[F], Unit], E) => F[Boolean] =
+    (c, e) => pidsExtractor(c, e).map(_.contains(c.arg(ProgramIdArgument)))
+
+  private def createdField[F[_]: ConcurrentEffect, T: OutputType, E <: Event.Created[T]: ClassTag](
     name: String
+  )(
+    pids: (Context[OdbRepo[F], Unit], E) => F[Set[ProgramModel.Id]]
   ): Field[OdbRepo[F], Unit] =
     subscriptionField[F, E](
       s"${name}Created",
       CreatedEventType[F, T, E](s"${name.capitalize}Created"),
-      Nil
-    )((_, _) => true)
+      List(ProgramIdArgument)
+    )(pidMatcher(pids))
 
-  def editedField[F[_]: ConcurrentEffect, I: Eq, T: OutputType, E <: Event.Edited[T]: ClassTag](
-    name: String,
-    arg:  Argument[I]
+  private def editedField[F[_]: ConcurrentEffect, T: OutputType, E <: Event.Edited[T]: ClassTag](
+    name: String
   )(
-    id: E => I  // extracts the top-level id from the event
+    pids: (Context[OdbRepo[F], Unit], E) => F[Set[ProgramModel.Id]]
   ): Field[OdbRepo[F], Unit] =
     subscriptionField[F, E](
       s"${name}Edited",
       EditedEventType[F, T, E](s"${name.capitalize}Edited"),
-      List(arg)
-    )((c, e) => c.arg(arg) === id(e))
+      List(ProgramIdArgument)
+    )(pidMatcher(pids))
 
-  def apply[F[_]: ConcurrentEffect]: ObjectType[OdbRepo[F], Unit] =
+  def apply[F[_]: ConcurrentEffect]: ObjectType[OdbRepo[F], Unit] = {
+    def programsForAsterism(c: Context[OdbRepo[F], Unit], aid: AsterismModel.Id): F[Set[ProgramModel.Id]] =
+      c.ctx.program.selectAllForAsterism(aid).map(_.map(_.id).toSet)
+
+    def programsForTarget(c: Context[OdbRepo[F], Unit], tid: TargetModel.Id): F[Set[ProgramModel.Id]] =
+      c.ctx.program.selectAllForTarget(tid).map(_.map(_.id).toSet)
+
     ObjectType(
       name   = "Subscription",
       fields = fields(
-        createdField[F, AsterismModel, AsterismCreatedEvent]("asterism"),
-        createdField[F, ObservationModel, ObservationCreatedEvent]("observation"),
-        createdField[F, ProgramModel, ProgramCreatedEvent]("program"),
-        createdField[F, TargetModel, TargetCreatedEvent]("target"),
+        createdField[F, AsterismModel, AsterismCreatedEvent]("asterism") { (c, e) =>
+          programsForAsterism(c, e.value.id)
+        },
 
-        editedField[F, AsterismModel.Id, AsterismModel, AsterismEditedEvent]("asterism", AsterismIdArgument)(_.newValue.id),
-        editedField[F, ObservationModel.Id, ObservationModel, ObservationEditedEvent]("observation", ObservationIdArgument)(_.newValue.id),
-        editedField[F, ProgramModel.Id, ProgramModel, ProgramEditedEvent]("program", ProgramIdArgument)(_.newValue.id),
-        editedField[F, TargetModel.Id, TargetModel, TargetEditedEvent]("target", TargetIdArgument)(_.newValue.id)
+        createdField[F, ObservationModel, ObservationCreatedEvent]("observation") { (_, e) =>
+          Set(e.value.pid).pure[F]
+        },
+
+        // ProgramCreatedEvent handled differently for now.  If we reserve
+        // program ids ahead of time and use them in creation then it might
+        // make sense to pass the id to the subscription.  If not, then we don't
+        // know the program id ahead of time.
+        subscriptionField[F, ProgramCreatedEvent](
+          "programCreated",
+          CreatedEventType[F, ProgramModel, ProgramCreatedEvent]("ProgramCreated"),
+          Nil
+        )((_,_) => true.pure[F]),
+
+        createdField[F, TargetModel, TargetCreatedEvent]("target") { (c, e) =>
+          programsForTarget(c, e.value.id)
+        },
+
+        editedField[F, AsterismModel, AsterismEditedEvent]("asterism") { (c, e) =>
+          programsForAsterism(c, e.newValue.id)
+        },
+
+        editedField[F, ObservationModel, ObservationEditedEvent]("observation") { (_, e) =>
+          Set(e.newValue.pid).pure[F]
+        },
+
+        editedField[F, ProgramModel, ProgramEditedEvent]("program") { (_, e) =>
+          Set(e.newValue.id).pure[F]
+        },
+
+        editedField[F, TargetModel, TargetEditedEvent]("target") { (c, e) =>
+          programsForTarget(c, e.newValue.id)
+        }
       )
     )
+  }
 }


### PR DESCRIPTION
An update to subscriptions to accept a program id argument such that only events that impact the associated program are received by the client.  For example, only events for the targets referenced by a particular program.