### PR TITLE
Pull up data stripping

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/api/service/Subscriptions.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Subscriptions.scala
@@ -75,16 +75,8 @@ object Subscriptions {
   // Converts raw graphQL subscription events into FromServer messages.
   private def fromServerPipe[F[_]](id: String): Pipe[F, Either[Throwable, Json], FromServer] =
     _.map {
-      case Left(err)           => Error(id, err.format)
-      case Right(json)         =>
-        Data(id,
-          DataWrapper(
-            // Sangria provides subscription results wrapped in "data".  If we
-            // add it directly to a DataWrapper then the encoding will have
-            // nested "data" fields.  This will strip the outer "data".
-            json.mapObject(o => o("data").fold(o)(_.asObject.fold(o)(identity)))
-          )
-        )
+      case Left(err)   => Error(id, err.format)
+      case Right(json) => Data(id, DataWrapper(json))
     }
 
   def apply[F[_]](


### PR DESCRIPTION
Sangria places results in a JSON object with a `data` field.  When we add results to a streaming message `DataWrapper` we end up with nested `data` fields.  I'd fixed this for subscription results, but we need this at a higher level to handle one-off queries over a web socket connection.