### PR TITLE
target => observations

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
@@ -3,7 +3,7 @@
 
 package lucuma.odb.api.repo
 
-import lucuma.odb.api.model.{AsterismModel, ProgramModel}
+import lucuma.odb.api.model.{AsterismModel, ProgramModel, TargetModel}
 import lucuma.odb.api.model.AsterismModel.{AsterismCreatedEvent, AsterismEditedEvent, AsterismProgramLinks, Create}
 import lucuma.odb.api.model.syntax.validatedinput._
 import cats._
@@ -19,6 +19,8 @@ import cats.syntax.traverse._
 sealed trait AsterismRepo[F[_]] extends TopLevelRepo[F, AsterismModel.Id, AsterismModel] {
 
   def selectAllForProgram(pid: ProgramModel.Id, includeDeleted: Boolean = false): F[List[AsterismModel]]
+
+  def selectAllForTarget(tid: TargetModel.Id, includeDeleted: Boolean = false): F[List[AsterismModel]]
 
   def insert[T <: AsterismModel](input: AsterismModel.Create[T]): F[T]
 
@@ -45,12 +47,17 @@ object AsterismRepo {
     ) with AsterismRepo[F]
       with LookupSupport[F] {
 
-      override def selectAllForProgram(pid: ProgramModel.Id, includeDeleted: Boolean = false): F[List[AsterismModel]] =
+      override def selectAllForProgram(pid: ProgramModel.Id, includeDeleted: Boolean): F[List[AsterismModel]] =
         tablesRef.get.map { t =>
           val ids = t.observations.values.filter(_.pid === pid).flatMap(_.asterism.toList).toSet
           ids.foldLeft(List.empty[AsterismModel]) { (l, i) =>
             t.asterisms.get(i).fold(l)(_ :: l)
           }
+        }.map(deletionFilter(includeDeleted))
+
+      override def selectAllForTarget(tid: TargetModel.Id, includeDeleted: Boolean): F[List[AsterismModel]] =
+        tablesRef.get.map { t =>
+          t.asterisms.values.filter(_.targets(tid)).toList
         }.map(deletionFilter(includeDeleted))
 
       private def addAsterism[T <: AsterismModel](

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/AsterismSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/AsterismSchema.scala
@@ -15,6 +15,7 @@ object AsterismSchema {
 
   import TargetSchema.{CoordinateType, TargetType}
   import GeneralSchema.{EnumTypeExistence, ArgumentIncludeDeleted}
+  import context._
 
   implicit val AsterismIdType: ScalarType[AsterismModel.Id] =
     ObjectIdSchema.idType[AsterismModel.Id](name = "AsterismId")
@@ -62,7 +63,7 @@ object AsterismSchema {
              .targets
              .iterator
              .toList
-             .traverse(c.ctx.target.select(_, c.arg(ArgumentIncludeDeleted)))
+             .traverse(c.ctx.target.select(_, c.includeDeleted))
              .map(_.flatMap(_.toList))
              .toIO
              .unsafeToFuture()

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
@@ -86,7 +86,7 @@ object ObservationSchema {
                 _.targets
                  .iterator
                  .toList
-                 .traverse(c.ctx.target.select(_, c.arg(ArgumentIncludeDeleted)))
+                 .traverse(c.ctx.target.select(_, c.includeDeleted))
                  .map(_.flatMap(_.toList))
               }
             }
@@ -103,7 +103,7 @@ object ObservationSchema {
     c.value.asterism.fold(F.pure(Option.empty[AsterismModel])) { aid =>
       c.ctx
        .asterism
-       .select(aid, c.arg(ArgumentIncludeDeleted))
+       .select(aid, c.includeDeleted)
     }
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
@@ -27,6 +27,13 @@ object ProgramSchema {
       description  = "Program ID"
     )
 
+  val OptionalProgramIdArgument: Argument[Option[ProgramModel.Id]] =
+    Argument(
+      name         = "id",
+      argumentType = OptionInputType(ProgramIdType),
+      description  = "Program ID"
+    )
+
   def ProgramType[F[_]: Effect]: ObjectType[OdbRepo[F], ProgramModel] =
     ObjectType(
       name     = "Program",

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/RepoContext.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/RepoContext.scala
@@ -19,6 +19,9 @@ final class RepoContextOps[F[_]: Effect, A](val self: Context[OdbRepo[F], A]) {
   def observationId: ObservationModel.Id =
     self.arg(ObservationSchema.ObservationIdArgument)
 
+  def optionalProgramId: Option[ProgramModel.Id] =
+    self.arg(ProgramSchema.OptionalProgramIdArgument)
+
   def programId: ProgramModel.Id =
     self.arg(ProgramSchema.ProgramIdArgument)
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetSchema.scala
@@ -10,13 +10,16 @@ import lucuma.core.`enum`.EphemerisKeyType
 import lucuma.core.math.{Coordinates, Declination, Parallax, ProperVelocity, RadialVelocity, RightAscension, VelocityAxis}
 import lucuma.core.model.{ EphemerisKey, SiderealTracking }
 import cats.effect.Effect
+import cats.syntax.eq._
+import cats.syntax.functor._
 import sangria.schema._
 
 object TargetSchema extends TargetScalars {
 
+  import AsterismSchema.AsterismType
   import GeneralSchema.{EnumTypeExistence, ArgumentIncludeDeleted}
   import ObservationSchema.ObservationType
-  import ProgramSchema.ProgramType
+  import ProgramSchema.{OptionalProgramIdArgument, ProgramType}
   import context._
 
   implicit val TargetIdType: ScalarType[TargetModel.Id] =
@@ -311,19 +314,41 @@ object TargetSchema extends TargetScalars {
         ),
 
         Field(
-          name        = "programs",
-          fieldType   = ListType(ProgramType[F]),
-          arguments   = List(ArgumentIncludeDeleted),
-          description = Some("The program associated with the target."),
-          resolve     = c => c.program(_.selectAllForTarget(c.value.id, c.includeDeleted))
+          name        = "asterisms",
+          fieldType   = ListType(AsterismType[F]),
+          arguments   = List(OptionalProgramIdArgument, ArgumentIncludeDeleted),
+          description = Some("The asterisms associated with the target."),
+          resolve     = c =>
+            c.asterism { repo =>
+              c.optionalProgramId.fold(
+                repo.selectAllForTarget(c.value.id, c.includeDeleted)
+              ) { pid =>
+                repo.selectAllForProgram(pid, c.includeDeleted).map(_.filter(_.targets(c.value.id)))
+              }
+            }
         ),
 
         Field(
           name        = "observations",
           fieldType   = ListType(ObservationType[F]),
-          arguments   = List(ArgumentIncludeDeleted),
+          arguments   = List(OptionalProgramIdArgument, ArgumentIncludeDeleted),
           description = Some("The observations associated with the target."),
-          resolve     = c => c.observation(_.selectAllForTarget(c.value.id, c.includeDeleted))
+          resolve     = c => c.observation(
+            _.selectAllForTarget(c.value.id, c.includeDeleted)
+             .map { obsList =>
+               c.optionalProgramId.fold(obsList) { pid =>
+                 obsList.filter(_.pid === pid)
+               }
+             }
+          )
+        ),
+
+        Field(
+          name        = "programs",
+          fieldType   = ListType(ProgramType[F]),
+          arguments   = List(ArgumentIncludeDeleted),
+          description = Some("The programs associated with the target."),
+          resolve     = c => c.program(_.selectAllForTarget(c.value.id, c.includeDeleted))
         ),
 
         Field(

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetSchema.scala
@@ -5,7 +5,6 @@ package lucuma.odb.api.schema
 
 import lucuma.odb.api.schema.syntax.all._
 import lucuma.odb.api.model.{DeclinationModel, ParallaxModel, ProperVelocityModel, RadialVelocityModel, RightAscensionModel, TargetModel}
-import lucuma.odb.api.schema.ProgramSchema.ProgramType
 import lucuma.odb.api.repo.OdbRepo
 import lucuma.core.`enum`.EphemerisKeyType
 import lucuma.core.math.{Coordinates, Declination, Parallax, ProperVelocity, RadialVelocity, RightAscension, VelocityAxis}
@@ -15,7 +14,9 @@ import sangria.schema._
 
 object TargetSchema extends TargetScalars {
 
-  import GeneralSchema.EnumTypeExistence
+  import GeneralSchema.{EnumTypeExistence, ArgumentIncludeDeleted}
+  import ObservationSchema.ObservationType
+  import ProgramSchema.ProgramType
   import context._
 
   implicit val TargetIdType: ScalarType[TargetModel.Id] =
@@ -312,8 +313,17 @@ object TargetSchema extends TargetScalars {
         Field(
           name        = "programs",
           fieldType   = ListType(ProgramType[F]),
+          arguments   = List(ArgumentIncludeDeleted),
           description = Some("The program associated with the target."),
-          resolve     = c => c.program(_.selectAllForTarget(c.value.id))
+          resolve     = c => c.program(_.selectAllForTarget(c.value.id, c.includeDeleted))
+        ),
+
+        Field(
+          name        = "observations",
+          fieldType   = ListType(ObservationType[F]),
+          arguments   = List(ArgumentIncludeDeleted),
+          description = Some("The observations associated with the target."),
+          resolve     = c => c.observation(_.selectAllForTarget(c.value.id, c.includeDeleted))
         ),
 
         Field(


### PR DESCRIPTION
As requested, adds an `observations` field to `Target`.  In this model, an observation has an optional asterism.  If the asterism is defined then it has a `Set` of targets.  So this will return all observations having an asterism that refers to this target.

@rpiaggio  Since targets (and asterisms too for that matter) can be shared across programs, do we want to add an optional program id argument and filter?