### PR TITLE
connection keep alive

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SubscriptionType.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SubscriptionType.scala
@@ -12,7 +12,7 @@ import cats.syntax.apply._
 import cats.syntax.eq._
 import cats.syntax.functor._
 import cats.effect.{ConcurrentEffect, Effect}
-import _root_.fs2.Stream
+import fs2.Stream
 import lucuma.odb.api.model.AsterismModel.{AsterismCreatedEvent, AsterismEditedEvent}
 import lucuma.odb.api.model.ObservationModel.{ObservationCreatedEvent, ObservationEditedEvent}
 import lucuma.odb.api.model.ProgramModel.{ProgramCreatedEvent, ProgramEditedEvent}

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Connection.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Connection.scala
@@ -16,8 +16,6 @@ import fs2.concurrent.NoneTerminatedQueue
 import org.log4s.getLogger
 import sangria.parser.QueryParser
 
-// TODO: will explore (etc.) expect keep alive messages?
-
 /**
  * A web-socket connection that receives messages from a client and processes
  * them.
@@ -55,7 +53,7 @@ object Connection {
       } yield ()
 
     override val init: (ConnectionState[F], F[Unit]) =
-      (this, reply(ConnectionAck))
+      (this, reply(ConnectionAck) *> reply(ConnectionKeepAlive))
 
     override def start(id: String, raw: GraphQLRequest): (ConnectionState[F], F[Unit]) = {
       val parseResult =

--- a/modules/service/src/main/scala/lucuma/odb/api/service/OdbService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/OdbService.scala
@@ -7,7 +7,7 @@ import lucuma.odb.api.schema.OdbSchema
 import lucuma.odb.api.repo.OdbRepo
 import cats.implicits._
 import cats.effect.{Async, ConcurrentEffect, ContextShift, IO}
-import _root_.fs2.Stream
+import fs2.Stream
 import io.circe._
 import org.log4s.getLogger
 import sangria.execution._

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Routes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Routes.scala
@@ -4,8 +4,6 @@
 package lucuma.odb.api.service
 
 import lucuma.odb.api.service.ErrorFormatter.syntax._
-import _root_.fs2.Stream
-import _root_.fs2.concurrent.Queue
 import cats.MonadError
 import cats.data.ValidatedNel
 import cats.effect.{ConcurrentEffect, Timer}
@@ -13,6 +11,8 @@ import cats.implicits._
 import clue.model.StreamingMessage.FromServer.{Data, DataWrapper}
 import clue.model.StreamingMessage.{FromClient, FromServer}
 import clue.model.json._
+import fs2.Stream
+import fs2.concurrent.Queue
 import io.circe._
 import io.circe.syntax._
 import org.http4s.circe._


### PR DESCRIPTION
This PR introduces connection keep alive messages from the server.  There are a couple of caveats. 

## Timeout Period

Rather arbitrarily, it uses a 5 second keep alive message interval.  There seems to be no standard agreeing upon the timeout period between client and server and at any rate the underlying web socket ping-pong frames are independent of this setting.  Longer settings like 2 minutes cause the Playground to timeout and stop subscriptions.  It's unclear what value makes sense.

## Cleanup

An outstanding issue with the Playground app is that when the user stops a subscription, it dutifully sends a `stop` streaming message but never actually terminates the connection.  If the user starts another subscription it sets up another web socket connection instead of reusing the existing one.  This means that after a series of start/stop subscription actions the server is sending multiple keep alive messages back to the same client though existing connections will never be used again.

A client refresh or closing of the tab does result in stopping the keep alive messages at least.