### PR TITLE
spell out microarcseconds

### DIFF
--- a/docs/units.md
+++ b/docs/units.md
@@ -157,14 +157,14 @@ ra {
   hms
   hours
   degrees
-  microarcsecs
+  microarcseconds
 }
 ⤹
 "ra": {
   "hms": "05:55:10.305000",
   "hours": 5.919529166666667,
   "degrees": 88.7929375,
-  "microarcsecs": 319654575000
+  "microarcseconds": 319654575000
 }
 ```
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetSchema.scala
@@ -138,7 +138,7 @@ object TargetSchema extends TargetScalars {
         ),
 
         Field(
-          name        = "microarcsecs",
+          name        = "microarcseconds",
           fieldType   = LongType,
           description = Some("Right Ascension (RA) in µas"),
           resolve     = v => RightAscensionModel.Units.Microarcseconds.long.get(v.value)
@@ -166,7 +166,7 @@ object TargetSchema extends TargetScalars {
         ),
 
         Field(
-          name        = "microarcsecs",
+          name        = "microarcseconds",
           fieldType   = LongType,
           description = Some("Declination in signed µas"),
           resolve     = v => DeclinationModel.Units.Microarcseconds.long.reverseGet(v.value)//.signedMicroarcseconds.get(v.value.toAngle)


### PR DESCRIPTION
A minor consistency update to use "microarcseconds" everywhere rather than a mix of "microarcseconds" and "microarcsecs".