### PR TITLE
Planned time placeholder

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -14,16 +14,14 @@ import io.circe.Decoder
 import io.circe.generic.semiauto._
 import monocle.Lens
 
-import scala.concurrent.duration.FiniteDuration
-
 
 final case class ObservationModel(
-  id:         ObservationModel.Id,
-  existence:  Existence,
-  programId:  ProgramModel.Id,
-  name:       Option[String],
-  asterismId: Option[AsterismModel.Id],
-  duration:   FiniteDuration
+  id:                 ObservationModel.Id,
+  existence:          Existence,
+  programId:          ProgramModel.Id,
+  name:               Option[String],
+  asterismId:         Option[AsterismModel.Id],
+  plannedTimeSummary: PlannedTimeSummaryModel
 )
 
 object ObservationModel extends ObservationOptics {
@@ -47,8 +45,8 @@ object ObservationModel extends ObservationOptics {
     asterismId: Option[AsterismModel.Id]
   ) {
 
-    def withId(id: ObservationModel.Id, d: FiniteDuration): ObservationModel =
-      ObservationModel(id, Present, programId, name, asterismId, d)
+    def withId(id: ObservationModel.Id, s: PlannedTimeSummaryModel): ObservationModel =
+      ObservationModel(id, Present, programId, name, asterismId, s)
 
   }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -6,7 +6,6 @@ package lucuma.odb.api.model
 import lucuma.odb.api.model.Existence._
 import lucuma.odb.api.model.syntax.all._
 import lucuma.core.util.Gid
-
 import cats.data.State
 import cats.syntax.validated._
 import eu.timepit.refined.auto._
@@ -15,13 +14,16 @@ import io.circe.Decoder
 import io.circe.generic.semiauto._
 import monocle.Lens
 
+import scala.concurrent.duration.FiniteDuration
+
 
 final case class ObservationModel(
   id:         ObservationModel.Id,
   existence:  Existence,
   programId:  ProgramModel.Id,
   name:       Option[String],
-  asterismId: Option[AsterismModel.Id]
+  asterismId: Option[AsterismModel.Id],
+  duration:   FiniteDuration
 )
 
 object ObservationModel extends ObservationOptics {
@@ -45,8 +47,8 @@ object ObservationModel extends ObservationOptics {
     asterismId: Option[AsterismModel.Id]
   ) {
 
-    def withId(id: ObservationModel.Id): ObservationModel =
-      ObservationModel(id, Present, programId, name, asterismId)
+    def withId(id: ObservationModel.Id, d: FiniteDuration): ObservationModel =
+      ObservationModel(id, Present, programId, name, asterismId, d)
 
   }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/PlannedTimeSummaryModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/PlannedTimeSummaryModel.scala
@@ -1,0 +1,46 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import cats.Monoid
+import cats.effect.Sync
+import cats.syntax.functor._
+import cats.syntax.flatMap._
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+final case class PlannedTimeSummaryModel(
+  piTime:        FiniteDuration,
+  unchargedTime: FiniteDuration
+) {
+
+  def executionTime: FiniteDuration =
+    piTime + unchargedTime
+
+}
+
+object PlannedTimeSummaryModel {
+
+  val Zero: PlannedTimeSummaryModel =
+    PlannedTimeSummaryModel(0.microseconds, 0.microseconds)
+
+  def random[F[_]: Sync]: F[PlannedTimeSummaryModel] =
+    for {
+      p <- Sync[F].delay(Random.between(5L, 120L))
+      u <- Sync[F].delay(Random.between(1L,  15L))
+    } yield PlannedTimeSummaryModel(p.minutes, u.minutes)
+
+
+  implicit val MonoidPlannedTimeSummaryModel: Monoid[PlannedTimeSummaryModel] =
+    Monoid.instance(
+      Zero,
+      (a, b) =>
+        PlannedTimeSummaryModel(
+          a.piTime + b.piTime,
+          a.unchargedTime + b.unchargedTime
+        )
+    )
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/GeneralSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/GeneralSchema.scala
@@ -4,7 +4,7 @@
 package lucuma.odb.api.schema
 
 import cats.effect.Effect
-import lucuma.odb.api.model.Existence
+import lucuma.odb.api.model.{Existence, PlannedTimeSummaryModel}
 import lucuma.odb.api.repo.OdbRepo
 import lucuma.odb.api.schema.syntax.`enum`._
 import sangria.schema._
@@ -68,4 +68,34 @@ object GeneralSchema {
         )
       )
     )
+
+  def PlannedTimeSummaryType[F[_]](implicit F: Effect[F]): ObjectType[OdbRepo[F], PlannedTimeSummaryModel] =
+    ObjectType(
+      name = "PlannedTimeSummary",
+      fieldsFn = () => fields(
+
+        Field(
+          name        = "pi",
+          fieldType   = DurationType[F],
+          description = Some("The portion of planned time that will be charged"),
+          resolve     = _.value.piTime
+        ),
+
+        Field(
+          name        = "uncharged",
+          fieldType   = DurationType[F],
+          description = Some("The portion of planned time that will not be charged"),
+          resolve     = _.value.unchargedTime
+        ),
+
+        Field(
+          name        = "execution",
+          fieldType   = DurationType[F],
+          description = Some("The total estimated execution time"),
+          resolve     = _.value.executionTime
+        )
+
+      )
+    )
+
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/GeneralSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/GeneralSchema.scala
@@ -3,9 +3,13 @@
 
 package lucuma.odb.api.schema
 
+import cats.effect.Effect
 import lucuma.odb.api.model.Existence
+import lucuma.odb.api.repo.OdbRepo
 import lucuma.odb.api.schema.syntax.`enum`._
 import sangria.schema._
+
+import scala.concurrent.duration.FiniteDuration
 
 object GeneralSchema {
 
@@ -23,4 +27,45 @@ object GeneralSchema {
       defaultValue = false
     )
 
+  def DurationType[F[_]: Effect]: ObjectType[OdbRepo[F], FiniteDuration] =
+    ObjectType(
+      name     = "Duration",
+      fieldsFn = () => fields(
+
+        Field(
+          name        = "microseconds",
+          fieldType   = LongType,
+          description = Some("Duration in µs"),
+          resolve     = v => v.value.toMicros
+        ),
+
+        Field(
+          name        = "milliseconds",
+          fieldType   = BigDecimalType,
+          description = Some("Duration in ms"),
+          resolve     = v => BigDecimal(v.value.toMicros, 3)
+        ),
+
+        Field(
+          name        = "seconds",
+          fieldType   = BigDecimalType,
+          description = Some("Duration in seconds"),
+          resolve     = v => BigDecimal(v.value.toMicros, 6)
+        ),
+
+        Field(
+          name        = "minutes",
+          fieldType   = BigDecimalType,
+          description = Some("Duration in minutes"),
+          resolve     = v => BigDecimal(v.value.toMicros, 6) / 60
+        ),
+
+        Field(
+          name        = "hours",
+          fieldType   = BigDecimalType,
+          description = Some("Duration in hours"),
+          resolve     = v => BigDecimal(v.value.toMicros, 6) / 3600
+        )
+      )
+    )
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
@@ -14,7 +14,7 @@ import sangria.schema._
 object ObservationSchema {
 
   import AsterismSchema.AsterismType
-  import GeneralSchema.{EnumTypeExistence, ArgumentIncludeDeleted}
+  import GeneralSchema.{EnumTypeExistence, ArgumentIncludeDeleted, DurationType}
   import ProgramSchema.ProgramType
   import TargetSchema.TargetType
   import context._
@@ -99,6 +99,13 @@ object ObservationSchema {
             }
             .toIO
             .unsafeToFuture()
+        ),
+
+        Field(
+          name        = "duration",
+          fieldType   = DurationType[F],
+          description = Some("Observation planned time calculation."),
+          resolve     = _.value.duration
         )
 
       )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
@@ -14,7 +14,7 @@ import sangria.schema._
 object ObservationSchema {
 
   import AsterismSchema.AsterismType
-  import GeneralSchema.{EnumTypeExistence, ArgumentIncludeDeleted, DurationType}
+  import GeneralSchema.{ArgumentIncludeDeleted, EnumTypeExistence, PlannedTimeSummaryType}
   import ProgramSchema.ProgramType
   import TargetSchema.TargetType
   import context._
@@ -102,10 +102,10 @@ object ObservationSchema {
         ),
 
         Field(
-          name        = "duration",
-          fieldType   = DurationType[F],
+          name        = "plannedTime",
+          fieldType   = PlannedTimeSummaryType[F],
           description = Some("Observation planned time calculation."),
-          resolve     = _.value.duration
+          resolve     = _.value.plannedTimeSummary
         )
 
       )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
@@ -5,8 +5,10 @@ package lucuma.odb.api.schema
 
 import lucuma.odb.api.model.ProgramModel
 import lucuma.odb.api.repo.OdbRepo
-
 import cats.effect.Effect
+import cats.syntax.foldable._
+import cats.syntax.functor._
+import lucuma.odb.api.schema.GeneralSchema.PlannedTimeSummaryType
 import sangria.schema._
 
 object ProgramSchema {
@@ -89,7 +91,19 @@ object ProgramSchema {
           description = Some("All targets associated with the program (needs pagination)."),
           arguments   = List(ArgumentIncludeDeleted),
           resolve     = c => c.target(_.selectAllForProgram(c.value.id, c.includeDeleted))
+        ),
+
+        Field(
+          name        = "plannedTime",
+          fieldType   = PlannedTimeSummaryType[F],
+          description = Some("Program planned time calculation."),
+          arguments   = List(ArgumentIncludeDeleted),
+          resolve     = c => c.observation {
+            _.selectAllForProgram(c.value.id, c.includeDeleted)
+              .map(_.foldMap(_.plannedTimeSummary))
+          }
         )
+
 
       )
     )


### PR DESCRIPTION
Adds a placeholder for planned time calculation summaries.  As I understand it, this is being displayed in the UI but we're a long way from being able to calculate it.

If merged, new observations would come with a random planned time summary.  A program would accurately display the sum of planned time for its observations (though once we have OR groups etc. this will have to change).

```
{
  "data": {
    "program": {
      "id": "p-2",
      "name": "Observing Stars in Constellation Orion for No Particular Reason",
      "plannedTime": {
        "pi": {
          "minutes": 312
        },
        "uncharged": {
          "minutes": 31
        },
        "execution": {
          "minutes": 343
        }
      },
      "observations": [
        {
          "id": "o-2",
          "plannedTime": {
            "pi": {
              "minutes": 92
            },
            "uncharged": {
              "minutes": 4
            },
            "execution": {
              "minutes": 96
            }
          }
        },
    ...
```