### PR TITLE
Allow ids to be provided by client during creation

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/AsterismModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/AsterismModel.scala
@@ -112,12 +112,14 @@ object AsterismModel extends AsterismOptics {
   }
 
   trait Create[T] {
+    def asterismId: Option[AsterismModel.Id]
     def programIds: List[ProgramModel.Id]  // to share immediately with the indicated programs
     def targetIds:  Set[TargetModel.Id]
     def withId:     ValidatedInput[AsterismModel.Id => T]
   }
 
   final case class CreateDefault(
+    asterismId:   Option[AsterismModel.Id],
     programIds:   List[ProgramModel.Id],
     explicitBase: Option[CoordinatesModel.Input],
     targetIds:    Set[TargetModel.Id]

--- a/modules/core/src/main/scala/lucuma/odb/api/model/InputError.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/InputError.scala
@@ -49,7 +49,12 @@ object InputError {
    * Indicates that an input contains an id whose referent could not be found.
    */
   def missingReference[A](name: String, value: String): InputError =
-    fromMessage(s"Could not find $name '$value''")
+    fromMessage(s"Could not find $name '$value'")
 
+  /**
+   * Attempt to reuse an id in the creation of a new object.
+   */
+  def idClash[A](name: String, value: String): InputError =
+    fromMessage(s"$name id '$value' is already in use")
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -40,9 +40,10 @@ object ObservationModel extends ObservationOptics {
     TopLevelModel.instance(_.id, ObservationModel.existence)
 
   final case class Create(
-    programId:  ProgramModel.Id,
-    name:       Option[String],
-    asterismId: Option[AsterismModel.Id]
+    observationId: Option[ObservationModel.Id],
+    programId:     ProgramModel.Id,
+    name:          Option[String],
+    asterismId:    Option[AsterismModel.Id]
   ) {
 
     def withId(id: ObservationModel.Id, s: PlannedTimeSummaryModel): ObservationModel =

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
@@ -41,7 +41,8 @@ object ProgramModel extends ProgramOptics {
    * Program creation input class.
    */
   final case class Create(
-    name: Option[String]
+    programId: Option[ProgramModel.Id],
+    name:      Option[String]
   )
 
   object Create {

--- a/modules/core/src/main/scala/lucuma/odb/api/model/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/TargetModel.scala
@@ -70,6 +70,8 @@ object TargetModel extends TargetOptics {
   /**
    * Describes input used to create a nonsidereal target.
    *
+   * @param targetId optional client-provided target id (if not specified one
+   *                 will be created)
    * @param programIds associated program(s), if any (which either exist or
    *                   results in an error)
    * @param name target name
@@ -77,6 +79,7 @@ object TargetModel extends TargetOptics {
    * @param des semi-permanent horizons identifier (relative to key type)
    */
   final case class CreateNonsidereal(
+    targetId:   Option[TargetModel.Id],
     programIds: List[ProgramModel.Id],
     name:       String,
     key:        EphemerisKeyType,
@@ -103,6 +106,8 @@ object TargetModel extends TargetOptics {
   /**
    * Describes input used to create a sidereal target.
    *
+   * @param targetId optional client-provided target id (if not specified one
+   *                 will be created)
    * @param programIds associated program(s), if any (which either exist or results
    *             in an error)
    * @param name target name
@@ -114,6 +119,7 @@ object TargetModel extends TargetOptics {
    * @param parallax parallax
    */
   final case class CreateSidereal(
+    targetId:       Option[TargetModel.Id],
     programIds:     List[ProgramModel.Id],
     name:           String,
     ra:             RightAscensionModel.Input,

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
@@ -72,7 +72,7 @@ object AsterismRepo {
 
       override def insert[T <: AsterismModel](input: Create[T]): F[T] =
         modify { t =>
-          val existing = dontLookup(t.asterisms, input.asterismId, "asterism")
+          val existing = dontFindAsterism(t, input.asterismId)
           val targets  = input.targetIds.iterator.toList.traverse(lookupTarget(t, _))
           val programs = input.programIds.traverse(lookupProgram(t, _))
           val asterism = input.withId

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
@@ -61,21 +61,23 @@ object AsterismRepo {
         }.map(deletionFilter(includeDeleted))
 
       private def addAsterism[T <: AsterismModel](
-        programs: Set[ProgramModel.Id],
-        factory:  AsterismModel.Id => T
+        asterismId: Option[AsterismModel.Id],
+        programs:   Set[ProgramModel.Id],
+        factory:    AsterismModel.Id => T
       ): State[Tables, T] =
         for {
-          a   <- createAndInsert(factory)
+          a   <- createAndInsert(asterismId, factory)
           _   <- Tables.shareAsterismWithPrograms(a, programs)
         } yield a
 
       override def insert[T <: AsterismModel](input: Create[T]): F[T] =
         modify { t =>
+          val existing = dontLookup(t.asterisms, input.asterismId, "asterism")
           val targets  = input.targetIds.iterator.toList.traverse(lookupTarget(t, _))
           val programs = input.programIds.traverse(lookupProgram(t, _))
           val asterism = input.withId
-          (targets, programs, asterism)
-            .mapN((_, _, f) => addAsterism(input.programIds.toSet, f).run(t).value)
+          (existing, targets, programs, asterism)
+            .mapN((_, _, _, f) => addAsterism(input.asterismId, input.programIds.toSet, f).run(t).value)
             .fold(
               err => (t, err.asLeft[T]),
               tup => tup.map(_.asRight)

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/LookupSupport.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/LookupSupport.scala
@@ -17,6 +17,14 @@ trait LookupSupport[F[_]] {
   def missingReference[I: Gid, T](id: I)(implicit M: MonadError[F, Throwable]): F[T] =
     ExecutionException.missingReference[F, I, T](id)
 
+  /**
+   * Verify that the given id, if defined, does not exist in the map.
+   */
+  def dontLookup[I: Gid, T](m: SortedMap[I, T], id: Option[I], name: String): ValidatedInput[Unit] =
+    id.fold(().validNec[InputError]) { i =>
+      m.get(i).as(InputError.idClash(name, Gid[I].show(i))).toInvalidNec(())
+    }
+
   def lookup[I: Gid, T](m: SortedMap[I, T], id: I, name: String): ValidatedInput[T] =
     m.get(id).toValidNec(InputError.missingReference(name, Gid[I].show(id)))
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/LookupSupport.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/LookupSupport.scala
@@ -17,28 +17,40 @@ trait LookupSupport[F[_]] {
   def missingReference[I: Gid, T](id: I)(implicit M: MonadError[F, Throwable]): F[T] =
     ExecutionException.missingReference[F, I, T](id)
 
+  def lookup[I: Gid, T](m: SortedMap[I, T], id: I, name: String): ValidatedInput[T] =
+    m.get(id).toValidNec(InputError.missingReference(name, Gid[I].show(id)))
+
   /**
-   * Verify that the given id, if defined, does not exist in the map.
+   * Verify that the given id, if supplied, does not exist in the map.
    */
-  def dontLookup[I: Gid, T](m: SortedMap[I, T], id: Option[I], name: String): ValidatedInput[Unit] =
+  def dontFind[I: Gid, T](m: SortedMap[I, T], id: Option[I], name: String): ValidatedInput[Unit] =
     id.fold(().validNec[InputError]) { i =>
       m.get(i).as(InputError.idClash(name, Gid[I].show(i))).toInvalidNec(())
     }
 
-  def lookup[I: Gid, T](m: SortedMap[I, T], id: I, name: String): ValidatedInput[T] =
-    m.get(id).toValidNec(InputError.missingReference(name, Gid[I].show(id)))
-
   def lookupAsterism(t: Tables, aid: AsterismModel.Id): ValidatedInput[AsterismModel] =
-    lookup(t.asterisms, aid, "aid")
+    lookup(t.asterisms, aid, "asterism")
+
+  def dontFindAsterism(t: Tables, aid: Option[AsterismModel.Id]): ValidatedInput[Unit] =
+    dontFind(t.asterisms, aid, "asterism")
 
   def lookupObservation(t: Tables, oid: ObservationModel.Id): ValidatedInput[ObservationModel] =
-    lookup(t.observations, oid, "oid")
+    lookup(t.observations, oid, "observation")
+
+  def dontFindObservation(t: Tables, oid: Option[ObservationModel.Id]): ValidatedInput[Unit] =
+    dontFind(t.observations, oid, "observation")
 
   def lookupProgram(t: Tables, pid: ProgramModel.Id): ValidatedInput[ProgramModel] =
-    lookup(t.programs, pid, "pid")
+    lookup(t.programs, pid, "program")
+
+  def dontFindProgram(t: Tables, pid: Option[ProgramModel.Id]): ValidatedInput[Unit] =
+    dontFind(t.programs, pid, "program")
 
   def lookupTarget(t: Tables, tid: TargetModel.Id): ValidatedInput[TargetModel] =
-    lookup(t.targets, tid, "tid")
+    lookup(t.targets, tid, "target")
+
+  def dontFindTarget(t: Tables, tid: Option[TargetModel.Id]): ValidatedInput[Unit] =
+    dontFind(t.targets, tid, "target")
 
   def inspectAsterismId(aid: AsterismModel.Id): State[Tables, ValidatedInput[AsterismModel]] =
     State.inspect(lookupAsterism(_, aid))

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
@@ -66,8 +66,9 @@ object ObservationRepo {
 
         def construct(s: PlannedTimeSummaryModel): F[ObservationModel] =
           modify { t =>
-            val existing = dontLookup(t.observations, newObs.observationId, "observation")
-            (existing, lookupProgram(t, newObs.programId))
+            (dontFindObservation(t, newObs.observationId),
+             lookupProgram(t, newObs.programId)
+            )
               .mapN((_, _) => ())
               .fold(
                 err => (t, err.asLeft[ObservationModel]),

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
@@ -57,7 +57,7 @@ object ProgramRepo {
         selectAllFor(tid, _.programTargets, includeDeleted)
 
       override def insert(input: ProgramModel.Create): F[ProgramModel] =
-        tablesRef.modifyState(createAndInsert(pid => ProgramModel(pid, Present, input.name)))
+        tablesRef.modifyState(createAndInsert(input.programId, pid => ProgramModel(pid, Present, input.name)))
 
     }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
@@ -57,7 +57,13 @@ object ProgramRepo {
         selectAllFor(tid, _.programTargets, includeDeleted)
 
       override def insert(input: ProgramModel.Create): F[ProgramModel] =
-        tablesRef.modifyState(createAndInsert(input.programId, pid => ProgramModel(pid, Present, input.name)))
+        modify { t =>
+          dontFindProgram(t, input.programId)
+           .fold(
+             err => (t, err.asLeft[ProgramModel]),
+             _   => createAndInsert(input.programId, pid => ProgramModel(pid, Present, input.name)).run(t).value.map(_.asRight)
+           )
+        }
 
     }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
@@ -61,18 +61,20 @@ object TargetRepo {
           }
         }.map(deletionFilter(includeDeleted))
 
-      def addAndShare(g: Target, pids: Set[ProgramModel.Id]): State[Tables, TargetModel] =
+      def addAndShare(id: Option[TargetModel.Id], g: Target, pids: Set[ProgramModel.Id]): State[Tables, TargetModel] =
         for {
-          t   <- createAndInsert(tid => TargetModel(tid, Present, g))
+          t   <- createAndInsert(id, tid => TargetModel(tid, Present, g))
           _   <- Tables.shareTargetWithPrograms(t, pids)
         } yield t
 
-      private def insertTarget(pids: List[ProgramModel.Id], vt: ValidatedInput[Target]): F[TargetModel] =
+      private def insertTarget(id: Option[TargetModel.Id], pids: List[ProgramModel.Id], vt: ValidatedInput[Target]): F[TargetModel] =
         modify { t =>
+          val existing = dontLookup(t.targets, id, "target")
+
           // NOTE: look up all the supplied program ids to make sure they
           // correspond to real programs.  We ignore a successful result though.
-          (vt, pids.traverse(lookupProgram(t, _)))
-            .mapN((g, _) => addAndShare(g, pids.toSet).run(t).value)
+          (vt, existing, pids.traverse(lookupProgram(t, _)))
+            .mapN((g, _, _) => addAndShare(id, g, pids.toSet).run(t).value)
             .fold(
               err => (t, err.asLeft[TargetModel]),
               tup => tup.map(_.asRight)
@@ -80,10 +82,10 @@ object TargetRepo {
         }
 
       override def insertNonsidereal(input: CreateNonsidereal): F[TargetModel] =
-        insertTarget(input.programIds, input.toGemTarget)
+        insertTarget(input.targetId, input.programIds, input.toGemTarget)
 
       override def insertSidereal(input: CreateSidereal): F[TargetModel] =
-        insertTarget(input.programIds, input.toGemTarget)
+        insertTarget(input.targetId, input.programIds, input.toGemTarget)
 
       private def programSharing(
         input: TargetProgramLinks,

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
@@ -69,11 +69,9 @@ object TargetRepo {
 
       private def insertTarget(id: Option[TargetModel.Id], pids: List[ProgramModel.Id], vt: ValidatedInput[Target]): F[TargetModel] =
         modify { t =>
-          val existing = dontLookup(t.targets, id, "target")
-
           // NOTE: look up all the supplied program ids to make sure they
           // correspond to real programs.  We ignore a successful result though.
-          (vt, existing, pids.traverse(lookupProgram(t, _)))
+          (vt, dontFindTarget(t, id), pids.traverse(lookupProgram(t, _)))
             .mapN((g, _, _) => addAndShare(id, g, pids.toSet).run(t).value)
             .fold(
               err => (t, err.asLeft[TargetModel]),

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TopLevelRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TopLevelRepo.scala
@@ -133,9 +133,9 @@ abstract class TopLevelRepoBase[F[_]: Monad, I: Gid, T: TopLevelModel[I, ?]](
       mapLens.get(tables).values.toList.filter(f(tables))
     }
 
-  def createAndInsert[U <: T](f: I => U): State[Tables, U] =
+  def createAndInsert[U <: T](id: Option[I], f: I => U): State[Tables, U] =
     for {
-      i <- idLens.mod(BoundedEnumerable[I].cycleNext)
+      i <- id.fold(idLens.mod(BoundedEnumerable[I].cycleNext))(State.pure[Tables, I])
       t  = f(i)
       _ <- mapLens.mod(_ + (i -> t))
     } yield t

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -19,16 +19,19 @@ object Init {
     for {
       p  <- repo.program.insert(
               ProgramModel.Create(
+                None,
                 Some("Observing Stars in Constellation Orion for No Particular Reason")
               )
             )
       _  <- repo.program.insert(
               ProgramModel.Create(
+                None,
                 Some("An Empty Placeholder Program")
               )
             )
       t0 <- repo.target.insertSidereal(
               TargetModel.CreateSidereal(
+                None,
                 List(p.id),
                 "Betelgeuse",
                 RightAscensionModel.Input.unsafeFromHms("05:55:10.305"),
@@ -41,6 +44,7 @@ object Init {
             )
       t1 <- repo.target.insertSidereal(
               TargetModel.CreateSidereal(
+                None,
                 List(p.id),
                 "Rigel",
                 RightAscensionModel.Input.unsafeFromHms("05:14:32.272"),
@@ -53,6 +57,7 @@ object Init {
             )
       a0 <- repo.asterism.insert(
               AsterismModel.CreateDefault(
+                None,
                 List(p.id),
                 None,
                 Set(t0.id, t1.id)
@@ -60,6 +65,7 @@ object Init {
             )
       _  <- repo.observation.insert(
               ObservationModel.Create(
+                None,
                 p.id,
                 Some("First Observation"),
                 Some(a0.id)


### PR DESCRIPTION
Pending an update to supply the client with an id-pool for use (as discussed), this PR allows ids to be provided by the client.  Duplicates are not yet checked for program ids, but this is needed quickly for work on a demo today so I'm sending it as-is and will fix it up subsequently. 