### PR TITLE
Event refactor

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/AsterismModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/AsterismModel.scala
@@ -210,7 +210,7 @@ object AsterismModel extends AsterismOptics {
   final case class AsterismEvent (
     id:       Long,
     editType: Event.EditType,
-    value:    AsterismModel,
+    value:    AsterismModel
   ) extends Event.Edit[AsterismModel]
 
   object AsterismEvent {

--- a/modules/core/src/main/scala/lucuma/odb/api/model/AsterismModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/AsterismModel.scala
@@ -207,26 +207,17 @@ object AsterismModel extends AsterismOptics {
       case (_, _)                   => false
     }
 
-  final case class AsterismCreatedEvent (
-    id:    Long,
-    value: AsterismModel,
-  ) extends Event.Created[AsterismModel]
-
-  object AsterismCreatedEvent {
-    def apply(value: AsterismModel)(id: Long): AsterismCreatedEvent =
-      AsterismCreatedEvent(id, value)
-  }
-
-  final case class AsterismEditedEvent (
+  final case class AsterismEvent (
     id:       Long,
-    oldValue: AsterismModel,
-    newValue: AsterismModel
-  ) extends Event.Edited[AsterismModel]
+    editType: Event.EditType,
+    value:    AsterismModel,
+  ) extends Event.Edit[AsterismModel]
 
-  object AsterismEditedEvent {
-    def apply(oldValue: AsterismModel, newValue: AsterismModel)(id: Long): AsterismEditedEvent =
-      AsterismEditedEvent(id, oldValue, newValue)
+  object AsterismEvent {
+    def apply(editType: Event.EditType, value: AsterismModel)(id: Long): AsterismEvent =
+      AsterismEvent(id, editType, value)
   }
+
 }
 
 trait AsterismOptics { self: AsterismModel.type =>

--- a/modules/core/src/main/scala/lucuma/odb/api/model/Event.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/Event.scala
@@ -3,6 +3,8 @@
 
 package lucuma.odb.api.model
 
+import lucuma.core.util.Enumerated
+
 trait Event {
   def id: Long
 }
@@ -17,14 +19,19 @@ object Event {
   def initialize: Event =
     Initialize
 
+  sealed trait EditType extends Product with Serializable
 
-  trait Created[T] extends Event {
-    def value: T
+  object EditType {
+    case object Created extends EditType
+    case object Updated extends EditType
+
+    implicit val EnumeratedEditType: Enumerated[EditType] =
+      Enumerated.of(Created, Updated)
   }
 
-  trait Edited[T] extends Event {
-    def oldValue: T
-    def newValue: T
+  trait Edit[T] extends Event {
+    def editType: EditType
+    def value: T
   }
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -97,27 +97,16 @@ object ObservationModel extends ObservationOptics {
 
   }
 
-  final case class ObservationCreatedEvent (
-    id:    Long,
-    value: ObservationModel,
-  ) extends Event.Created[ObservationModel]
-
-  object ObservationCreatedEvent {
-    def apply(value: ObservationModel)(id: Long): ObservationCreatedEvent =
-      ObservationCreatedEvent(id, value)
-  }
-
-  final case class ObservationEditedEvent (
+  final case class ObservationEvent (
     id:       Long,
-    oldValue: ObservationModel,
-    newValue: ObservationModel
-  ) extends Event.Edited[ObservationModel]
+    editType: Event.EditType,
+    value:    ObservationModel,
+  ) extends Event.Edit[ObservationModel]
 
-  object ObservationEditedEvent {
-    def apply(oldValue: ObservationModel, newValue: ObservationModel)(id: Long): ObservationEditedEvent =
-      ObservationEditedEvent(id, oldValue, newValue)
+  object ObservationEvent {
+    def apply(editType: Event.EditType, value: ObservationModel)(id: Long): ObservationEvent =
+      ObservationEvent(id, editType, value)
   }
-
 
 }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
@@ -52,25 +52,15 @@ object ProgramModel extends ProgramOptics {
 
   }
 
-  final case class ProgramCreatedEvent (
-    id:    Long,
-    value: ProgramModel,
-  ) extends Event.Created[ProgramModel]
-
-  object ProgramCreatedEvent {
-    def apply(value: ProgramModel)(id: Long): ProgramCreatedEvent =
-      ProgramCreatedEvent(id, value)
-  }
-
-  final case class ProgramEditedEvent (
+  final case class ProgramEvent (
     id:       Long,
-    oldValue: ProgramModel,
-    newValue: ProgramModel
-  ) extends Event.Edited[ProgramModel]
+    editType: Event.EditType,
+    value:    ProgramModel,
+  ) extends Event.Edit[ProgramModel]
 
-  object ProgramEditedEvent {
-    def apply(oldValue: ProgramModel, newValue: ProgramModel)(id: Long): ProgramEditedEvent =
-      ProgramEditedEvent(id, oldValue, newValue)
+  object ProgramEvent {
+    def apply(editType: Event.EditType, value: ProgramModel)(id: Long): ProgramEvent =
+      ProgramEvent(id, editType, value)
   }
 
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/TargetModel.scala
@@ -235,25 +235,15 @@ object TargetModel extends TargetOptics {
 
   }
 
-  final case class TargetCreatedEvent (
-    id:    Long,
-    value: TargetModel,
-  ) extends Event.Created[TargetModel]
-
-  object TargetCreatedEvent {
-    def apply(value: TargetModel)(id: Long): TargetCreatedEvent =
-      TargetCreatedEvent(id, value)
-  }
-
-  final case class TargetEditedEvent (
+  final case class TargetEvent (
     id:       Long,
-    oldValue: TargetModel,
-    newValue: TargetModel
-  ) extends Event.Edited[TargetModel]
+    editType: Event.EditType,
+    value:    TargetModel,
+  ) extends Event.Edit[TargetModel]
 
-  object TargetEditedEvent {
-    def apply(oldValue: TargetModel, newValue: TargetModel)(id: Long): TargetEditedEvent =
-      TargetEditedEvent(id, oldValue, newValue)
+  object TargetEvent {
+    def apply(editType: Event.EditType, value: TargetModel)(id: Long): TargetEvent =
+      TargetEvent(id, editType, value)
   }
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
@@ -4,7 +4,7 @@
 package lucuma.odb.api.repo
 
 import lucuma.odb.api.model.{AsterismModel, ProgramModel, TargetModel}
-import lucuma.odb.api.model.AsterismModel.{AsterismCreatedEvent, AsterismEditedEvent, AsterismProgramLinks, Create}
+import lucuma.odb.api.model.AsterismModel.{AsterismEvent, AsterismProgramLinks, Create}
 import lucuma.odb.api.model.syntax.validatedinput._
 import cats._
 import cats.data.State
@@ -42,8 +42,7 @@ object AsterismRepo {
       eventService,
       Tables.lastAsterismId,
       Tables.asterisms,
-      AsterismCreatedEvent.apply,
-      AsterismEditedEvent.apply
+      AsterismEvent.apply
     ) with AsterismRepo[F]
       with LookupSupport[F] {
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
@@ -4,7 +4,7 @@
 package lucuma.odb.api.repo
 
 import lucuma.odb.api.model.{AsterismModel, ObservationModel, PlannedTimeSummaryModel, ProgramModel, TargetModel}
-import lucuma.odb.api.model.ObservationModel.{ObservationCreatedEvent, ObservationEditedEvent}
+import lucuma.odb.api.model.ObservationModel.ObservationEvent
 import cats.effect.Sync
 import cats.effect.concurrent.Ref
 import cats.implicits._
@@ -33,8 +33,7 @@ object ObservationRepo {
       eventService,
       Tables.lastObservationId,
       Tables.observations,
-      ObservationCreatedEvent.apply,
-      ObservationEditedEvent.apply
+      ObservationEvent.apply
     ) with ObservationRepo[F]
       with LookupSupport[F] {
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
@@ -4,7 +4,7 @@
 package lucuma.odb.api.repo
 
 import lucuma.odb.api.model.{AsterismModel, ProgramModel, TargetModel}
-import lucuma.odb.api.model.ProgramModel.{ProgramCreatedEvent, ProgramEditedEvent}
+import lucuma.odb.api.model.ProgramModel.ProgramEvent
 import lucuma.odb.api.model.Existence._
 import cats.Monad
 import cats.implicits._
@@ -34,8 +34,7 @@ object ProgramRepo {
       eventService,
       Tables.lastProgramId,
       Tables.programs,
-      ProgramCreatedEvent.apply,
-      ProgramEditedEvent.apply
+      ProgramEvent.apply
     ) with ProgramRepo[F]
       with LookupSupport[F] {
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
@@ -56,12 +56,10 @@ object ProgramRepo {
         selectAllFor(tid, _.programTargets, includeDeleted)
 
       override def insert(input: ProgramModel.Create): F[ProgramModel] =
-        modify { t =>
-          dontFindProgram(t, input.programId)
-           .fold(
-             err => (t, err.asLeft[ProgramModel]),
-             _   => createAndInsert(input.programId, pid => ProgramModel(pid, Present, input.name)).run(t).value.map(_.asRight)
-           )
+        constructAndPublish { t =>
+          dontFindProgram(t, input.programId).as(
+            createAndInsert(input.programId, ProgramModel(_, Present, input.name))
+          )
         }
 
     }

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
@@ -4,7 +4,7 @@
 package lucuma.odb.api.repo
 
 import lucuma.odb.api.model.{ProgramModel, TargetModel, ValidatedInput}
-import lucuma.odb.api.model.TargetModel.{CreateNonsidereal, CreateSidereal, TargetCreatedEvent, TargetEditedEvent, TargetProgramLinks}
+import lucuma.odb.api.model.TargetModel.{CreateNonsidereal, CreateSidereal, TargetEvent, TargetProgramLinks}
 import lucuma.odb.api.model.Existence._
 import lucuma.odb.api.model.syntax.validatedinput._
 import lucuma.core.model.Target
@@ -44,8 +44,7 @@ object TargetRepo {
       eventService,
       Tables.lastTargetId,
       Tables.targets,
-      TargetCreatedEvent.apply,
-      TargetEditedEvent.apply
+      TargetEvent.apply
     ) with TargetRepo[F]
       with LookupSupport[F] {
 


### PR DESCRIPTION
Collapses created and updated events into one.  Simplifies logic surrounding inserts.  This is a breaking change.