### PR TITLE
Target observation link

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/Sharing.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/Sharing.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+/**
+ * Input objects for sharing.
+ */
+object Sharing {
+
+  final case class TargetObservationLinks(
+    targets:      List[TargetModel.Id],
+    observations: List[ObservationModel.Id]
+  )
+
+  object TargetObservationLinks {
+    implicit val DecoderTargetObservationLinks: Decoder[TargetObservationLinks] =
+      deriveDecoder[TargetObservationLinks]
+  }
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/Sharing.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/Sharing.scala
@@ -12,8 +12,8 @@ import io.circe.generic.semiauto.deriveDecoder
 object Sharing {
 
   final case class TargetObservationLinks(
-    targets:      List[TargetModel.Id],
-    observations: List[ObservationModel.Id]
+    targetIds:      List[TargetModel.Id],
+    observationIds: List[ObservationModel.Id]
   )
 
   object TargetObservationLinks {

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
@@ -65,7 +65,7 @@ object AsterismRepo {
       ): State[Tables, T] =
         for {
           a   <- createAndInsert(asterismId, factory)
-          _   <- Tables.shareAsterismWithPrograms(a, programs)
+          _   <- TableState.shareAsterismWithPrograms(a, programs)
         } yield a
 
       override def insert[T <: AsterismModel](input: Create[T]): F[T] =
@@ -85,17 +85,17 @@ object AsterismRepo {
       ): F[AsterismModel] =
         tablesRef.modifyState {
           for {
-            a  <- Tables.tryAsterism(input.asterismId)
-            ps <- input.programIds.traverse(Tables.tryProgram).map(_.sequence)
+            a  <- TableState.asterism(input.asterismId)
+            ps <- input.programIds.traverse(TableState.program).map(_.sequence)
             r  <- (a, ps).traverseN { (am, _) => f(am, input.programIds.toSet).as(am) }
           } yield r
         }.flatMap(_.liftTo[F])
 
       override def shareWithPrograms(input: AsterismProgramLinks): F[AsterismModel] =
-        programSharing(input, Tables.shareAsterismWithPrograms)
+        programSharing(input, TableState.shareAsterismWithPrograms)
 
       override def unshareWithPrograms(input: AsterismProgramLinks): F[AsterismModel] =
-        programSharing(input, Tables.unshareAsterismWithPrograms)
+        programSharing(input, TableState.unshareAsterismWithPrograms)
 
     }
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
@@ -43,7 +43,7 @@ object AsterismRepo {
       Tables.asterisms,
       AsterismEvent.apply
     ) with AsterismRepo[F]
-      with LookupSupport[F] {
+      with LookupSupport {
 
       override def selectAllForProgram(pid: ProgramModel.Id, includeDeleted: Boolean): F[List[AsterismModel]] =
         tablesRef.get.map { t =>

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/EventService.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/EventService.scala
@@ -24,7 +24,7 @@ final class EventService[F[_]](
 
   def publish(f: Long => Event)(implicit F: FlatMap[F]): F[Unit] =
     for {
-      n <- refTables.modifyState(Tables.nextEventId)
+      n <- refTables.modifyState(TableState.nextEventId)
       _ <- topic.publish1(f(n))
     } yield ()
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/LookupSupport.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/LookupSupport.scala
@@ -7,7 +7,6 @@ import lucuma.odb.api.model.{AsterismModel, ObservationModel, ProgramModel, Targ
 import lucuma.odb.api.model.InputError
 import lucuma.core.util.Gid
 import cats._
-import cats.data.State
 import cats.implicits._
 
 import scala.collection.immutable.SortedMap
@@ -17,52 +16,41 @@ trait LookupSupport {
   def missingReference[F[_], I: Gid, T](id: I)(implicit M: MonadError[F, Throwable]): F[T] =
     ExecutionException.missingReference[F, I, T](id)
 
-  def lookup[I: Gid, T](m: SortedMap[I, T], id: I, name: String): ValidatedInput[T] =
+  def tryFind[I: Gid, T](m: SortedMap[I, T], id: I, name: String): ValidatedInput[T] =
     m.get(id).toValidNec(InputError.missingReference(name, Gid[I].show(id)))
+
+  def tryFindAsterism(t: Tables, aid: AsterismModel.Id): ValidatedInput[AsterismModel] =
+    tryFind(t.asterisms, aid, "asterism")
+
+  def tryFindObservation(t: Tables, oid: ObservationModel.Id): ValidatedInput[ObservationModel] =
+    tryFind(t.observations, oid, "observation")
+
+  def tryFindProgram(t: Tables, pid: ProgramModel.Id): ValidatedInput[ProgramModel] =
+    tryFind(t.programs, pid, "program")
+
+  def tryFindTarget(t: Tables, tid: TargetModel.Id): ValidatedInput[TargetModel] =
+    tryFind(t.targets, tid, "target")
+
 
   /**
    * Verify that the given id, if supplied, does not exist in the map.
    */
-  def dontFind[I: Gid, T](m: SortedMap[I, T], id: Option[I], name: String): ValidatedInput[Unit] =
+  def tryNotFind[I: Gid, T](m: SortedMap[I, T], id: Option[I], name: String): ValidatedInput[Unit] =
     id.fold(().validNec[InputError]) { i =>
       m.get(i).as(InputError.idClash(name, Gid[I].show(i))).toInvalidNec(())
     }
 
-  def lookupAsterism(t: Tables, aid: AsterismModel.Id): ValidatedInput[AsterismModel] =
-    lookup(t.asterisms, aid, "asterism")
+  def tryNotFindAsterism(t: Tables, aid: Option[AsterismModel.Id]): ValidatedInput[Unit] =
+    tryNotFind(t.asterisms, aid, "asterism")
 
-  def dontFindAsterism(t: Tables, aid: Option[AsterismModel.Id]): ValidatedInput[Unit] =
-    dontFind(t.asterisms, aid, "asterism")
+  def tryNotFindObservation(t: Tables, oid: Option[ObservationModel.Id]): ValidatedInput[Unit] =
+    tryNotFind(t.observations, oid, "observation")
 
-  def lookupObservation(t: Tables, oid: ObservationModel.Id): ValidatedInput[ObservationModel] =
-    lookup(t.observations, oid, "observation")
+  def tryNotFindProgram(t: Tables, pid: Option[ProgramModel.Id]): ValidatedInput[Unit] =
+    tryNotFind(t.programs, pid, "program")
 
-  def dontFindObservation(t: Tables, oid: Option[ObservationModel.Id]): ValidatedInput[Unit] =
-    dontFind(t.observations, oid, "observation")
-
-  def lookupProgram(t: Tables, pid: ProgramModel.Id): ValidatedInput[ProgramModel] =
-    lookup(t.programs, pid, "program")
-
-  def dontFindProgram(t: Tables, pid: Option[ProgramModel.Id]): ValidatedInput[Unit] =
-    dontFind(t.programs, pid, "program")
-
-  def lookupTarget(t: Tables, tid: TargetModel.Id): ValidatedInput[TargetModel] =
-    lookup(t.targets, tid, "target")
-
-  def dontFindTarget(t: Tables, tid: Option[TargetModel.Id]): ValidatedInput[Unit] =
-    dontFind(t.targets, tid, "target")
-
-  def inspectAsterismId(aid: AsterismModel.Id): State[Tables, ValidatedInput[AsterismModel]] =
-    State.inspect(lookupAsterism(_, aid))
-
-  def inspectObservationId(oid: ObservationModel.Id): State[Tables, ValidatedInput[ObservationModel]] =
-    State.inspect(lookupObservation(_, oid))
-
-  def inspectProgramId(pid: ProgramModel.Id): State[Tables, ValidatedInput[ProgramModel]] =
-    State.inspect(lookupProgram(_, pid))
-
-  def inspectTargetId(tid: TargetModel.Id): State[Tables, ValidatedInput[TargetModel]] =
-    State.inspect(lookupTarget(_, tid))
+  def tryNotFindTarget(t: Tables, tid: Option[TargetModel.Id]): ValidatedInput[Unit] =
+    tryNotFind(t.targets, tid, "target")
 
 }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/LookupSupport.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/LookupSupport.scala
@@ -12,9 +12,9 @@ import cats.implicits._
 
 import scala.collection.immutable.SortedMap
 
-trait LookupSupport[F[_]] {
+trait LookupSupport {
 
-  def missingReference[I: Gid, T](id: I)(implicit M: MonadError[F, Throwable]): F[T] =
+  def missingReference[F[_], I: Gid, T](id: I)(implicit M: MonadError[F, Throwable]): F[T] =
     ExecutionException.missingReference[F, I, T](id)
 
   def lookup[I: Gid, T](m: SortedMap[I, T], id: I, name: String): ValidatedInput[T] =
@@ -65,3 +65,5 @@ trait LookupSupport[F[_]] {
     State.inspect(lookupTarget(_, tid))
 
 }
+
+object LookupSupport extends LookupSupport

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/LookupSupport.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/LookupSupport.scala
@@ -6,15 +6,11 @@ package lucuma.odb.api.repo
 import lucuma.odb.api.model.{AsterismModel, ObservationModel, ProgramModel, TargetModel, ValidatedInput}
 import lucuma.odb.api.model.InputError
 import lucuma.core.util.Gid
-import cats._
 import cats.implicits._
 
 import scala.collection.immutable.SortedMap
 
 trait LookupSupport {
-
-  def missingReference[F[_], I: Gid, T](id: I)(implicit M: MonadError[F, Throwable]): F[T] =
-    ExecutionException.missingReference[F, I, T](id)
 
   def tryFind[I: Gid, T](m: SortedMap[I, T], id: I, name: String): ValidatedInput[T] =
     m.get(id).toValidNec(InputError.missingReference(name, Gid[I].show(id)))

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
@@ -65,7 +65,7 @@ object ObservationRepo {
 
         def construct(s: PlannedTimeSummaryModel): F[ObservationModel] =
           constructAndPublish { t =>
-            (dontFindObservation(t, newObs.observationId) *> lookupProgram(t, newObs.programId))
+            (tryNotFindObservation(t, newObs.observationId) *> tryFindProgram(t, newObs.programId))
               .as(createAndInsert(newObs.observationId, newObs.withId(_, s)))
           }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
@@ -35,7 +35,7 @@ object ObservationRepo {
       Tables.observations,
       ObservationEvent.apply
     ) with ObservationRepo[F]
-      with LookupSupport[F] {
+      with LookupSupport {
 
       override def selectAllForAsterism(aid: AsterismModel.Id, includeDeleted: Boolean): F[List[ObservationModel]] =
         tablesRef

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/OdbRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/OdbRepo.scala
@@ -13,6 +13,8 @@ import cats.effect.concurrent.Ref
  */
 trait OdbRepo[F[_]] {
 
+  def tables: Ref[F, Tables]
+
   def eventService: EventService[F]
 
   def asterism: AsterismRepo[F]
@@ -35,6 +37,9 @@ object OdbRepo {
       r <- Ref.of[F, Tables](Tables.empty)
       s <- EventService(r)
     } yield new OdbRepo[F] {
+
+      override def tables: Ref[F, Tables] =
+        r
 
       override def eventService: EventService[F] =
         s

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
@@ -57,7 +57,7 @@ object ProgramRepo {
 
       override def insert(input: ProgramModel.Create): F[ProgramModel] =
         constructAndPublish { t =>
-          dontFindProgram(t, input.programId).as(
+          tryNotFindProgram(t, input.programId).as(
             createAndInsert(input.programId, ProgramModel(_, Present, input.name))
           )
         }

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
@@ -6,6 +6,7 @@ package lucuma.odb.api.repo
 import lucuma.odb.api.model.{AsterismModel, ProgramModel, TargetModel}
 import lucuma.odb.api.model.ProgramModel.ProgramEvent
 import lucuma.odb.api.model.Existence._
+import lucuma.odb.api.model.syntax.validatedinput._
 import cats.Monad
 import cats.implicits._
 import cats.MonadError
@@ -45,7 +46,7 @@ object ProgramRepo {
       ): F[List[ProgramModel]] =
         tablesRef.get.flatMap { tables =>
           f(tables).selectLeft(id).toList.traverse { pid =>
-            tables.programs.get(pid).fold(missingReference[F, ProgramModel.Id, ProgramModel](pid))(M.pure)
+            tryFindProgram(tables, pid).liftTo[F]
           }
         }.map(deletionFilter(includeDeleted))
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
@@ -36,7 +36,7 @@ object ProgramRepo {
       Tables.programs,
       ProgramEvent.apply
     ) with ProgramRepo[F]
-      with LookupSupport[F] {
+      with LookupSupport {
 
       private def selectAllFor[I](
         id:             I,
@@ -45,7 +45,7 @@ object ProgramRepo {
       ): F[List[ProgramModel]] =
         tablesRef.get.flatMap { tables =>
           f(tables).selectLeft(id).toList.traverse { pid =>
-            tables.programs.get(pid).fold(missingReference[ProgramModel.Id, ProgramModel](pid))(M.pure)
+            tables.programs.get(pid).fold(missingReference[F, ProgramModel.Id, ProgramModel](pid))(M.pure)
           }
         }.map(deletionFilter(includeDeleted))
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TableState.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TableState.scala
@@ -1,0 +1,85 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.repo
+
+import lucuma.core.util.Gid
+import lucuma.odb.api.model.{AsterismModel, InputError, ObservationModel, ProgramModel, TargetModel, ValidatedInput}
+
+import cats.data.State
+import cats.kernel.BoundedEnumerable
+import cats.syntax.functor._
+import cats.syntax.option._
+import monocle.Lens
+import monocle.state.all._
+
+trait TableState {
+
+  val nextEventId: State[Tables, Long] =
+    Tables.lastEventId.mod(_ + 1L)
+
+  val nextAsterismId: State[Tables, AsterismModel.Id] =
+    Tables.lastAsterismId.mod(BoundedEnumerable[AsterismModel.Id].cycleNext)
+
+  val nextObservationId: State[Tables, ObservationModel.Id] =
+    Tables.lastObservationId.mod(BoundedEnumerable[ObservationModel.Id].cycleNext)
+
+  val nextProgramId: State[Tables, ProgramModel.Id] =
+    Tables.lastProgramId.mod(BoundedEnumerable[ProgramModel.Id].cycleNext)
+
+  val nextTargetId: State[Tables, TargetModel.Id] =
+    Tables.lastTargetId.mod(BoundedEnumerable[TargetModel.Id].cycleNext)
+
+  def shareAsterismWithPrograms(a: AsterismModel, pids: Set[ProgramModel.Id]): State[Tables, Unit] =
+    Tables.programAsterisms.mod_(_ ++ pids.toList.tupleRight(a.id))
+
+  def unshareAsterismWithPrograms(a: AsterismModel, pids: Set[ProgramModel.Id]): State[Tables, Unit] =
+    Tables.programAsterisms.mod_(_ -- pids.toList.tupleRight(a.id))
+
+  def unshareAsterismAll(aid: AsterismModel.Id): State[Tables, Unit] =
+    Tables.programAsterisms.mod_(_.removeRight(aid))
+
+  def shareTargetWithPrograms(t: TargetModel, pids: Set[ProgramModel.Id]): State[Tables, Unit] =
+    Tables.programTargets.mod_(_ ++ pids.toList.tupleRight(t.id))
+
+  def unshareTargetWithPrograms(t: TargetModel, pids: Set[ProgramModel.Id]): State[Tables, Unit] =
+    Tables.programTargets.mod_(_ -- pids.toList.tupleRight(t.id))
+
+  def unshareTargetAll(tid: TargetModel.Id): State[Tables, Unit] =
+    Tables.programTargets.mod_(_.removeRight(tid))
+
+
+  private def tryFind[I: Gid, T](name: String, id: I, lens: I => Lens[Tables, Option[T]]): State[Tables, ValidatedInput[T]] =
+    lens(id).st.map(_.toValidNec(InputError.missingReference(name, Gid[I].show(id))))
+
+  def asterism(aid: AsterismModel.Id): State[Tables, ValidatedInput[AsterismModel]] =
+    tryFind("asterism", aid, Tables.asterism)
+
+  def observation(oid: ObservationModel.Id): State[Tables, ValidatedInput[ObservationModel]] =
+    tryFind("observation", oid, Tables.observation)
+
+  def program(pid: ProgramModel.Id): State[Tables, ValidatedInput[ProgramModel]] =
+    tryFind("program", pid, Tables.program)
+
+  def target(tid: TargetModel.Id): State[Tables, ValidatedInput[TargetModel]] =
+    tryFind("target", tid, Tables.target)
+
+
+  private def require[A](s: State[Tables, ValidatedInput[A]]): State[Tables, A] =
+    s.map(_.valueOr(nec => throw InputError.Exception(nec)))
+
+  def requireAsterism(aid: AsterismModel.Id): State[Tables, AsterismModel] =
+    require(asterism(aid))
+
+  def requireObservation(oid: ObservationModel.Id): State[Tables, ObservationModel] =
+    require(observation(oid))
+
+  def requireProgram(pid: ProgramModel.Id): State[Tables, ProgramModel] =
+    require(program(pid))
+
+  def requireTarget(tid: TargetModel.Id): State[Tables, TargetModel] =
+    require(target(tid))
+
+}
+
+object TableState extends TableState

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
@@ -45,7 +45,7 @@ object TargetRepo {
       Tables.targets,
       TargetEvent.apply
     ) with TargetRepo[F]
-      with LookupSupport[F] {
+      with LookupSupport {
 
       override def selectAllForProgram(
         pid:            ProgramModel.Id,
@@ -54,7 +54,7 @@ object TargetRepo {
         tablesRef.get.flatMap { tables =>
           tables.programTargets.selectRight(pid).toList.traverse { tid =>
             tables.targets.get(tid).fold(
-              missingReference[TargetModel.Id, TargetModel](tid)
+              missingReference[F, TargetModel.Id, TargetModel](tid)
             )(M.pure)
           }
         }.map(deletionFilter(includeDeleted))

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
@@ -53,9 +53,7 @@ object TargetRepo {
       ): F[List[TargetModel]] =
         tablesRef.get.flatMap { tables =>
           tables.programTargets.selectRight(pid).toList.traverse { tid =>
-            tables.targets.get(tid).fold(
-              missingReference[F, TargetModel.Id, TargetModel](tid)
-            )(M.pure)
+            tryFindTarget(tables, tid).liftTo[F]
           }
         }.map(deletionFilter(includeDeleted))
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
@@ -62,7 +62,7 @@ object TargetRepo {
       def addAndShare(id: Option[TargetModel.Id], g: Target, pids: Set[ProgramModel.Id]): State[Tables, TargetModel] =
         for {
           t   <- createAndInsert(id, tid => TargetModel(tid, Present, g))
-          _   <- Tables.shareTargetWithPrograms(t, pids)
+          _   <- TableState.shareTargetWithPrograms(t, pids)
         } yield t
 
       private def insertTarget(id: Option[TargetModel.Id], pids: List[ProgramModel.Id], vt: ValidatedInput[Target]): F[TargetModel] =
@@ -84,17 +84,17 @@ object TargetRepo {
       ): F[TargetModel] =
         tablesRef.modifyState {
           for {
-            t  <- Tables.tryTarget(input.targetId)
-            ps <- input.programIds.traverse(Tables.tryProgram).map(_.sequence)
+            t  <- TableState.target(input.targetId)
+            ps <- input.programIds.traverse(TableState.program).map(_.sequence)
             r  <- (t, ps).traverseN { (tm, _) => f(tm, input.programIds.toSet).as(tm) }
           } yield r
         }.flatMap(_.liftTo[F])
 
       override def shareWithPrograms(input: TargetProgramLinks): F[TargetModel] =
-        programSharing(input, Tables.shareTargetWithPrograms)
+        programSharing(input, TableState.shareTargetWithPrograms)
 
       override def unshareWithPrograms(input: TargetProgramLinks): F[TargetModel] =
-        programSharing(input, Tables.unshareTargetWithPrograms)
+        programSharing(input, TableState.unshareTargetWithPrograms)
 
     }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/MutationType.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/MutationType.scala
@@ -18,7 +18,8 @@ object MutationType {
       fields =
         AsterismMutation.allFields[F]    ++
         ObservationMutation.allFields[F] ++
-        TargetMutation.allFields[F]
+        TargetMutation.allFields[F]      ++
+        SharingMutation.allFields[F]
 
     )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SharingMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SharingMutation.scala
@@ -17,6 +17,8 @@ import sangria.marshalling.circe._
 import sangria.schema._
 import monocle.state.all._
 
+import scala.concurrent.Future
+
 
 /**
  *
@@ -63,52 +65,107 @@ trait SharingMutation {
       o <- Tables.retrieveObservation(observationId)
     } yield (a, List[Long => Event](AsterismEvent(Created, a), ObservationEvent(Updated, o)))
 
+  // Produces a `State` computation that adds or removes targets from an
+  // asterism
+  private def updateAsterism(
+    asterismId: AsterismModel.Id,
+    update:     Set[TargetModel.Id] => Set[TargetModel.Id]
+  ): State[Tables, (AsterismModel, List[Long => Event])] =
+    Tables.retrieveAsterism(asterismId).transform { (t, a) =>
+      val newIds = update(a.targetIds)
+      if (newIds == a.targetIds)
+        (t, (a, List.empty[Long => Event]))
+      else {
+        val aʹ = AsterismModel.Default.asterismTargetIds.set(newIds)(a)
+        (Tables.asterisms.modify(_.updated(asterismId, aʹ))(t), (aʹ, List[Long => Event](AsterismEvent(Updated, aʹ))))
+      }
+    }
+
+  /**
+   * Returns a `State[Tables, ?]` program that will update a `Default` asterism,
+   * adding the given target ids.
+   *
+   * @param asterismId asterism to update (assuming it is a `Default` asterism
+   * @param targetIds target ids to _add_
+   *
+   * @return updated `Default` asterism paired with the list of resultant events
+   *         that should be published
+   */
   private def addTargetsToAsterism(
     asterismId: AsterismModel.Id,
     targetIds:  Set[TargetModel.Id]
   ): State[Tables, (AsterismModel, List[Long => Event])] =
-    for {
-      a   <- Tables.retrieveAsterism(asterismId)
-      tup <- Tables.asterism(asterismId).st.transform { (t, _) =>
-        if (a.targetIds == targetIds)
-          (t, (a, List.empty[Long => Event]))
-        else  {
-          val a2 = AsterismModel.Default.asterismTargetIds.modify(_ ++ targetIds)(a)
-          (Tables.asterisms.modify(_.updated(asterismId, a2))(t), (a2, List[Long => Event](AsterismEvent(Updated, a2))))
-        }
-      }
-    } yield tup
+    updateAsterism(asterismId, _ ++ targetIds)
+
+  /**
+   * Returns a `State[Tables, ?]` program that will update a `Default` asterism,
+   * removing the given target ids.
+   *
+   * @param asterismId asterism to update (assuming it is a `Default` asterism
+   * @param targetIds target ids to remove
+   *
+   * @return updated `Default` asterism paired with the list of resultant events
+   *         that should be published
+   */
+  private def removeTargetsFromAsterism(
+    asterismId: AsterismModel.Id,
+    targetIds:  Set[TargetModel.Id]
+  ): State[Tables, (AsterismModel, List[Long => Event])] =
+    updateAsterism(asterismId, _ -- targetIds)
+
+  // Implements the bulk of a share/unshare field for targets and observations.
+  // Takes a function that produces a `State` operation to apply to do the
+  // tables.
+  private def targetObservationShare[F[_]: Effect](
+    c: Context[OdbRepo[F], Unit]
+  )(
+    f: (Set[TargetModel.Id], List[ObservationModel]) => State[Tables, List[(AsterismModel, List[Long => Event])]]
+  ): Future[List[AsterismModel]] = {
+
+    val links   = c.arg(ArgumentTargetObservationLinks)
+
+    val updates = c.ctx.tables.modify { t =>
+      val targetIds  = links.targets.toSet
+      val targetList = links.targets.traverse(LookupSupport.lookupTarget(t, _))
+      val obsList    = links.observations.traverse(LookupSupport.lookupObservation(t, _))
+      (targetList, obsList).mapN { (_, os) =>
+        f(targetIds, os).run(t).value
+      }.fold(err => (t, InputError.Exception(err).asLeft), _.map(_.asRight))
+    }
+
+    (for {
+      us <- EitherT(updates).rethrowT
+      (as, es) = us.unzip
+      _  <- es.flatten.traverse(c.ctx.eventService.publish)
+    } yield as).toIO.unsafeToFuture()
+  }
 
   def shareTargetsWithObservations[F[_]: Effect]: Field[OdbRepo[F], Unit] =
     Field(
       name      = "shareTargetsWithObservations",
       fieldType = ListType(AsterismType[F]),
       arguments = List(ArgumentTargetObservationLinks),
-      resolve   = c => {
-        val links   = c.arg(ArgumentTargetObservationLinks)
-
-        val updates = c.ctx.tables.modify { t =>
-          val targetList = links.targets.traverse(LookupSupport.lookupTarget(t, _))
-          val obsList    = links.observations.traverse(LookupSupport.lookupObservation(t, _))
-          (targetList, obsList).mapN { (_, os) =>
-            os.traverse { o =>
-              val targetIds = links.targets.toSet
-              o.asterismId.fold(createDefaultAsterism(o.id, targetIds))(addTargetsToAsterism(_, targetIds))
-            }.run(t).value
-          }.fold(err => (t, InputError.Exception(err).asLeft), _.map(_.asRight))
+      resolve   = c => targetObservationShare[F](c) { (targetIds, obsList) =>
+        obsList.traverse { o =>
+          o.asterismId.fold(createDefaultAsterism(o.id, targetIds))(addTargetsToAsterism(_, targetIds))
         }
+      }
+    )
 
-        (for {
-          us <- EitherT(updates).rethrowT
-          (as, es) = us.unzip
-          _  <- es.flatten.traverse(c.ctx.eventService.publish)
-        } yield as).toIO.unsafeToFuture()
+  def unshareTargetsWithObservations[F[_]: Effect]: Field[OdbRepo[F], Unit] =
+    Field(
+      name      = "unshareTargetsWithObservations",
+      fieldType = ListType(AsterismType[F]),
+      arguments = List(ArgumentTargetObservationLinks),
+      resolve   = c => targetObservationShare[F](c) { (targetIds, obsList) =>
+        obsList.flatMap(_.asterismId.toList).traverse(removeTargetsFromAsterism(_, targetIds))
       }
     )
 
   def allFields[F[_]: Effect]: List[Field[OdbRepo[F], Unit]] =
     List(
-      shareTargetsWithObservations
+      shareTargetsWithObservations,
+      unshareTargetsWithObservations
     )
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SharingMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SharingMutation.scala
@@ -1,0 +1,108 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.schema
+
+import cats.data.State
+import lucuma.odb.api.model.{AsterismModel, Existence, InputError, ObservationModel, Sharing, TargetModel}
+import lucuma.odb.api.repo.{LookupSupport, OdbRepo, Tables}
+import cats.effect.Effect
+import cats.effect.implicits._
+import cats.syntax.all._
+import sangria.macros.derive._
+import sangria.marshalling.circe._
+import sangria.schema._
+import monocle.state.all._
+
+
+/**
+ *
+ */
+trait SharingMutation {
+
+  import GeneralSchema.ArgumentIncludeDeleted
+
+  import AsterismSchema.AsterismType
+  import ObservationSchema.ObservationIdType
+  import TargetSchema.TargetIdType
+
+  import syntax.inputobjecttype._
+
+  val InputObjectTargetObservationLinks: InputObjectType[Sharing.TargetObservationLinks] =
+    deriveInputObjectType[Sharing.TargetObservationLinks](
+      InputObjectTypeName("TargetObservationLinks"),
+      InputObjectTypeDescription("Target and the observations with which they are associated")
+    )
+
+  val ArgumentTargetObservationLinks: Argument[Sharing.TargetObservationLinks] =
+    InputObjectTargetObservationLinks.argument(
+      "input",
+      "Target/observation links"
+    )
+
+  def share[F[_]: Effect]: Field[OdbRepo[F], Unit] = {
+
+    def createDefaultAsterism(
+      observationId: ObservationModel.Id,
+      targetIds:     Set[TargetModel.Id]
+    ): State[Tables, (ObservationModel, AsterismModel)] =
+      for {
+        i <- Tables.nextAsterismId
+        a = AsterismModel.Default(i, Existence.Present, None, targetIds): AsterismModel
+        _ <- Tables.asterisms.mod(_ + (i -> a))
+        _ <- Tables.observation(observationId).mod(_.map(ObservationModel.asterismId.set(Some(i))))
+        o <- Tables.retrieveObservation(observationId)
+      } yield (o, a)
+
+
+    Field(
+      name      = "share",
+      fieldType = ListType(AsterismType[F]),
+      arguments = List(ArgumentTargetObservationLinks, ArgumentIncludeDeleted),
+      resolve   = c => {
+        val links   = c.arg(ArgumentTargetObservationLinks)
+
+        val updates = c.ctx.tables.modify { t =>
+          val targetList = links.targets.traverse(LookupSupport.lookupTarget(t, _))
+          val obsList    = links.observations.traverse(LookupSupport.lookupObservation(t, _))
+          (targetList, obsList).mapN { (_, os) =>
+            val asterisms = os.traverse { o =>
+              o.asterismId.fold(
+                createDefaultAsterism(o.id, links.targets.toSet).map(_.leftMap(Option(_)))
+              )(
+                id => Tables.retrieveAsterism(id).tupleLeft(Option.empty[ObservationModel])
+              )
+            }
+
+            (for {
+              as <- asterisms
+              _  <- Tables.asterisms.mod { aMap =>
+                as.foldLeft(aMap) { case (m, (_, a)) =>
+                  m.updated(a.id, AsterismModel.Default.asterismTargetIds.set(links.targets.toSet)(a))
+                }
+              }
+            } yield as).run(t).value
+          }.fold(
+            err => (t, err.asLeft[List[(Option[ObservationModel], AsterismModel)]]),
+            tup => tup.map(_.asRight)
+          )
+        }.flatMap {
+          case Left(err) => Effect[F].raiseError[List[(Option[ObservationModel], AsterismModel)]](InputError.Exception(err))
+          case Right(as) => Effect[F].pure(as)
+        }
+
+        (for {
+          us <- updates
+          _  <- us.traverse { case (oo, a) =>
+            val es = c.ctx.eventService
+            oo.fold(es.publish(AsterismModel.AsterismEditedEvent(a, a))) { o =>
+              es.publish(AsterismModel.AsterismCreatedEvent(a)) *>
+                es.publish(ObservationModel.ObservationEditedEvent(o, o))
+            }
+          }
+        } yield us.map(_._2)).toIO.unsafeToFuture()
+      }
+    )
+  }
+
+}


### PR DESCRIPTION
I'm part-way through refactoring sharing/unsharing, but the change set is already pretty large and I have something that might be usable for the requested feature of target/observation sharing.  There will be a follow-up PR with the remainder of the refactoring which should make the various sharing options more similar.  For now, this will add `shareTargetsWithObservations` and `unshareTargetsWithObservations`.  The long-term fate of this is questionable because it requires working with asterisms, which for the moment must be `Default` asterisms.