### PR TITLE
Update streaming message sent for error

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/api/service/Connection.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Connection.scala
@@ -90,7 +90,7 @@ object Connection {
         r <- odbService.query(request)
         _ <- r.fold(
                err  => reply(Error(id, err.format)),
-               json => reply(json.toDataMessage(id)) *> reply(Complete(id))
+               json => reply(json.toStreamingMessage(id)) *> reply(Complete(id))
              )
       } yield ()
 

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Subscriptions.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Subscriptions.scala
@@ -78,7 +78,7 @@ object Subscriptions {
   private def fromServerPipe[F[_]](id: String): Pipe[F, Either[Throwable, Json], FromServer] =
     _.map {
       case Left(err)   => Error(id, err.format)
-      case Right(json) => json.toDataMessage(id)
+      case Right(json) => json.toStreamingMessage(id)
     }
 
   def apply[F[_]](


### PR DESCRIPTION
When there is no `data`, send an `error` message instead of a `data` message with no `data` field.