### PR TITLE
More Sharing

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/AsterismModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/AsterismModel.scala
@@ -178,8 +178,8 @@ object AsterismModel extends AsterismOptics {
   }
 
   final case class AsterismProgramLinks(
-    asterismId: Asterism.Id,
-    programIds: List[Program.Id]
+    asterismIds: List[Asterism.Id],
+    programIds:  List[Program.Id]
   )
 
   object AsterismProgramLinks {

--- a/modules/core/src/main/scala/lucuma/odb/api/model/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/TargetModel.scala
@@ -225,7 +225,7 @@ object TargetModel extends TargetOptics {
   }
 
   final case class TargetProgramLinks(
-    targetId:   Target.Id,
+    targetIds:  List[Target.Id],
     programIds: List[Program.Id]
   )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/AsterismMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/AsterismMutation.scala
@@ -64,18 +64,6 @@ trait AsterismMutation extends TargetScalars {
       "Edit default asterism"
     )
 
-  val InputObjectAsterismProgramLinks: InputObjectType[AsterismModel.AsterismProgramLinks] =
-    deriveInputObjectType[AsterismModel.AsterismProgramLinks](
-      InputObjectTypeName("AsterismProgramLinks"),
-      InputObjectTypeDescription("Asterism and the programs with which they are associated")
-    )
-
-  val ArgumentAsterismProgramLinks: Argument[AsterismModel.AsterismProgramLinks] =
-    InputObjectAsterismProgramLinks.argument(
-      "input",
-      "Asterism/program links"
-    )
-
   def createDefault[F[_]: Effect]: Field[OdbRepo[F], Unit] =
     Field(
       name      = "createDefaultAsterism",
@@ -122,30 +110,12 @@ trait AsterismMutation extends TargetScalars {
       resolve   = c => c.asterism(_.undelete(c.asterismId))
     )
 
-  def shareAsterismWithPrograms[F[_]: Effect]: Field[OdbRepo[F], Unit] =
-    Field(
-      name      = "shareAsterismWithPrograms",
-      fieldType = OptionType(AsterismType[F]),
-      arguments = List(ArgumentAsterismProgramLinks),
-      resolve   = c => c.asterism(_.shareWithPrograms(c.arg(ArgumentAsterismProgramLinks)))
-    )
-
-  def unshareAsterismWithPrograms[F[_]: Effect]: Field[OdbRepo[F], Unit] =
-    Field(
-      name      = "unshareAsterismWithPrograms",
-      fieldType = OptionType(AsterismType[F]),
-      arguments = List(ArgumentAsterismProgramLinks),
-      resolve   = c => c.asterism(_.unshareWithPrograms(c.arg(ArgumentAsterismProgramLinks)))
-    )
-
   def allFields[F[_]: Effect]: List[Field[OdbRepo[F], Unit]] =
     List(
       createDefault,
       updateDefault,
       delete,
-      undelete,
-      shareAsterismWithPrograms,
-      unshareAsterismWithPrograms
+      undelete
     )
 }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
@@ -162,18 +162,6 @@ trait TargetMutation extends TargetScalars {
       "Sidereal target edit"
     )
 
-  val InputObjectTargetProgramLinks: InputObjectType[TargetModel.TargetProgramLinks] =
-    deriveInputObjectType[TargetModel.TargetProgramLinks](
-      InputObjectTypeName("TargetProgramLinks"),
-      InputObjectTypeDescription("Target and the programs with which they are associated")
-    )
-
-  val ArgumentTargetProgramLinks: Argument[TargetModel.TargetProgramLinks] =
-    InputObjectTargetProgramLinks.argument(
-      "input",
-      "Target/program links"
-    )
-
   def createNonsidereal[F[_]: Effect]: Field[OdbRepo[F], Unit] =
     Field(
       name      = "createNonsiderealTarget",
@@ -215,31 +203,13 @@ trait TargetMutation extends TargetScalars {
       resolve   = c => c.target(_.undelete(c.targetId))
     )
 
-  def shareTargetWithPrograms[F[_]: Effect]: Field[OdbRepo[F], Unit] =
-    Field(
-      name      = "shareTargetWithPrograms",
-      fieldType = OptionType(TargetType[F]),
-      arguments = List(ArgumentTargetProgramLinks),
-      resolve   = c => c.target(_.shareWithPrograms(c.arg(ArgumentTargetProgramLinks)))
-    )
-
-  def unshareTargetWithPrograms[F[_]: Effect]: Field[OdbRepo[F], Unit] =
-    Field(
-      name      = "unshareTargetWithPrograms",
-      fieldType = OptionType(TargetType[F]),
-      arguments = List(ArgumentTargetProgramLinks),
-      resolve   = c => c.target(_.unshareWithPrograms(c.arg(ArgumentTargetProgramLinks)))
-    )
-
   def allFields[F[_]: Effect]: List[Field[OdbRepo[F], Unit]] =
     List(
       createNonsidereal,
       createSidereal,
       updateSidereal,
       delete,
-      undelete,
-      shareTargetWithPrograms,
-      unshareTargetWithPrograms
+      undelete
     )
 
 }


### PR DESCRIPTION
A minor update to sharing (though it will break anything other than target/observation sharing).  Makes the asterism/program and target/program sharing API similar to the target/observation (plural on each side of the share) and moves them all into the `SharingMutation`.