### PR TITLE
stop spurious events

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -7,6 +7,7 @@ import lucuma.odb.api.model.Existence._
 import lucuma.core.`enum`.ObsStatus
 import lucuma.core.optics.syntax.lens._
 import lucuma.core.model.{Asterism, Observation, Program}
+import cats.Eq
 import cats.data.State
 import cats.syntax.validated._
 import io.circe.Decoder
@@ -28,6 +29,9 @@ object ObservationModel extends ObservationOptics {
 
   implicit val TopLevelObservation: TopLevelModel[Observation.Id, ObservationModel] =
     TopLevelModel.instance(_.id, ObservationModel.existence)
+
+  implicit val EqObservation: Eq[ObservationModel] =
+    Eq.by(o => (o.id, o.existence, o.programId, o.name, o.status, o.asterismId, o.plannedTimeSummary))
 
   final case class Create(
     observationId: Option[Observation.Id],

--- a/modules/core/src/main/scala/lucuma/odb/api/model/PlannedTimeSummaryModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/PlannedTimeSummaryModel.scala
@@ -3,7 +3,7 @@
 
 package lucuma.odb.api.model
 
-import cats.Monoid
+import cats.{Eq, Monoid}
 import cats.effect.Sync
 import cats.syntax.functor._
 import cats.syntax.flatMap._
@@ -42,5 +42,8 @@ object PlannedTimeSummaryModel {
           a.unchargedTime + b.unchargedTime
         )
     )
+
+  implicit val EqPlannedTimeSummaryModel: Eq[PlannedTimeSummaryModel] =
+    Eq.by(t => (t.piTime.toNanos, t.unchargedTime.toNanos))
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
@@ -4,6 +4,7 @@
 package lucuma.odb.api.model
 
 import lucuma.core.model.Program
+import cats.Eq
 import io.circe.Decoder
 import io.circe.generic.semiauto._
 import monocle.Lens
@@ -22,6 +23,9 @@ object ProgramModel extends ProgramOptics {
 
   implicit val TopLevelProgram: TopLevelModel[Program.Id, ProgramModel] =
     TopLevelModel.instance(_.id, ProgramModel.existence)
+
+  implicit val EqProgram: Eq[ProgramModel] =
+    Eq.by(p => (p.id, p.existence, p.name))
 
   /**
    * Program creation input class.

--- a/modules/core/src/main/scala/lucuma/odb/api/model/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/TargetModel.scala
@@ -3,6 +3,7 @@
 
 package lucuma.odb.api.model
 
+import cats.Eq
 import lucuma.odb.api.model.json.targetmath._
 import lucuma.core.`enum`.EphemerisKeyType
 import lucuma.core.math.{Coordinates, Declination, Epoch, Parallax, ProperMotion, RadialVelocity, RightAscension}
@@ -32,6 +33,8 @@ object TargetModel extends TargetOptics {
   implicit val TopLevelTarget: TopLevelModel[Target.Id, TargetModel] =
     TopLevelModel.instance(_.id, existence)
 
+  implicit val EqualTarget: Eq[TargetModel] =
+    Eq.by(t => (t.id, t.existence, t.target))
 
   object parse {
 


### PR DESCRIPTION
When using Explore, switching from one target to another generates spurious edits.  For example, if the focus is in the target name when clicking on a different target the focus is lost.  That triggers a `mutation` request from the client whether or not the target name has actually changed.  

```
2020-11-10T13:58:34.800652+00:00 app[web.1]: [ioapp-compute-2] INFO  l.o.a.s.Routes - Received message from client: Text('{
2020-11-10T13:58:34.800668+00:00 app[web.1]: "type" : "start",
2020-11-10T13:58:34.800668+00:00 app[web.1]: "id" : "6761a6a7-2b5b-4855-9b11-c2e93cc9092e",
2020-11-10T13:58:34.800669+00:00 app[web.1]: "payload" : {
2020-11-10T13:58:34.800680+00:00 app[web.1]: "query" : "\n      mutation($input: EditSiderealInput!) {\n        updateSiderealTarget(input: $input) {\n          id\n        }\n      }\n    ",
2020-11-10T13:58:34.800681+00:00 app[web.1]: "variables" : {
2020-11-10T13:58:34.800681+00:00 app[web.1]: "input" : {
2020-11-10T13:58:34.800682+00:00 app[web.1]: "targetId" : "t-15099551",
2020-11-10T13:58:34.800682+00:00 app[web.1]: "name" : "NGC 2070"
2020-11-10T13:58:34.800682+00:00 app[web.1]: }
2020-11-10T13:58:34.800683+00:00 app[web.1]: }
2020-11-10T13:58:34.800683+00:00 app[web.1]: }
2020-11-10T13:58:34.800683+00:00 app[web.1]: }', last: true)
```

The edit in turn causes subscriptions to be notified of an update despite the fact that nothing has really changed.

```
2020-11-10T13:58:34.811797+00:00 app[web.1]: [ioapp-compute-0] INFO  l.o.a.s.Main - subscription event (1 still queued): TargetEvent(108,Updated,TargetModel(t-15099551,Present,Target(NGC 2070,Right(SiderealTracking(Some(CatalogId(Simbad,NGC  2070)),Coordinates(05:38:42.000000 -69:05:59.999999),Epoch(J2000.000),None,Some(RadialVelocity(251.0 km/s)),None)),TreeMap())))
2020-11-10T13:58:34.812441+00:00 app[web.1]: [ioapp-compute-0] INFO  l.o.a.s.Main - subscription event (1 still queued): TargetEvent(108,Updated,TargetModel(t-15099551,Present,Target(NGC 2070,Right(SiderealTracking(Some(CatalogId(Simbad,NGC  2070)),Coordinates(05:38:42.000000 -69:05:59.999999),Epoch(J2000.000),None,Some(RadialVelocity(251.0 km/s)),None)),TreeMap())))
```
... many more of the same as all clients are notified ...

This PR will avoid triggering events unless an item is actually edited according to an `Eq` comparison of the old and new values.
