### PR TITLE
Less logging

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/syntax/LoggerOps.scala
+++ b/modules/core/src/main/scala/lucuma/odb/syntax/LoggerOps.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.syntax
+
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.extras.LogLevel
+
+final class LoggerOps[F[_]](val self: Logger[F]) extends AnyVal {
+
+  def log(level: LogLevel, message: => String): F[Unit] =
+    level match {
+      case LogLevel.Error => self.error(message)
+      case LogLevel.Warn  => self.warn(message)
+      case LogLevel.Info  => self.info(message)
+      case LogLevel.Debug => self.debug(message)
+      case LogLevel.Trace => self.trace(message)
+    }
+
+  def log(t: Throwable)(level: LogLevel, message: => String): F[Unit] =
+    level match {
+      case LogLevel.Error => self.error(t)(message)
+      case LogLevel.Warn  => self.warn(t)(message)
+      case LogLevel.Info  => self.info(t)(message)
+      case LogLevel.Debug => self.debug(t)(message)
+      case LogLevel.Trace => self.trace(t)(message)
+    }
+
+}
+
+trait ToLoggerOps {
+  implicit def ToLoggerOps[F[_]](log: Logger[F]): LoggerOps[F] =
+    new LoggerOps[F](log)
+}
+
+object logger extends ToLoggerOps

--- a/modules/core/src/main/scala/lucuma/odb/syntax/package.scala
+++ b/modules/core/src/main/scala/lucuma/odb/syntax/package.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb
+
+package object syntax {
+
+  object all extends ToLoggerOps
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/api/service/OdbService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/OdbService.scala
@@ -39,8 +39,6 @@ object OdbService {
 
     new OdbService[F] {
 
-      def info(m: String): F[Unit] = Logger[F].info(m)
-
       override def query(request: ParsedGraphQLRequest): F[Either[Throwable, Json]] =
 
         F.async { (cb: Either[Throwable, Json] => Unit) =>
@@ -77,7 +75,7 @@ object OdbService {
               ).map { preparedQuery =>
                 preparedQuery
                   .execute()
-                  .evalTap(n => info(s"Subscription event: ${n.printWith(Printer.spaces2)}"))
+                  .evalTap(n => Logger[F].info(s"Subscription event: ${n.printWith(Printer.spaces2)}"))
                   .map(_.asRight[Throwable])
                   .recover { case NonFatal(error) => error.asLeft[Json] }
               }

--- a/modules/service/src/main/scala/lucuma/odb/api/service/OdbService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/OdbService.scala
@@ -10,7 +10,6 @@ import cats.effect.{Async, ConcurrentEffect, ContextShift, IO}
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
 import io.circe._
-import org.log4s.getLogger
 import sangria.execution._
 import sangria.marshalling.circe._
 import sangria.streaming
@@ -32,8 +31,6 @@ trait OdbService[F[_]] {
 
 object OdbService {
 
-  private[this] val logger = getLogger
-
   def apply[F[_]: Logger](
     odb: OdbRepo[F]
   )(
@@ -42,8 +39,7 @@ object OdbService {
 
     new OdbService[F] {
 
-      def info(m: String): F[Unit] =
-        F.delay(logger.info(m))
+      def info(m: String): F[Unit] = Logger[F].info(m)
 
       override def query(request: ParsedGraphQLRequest): F[Either[Throwable, Json]] =
 

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Routes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Routes.scala
@@ -121,6 +121,9 @@ object Routes {
         }
 
       def logTextFrame(user: F[Option[User]], f: WebSocketFrame): F[Unit] = {
+
+        // The connection_init message payload has authorization information
+        // which should not be logged.
         val AuthRegEx    = """"Authorization":\s*"[^"]*"""".r.unanchored
         val RedactedAuth = """"Authorization": <REDACTED>"""
 

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Subscriptions.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Subscriptions.scala
@@ -4,6 +4,8 @@
 package lucuma.odb.api.service
 
 import lucuma.odb.api.service.ErrorFormatter.syntax._
+import lucuma.core.model.User
+
 import clue.model.StreamingMessage._
 import clue.model.StreamingMessage.FromServer._
 import cats.effect.{ConcurrentEffect, Fiber}
@@ -11,9 +13,8 @@ import cats.effect.concurrent.Ref
 import cats.implicits._
 import fs2.{Pipe, Stream}
 import fs2.concurrent.SignallingRef
+import io.chrisdavenport.log4cats.Logger
 import io.circe.Json
-import lucuma.core.model.User
-import org.log4s.getLogger
 
 
 /**
@@ -48,8 +49,6 @@ object Subscriptions {
 
   import syntax.json._
 
-  private[this] val logger = getLogger
-
   /**
    * Tracks a single client subscription.
    *
@@ -82,7 +81,7 @@ object Subscriptions {
       case Right(json) => json.toStreamingMessage(id)
     }
 
-  def apply[F[_]](
+  def apply[F[_]: Logger](
     user: Option[User],
     send: Option[FromServer] => F[Unit]
   )(implicit F: ConcurrentEffect[F]): F[Subscriptions[F]] =
@@ -91,7 +90,7 @@ object Subscriptions {
       new Subscriptions[F]() {
 
         def info(m: String): F[Unit] =
-          F.delay(logger.info(s"user=$user, message=$m"))
+          Logger[F].info(s"(user=$user): message=$m")
 
         def replySink(id: String): Pipe[F, Either[Throwable, Json], Unit] =
           events => fromServerPipe(id)(events).evalMap(m => send(Some(m)))

--- a/modules/service/src/main/scala/lucuma/odb/api/service/package.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/package.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api
+
+import lucuma.core.model.User
+import lucuma.odb.syntax.logger._
+
+import cats.FlatMap
+import cats.syntax.all._
+
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.extras.LogLevel
+
+
+package object service {
+
+  def log[F[_]: Logger](level: LogLevel, u: Option[User], s: => String): F[Unit] =
+    Logger[F].log(level, s"$s: (user=${u.map(_.toString()).getOrElse("None")})")
+
+  def log[F[_]: Logger: FlatMap](level: LogLevel, u: F[Option[User]], s: => String): F[Unit] =
+    u.flatMap(log(level, _, s))
+
+  def debug[F[_]: Logger](u: Option[User], s: => String): F[Unit] =
+    log(LogLevel.Debug, u, s)
+
+  def debug[F[_]: Logger: FlatMap](u: F[Option[User]], s: => String): F[Unit] =
+    log(LogLevel.Debug, u, s)
+
+  def info[F[_]: Logger](u: Option[User], s: => String): F[Unit] =
+    log(LogLevel.Info, u, s)
+
+  def info[F[_]: Logger: FlatMap](u: F[Option[User]], s: => String): F[Unit] =
+    log(LogLevel.Info, u, s)
+
+}


### PR DESCRIPTION
A few minor logging updates to avoid flooding the log:

1) Lowers the priority of keep alive messages to debug.
2) Uses `log4cats` everywhere.
3) Redacts authorization information coming in websocket `connection_init` message `payload`.