### PR TITLE
Unset asterism, etc. with null value

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -4,12 +4,18 @@
 package lucuma.odb.api.model
 
 import lucuma.odb.api.model.Existence._
+import lucuma.odb.api.model.syntax.input._
 import lucuma.core.`enum`.ObsStatus
 import lucuma.core.optics.syntax.lens._
 import lucuma.core.model.{Asterism, Observation, Program}
+
 import cats.Eq
 import cats.data.State
-import cats.syntax.validated._
+import cats.syntax.apply._
+import cats.syntax.traverse._
+import clue.data.Input
+import eu.timepit.refined.cats._
+import eu.timepit.refined.types.string._
 import io.circe.Decoder
 import io.circe.generic.semiauto._
 import monocle.Lens
@@ -19,7 +25,7 @@ final case class ObservationModel(
   id:                 Observation.Id,
   existence:          Existence,
   programId:          Program.Id,
-  name:               Option[String],
+  name:               Option[NonEmptyString],
   status:             ObsStatus,
   asterismId:         Option[Asterism.Id],
   plannedTimeSummary: PlannedTimeSummaryModel
@@ -41,16 +47,20 @@ object ObservationModel extends ObservationOptics {
     status:        Option[ObsStatus]
   ) {
 
-    def withId(id: Observation.Id, s: PlannedTimeSummaryModel): ObservationModel =
-      ObservationModel(
-        id,
-        Present,
-        programId,
-        name,
-        status.getOrElse(ObsStatus.New),
-        asterismId,
-        s
-      )
+    def withId(s: PlannedTimeSummaryModel): ValidatedInput[Observation.Id => ObservationModel] =
+      name
+        .traverse(ValidatedInput.nonEmptyString("name", _))
+        .map { n => oid =>
+          ObservationModel(
+            oid,
+            Present,
+            programId,
+            n,
+            status.getOrElse(ObsStatus.New),
+            asterismId,
+            s
+          )
+        }
 
   }
 
@@ -59,33 +69,61 @@ object ObservationModel extends ObservationOptics {
     implicit val DecoderCreate: Decoder[Create] =
       deriveDecoder[Create]
 
+    implicit val EqCreate: Eq[Create] =
+      Eq.by { a => (
+        a.observationId,
+        a.programId,
+        a.name,
+        a.asterismId,
+        a.status
+      )}
+
   }
 
   final case class Edit(
     observationId: Observation.Id,
-    existence:     Option[Existence],
-    name:          Option[Option[String]],
-    status:        Option[ObsStatus],
-    asterismId:    Option[Option[Asterism.Id]]
+    existence:     Input[Existence]   = Input.ignore,
+    name:          Input[String]      = Input.ignore,
+    status:        Input[ObsStatus]   = Input.ignore,
+    asterismId:    Input[Asterism.Id] = Input.ignore
   ) extends Editor[Observation.Id, ObservationModel] {
 
     override def id: Observation.Id =
       observationId
 
-    override def editor: ValidatedInput[State[ObservationModel, Unit]] =
-      (for {
-        _ <- ObservationModel.existence  := existence
-        _ <- ObservationModel.name       := name
-        _ <- ObservationModel.status     := status
-        _ <- ObservationModel.asterismId := asterismId
-      } yield ()).validNec
+    override def editor: ValidatedInput[State[ObservationModel, Unit]] = {
+      (existence.validateIsNotNull("existence"),
+       name     .validateNullable(n => ValidatedInput.nonEmptyString("name", n)),
+       status   .validateIsNotNull("status")
+      ).mapN { (e, n, s) =>
+        for {
+          _ <- ObservationModel.existence  := e
+          _ <- ObservationModel.name       := n
+          _ <- ObservationModel.status     := s
+          _ <- ObservationModel.asterismId := asterismId.toOptionOption
+        } yield ()
+      }
+    }
 
   }
 
   object Edit {
 
+    import io.circe.generic.extras.semiauto._
+    import io.circe.generic.extras.Configuration
+    implicit val customConfig: Configuration = Configuration.default.withDefaults
+
     implicit val DecoderEdit: Decoder[Edit] =
-      deriveDecoder[Edit]
+      deriveConfiguredDecoder[Edit]
+
+    implicit val EqEdit: Eq[Edit] =
+      Eq.by{ a => (
+        a.observationId,
+        a.existence,
+        a.name,
+        a.status,
+        a.asterismId
+      )}
 
   }
 
@@ -105,18 +143,18 @@ object ObservationModel extends ObservationOptics {
 trait ObservationOptics { self: ObservationModel.type =>
 
   val id: Lens[ObservationModel, Observation.Id] =
-    Lens[ObservationModel, Observation.Id](_.id)(a => b => b.copy(id = a))
+    Lens[ObservationModel, Observation.Id](_.id)(a => _.copy(id = a))
 
   val existence: Lens[ObservationModel, Existence] =
-    Lens[ObservationModel, Existence](_.existence)(a => b => b.copy(existence = a))
+    Lens[ObservationModel, Existence](_.existence)(a => _.copy(existence = a))
 
-  val name: Lens[ObservationModel, Option[String]] =
-    Lens[ObservationModel, Option[String]](_.name)(a => b => b.copy(name = a))
+  val name: Lens[ObservationModel, Option[NonEmptyString]] =
+    Lens[ObservationModel, Option[NonEmptyString]](_.name)(a => _.copy(name = a))
 
   val status: Lens[ObservationModel, ObsStatus] =
-    Lens[ObservationModel, ObsStatus](_.status)(a => b => b.copy(status = a))
+    Lens[ObservationModel, ObsStatus](_.status)(a => _.copy(status = a))
 
   val asterismId: Lens[ObservationModel, Option[Asterism.Id]] =
-    Lens[ObservationModel, Option[Asterism.Id]](_.asterismId)(a => b => b.copy(asterismId = a))
+    Lens[ObservationModel, Option[Asterism.Id]](_.asterismId)(a => _.copy(asterismId = a))
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
@@ -66,8 +66,10 @@ object ObservationRepo {
 
         def construct(s: PlannedTimeSummaryModel): F[ObservationModel] =
           constructAndPublish { t =>
-            (tryNotFindObservation(t, newObs.observationId) *> tryFindProgram(t, newObs.programId))
-              .as(createAndInsert(newObs.observationId, newObs.withId(_, s)))
+            (tryNotFindObservation(t, newObs.observationId) *>
+             tryFindProgram(t, newObs.programId)            *>
+              newObs.withId(s)
+            ).map(createAndInsert(newObs.observationId, _))
           }
 
         for {

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -6,6 +6,8 @@ package lucuma.odb.api.schema
 import lucuma.odb.api.model.ObservationModel
 import lucuma.odb.api.repo.OdbRepo
 
+import lucuma.odb.api.schema.syntax.inputtype._
+
 import cats.effect.Effect
 import sangria.macros.derive._
 import sangria.marshalling.circe._
@@ -35,7 +37,11 @@ trait ObservationMutation {
   val InputObjectTypeObservationEdit: InputObjectType[ObservationModel.Edit] =
     deriveInputObjectType[ObservationModel.Edit](
       InputObjectTypeName("EditObservationInput"),
-      InputObjectTypeDescription("Edit observation")
+      InputObjectTypeDescription("Edit observation"),
+      ReplaceInputField("existence",  EnumTypeExistence.notNullableField("existence")),
+      ReplaceInputField("name",       StringType.nullableField("name")),
+      ReplaceInputField("status",     ObsStatusType.notNullableField("status")),
+      ReplaceInputField("asterismId", AsterismIdType.nullableField("asterismId"))
     )
 
   val ArgumentObservationEdit: Argument[ObservationModel.Edit] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
@@ -69,7 +69,7 @@ object ObservationSchema {
           name        = "name",
           fieldType   = OptionType(StringType),
           description = Some("Observation name"),
-          resolve     = _.value.name
+          resolve     = _.value.name.map(_.value)
         ),
 
         Field(


### PR DESCRIPTION
Adds the ability to disconnect observations and asterisms (via `updateObservation`, passing in `null` for `asterismId`).  Switches to clue `Input` in general for observation editing.