### PR TITLE
GMOS Sequence (Part 1)

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ConfigModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ConfigModel.scala
@@ -3,46 +3,176 @@
 
 package lucuma.odb.api.model
 
-import cats.Eq
 import lucuma.core.`enum`.Instrument
+
+import cats.Eq
+import cats.syntax.all._
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
 import monocle.Lens
 
-sealed abstract class ConfigModel[I](val instrument: I) extends Product with Serializable
+/**
+ * Instrument specific configuration.  Instances for each instrument.
+ */
+sealed abstract class ConfigModel(val instrument: Instrument) extends Product with Serializable {
+
+  def gmosNorth: Option[ConfigModel.GmosNorth] =
+    this match {
+      case gn: ConfigModel.GmosNorth => Some(gn)
+      case _                         => None
+    }
+
+  def gmosSouth: Option[ConfigModel.GmosSouth] =
+    this match {
+      case gs: ConfigModel.GmosSouth => Some(gs)
+      case _                         => None
+    }
+
+}
 
 
 object ConfigModel {
 
+  implicit val EqConfigModel: Eq[ConfigModel] =
+    Eq.instance[ConfigModel] {
+      case (a: GmosNorth, b: GmosNorth) => a === b
+      case (a: GmosSouth, b: GmosSouth) => a === b
+      case (_, _)                       => false
+    }
+
+
+  // Here I was anticipating that each instrument will have other specific
+  // configuration besides the manual sequence but I'm not sure.  At the very
+  // least it gives a GmosNorth-specific ManualSequence type.  Perhaps there
+  // are better ideas?
+
+  type ManualSequenceGmosNorth = ManualSequence[GmosModel.NorthStatic, GmosModel.NorthDynamic]
+
   final case class GmosNorth(
-    static:      GmosModel.NorthStatic,
-    acquisition: List[StepModel[GmosModel.NorthDynamic]],
-    science:     List[StepModel[GmosModel.NorthDynamic]]
+    manual: ManualSequenceGmosNorth
   ) extends ConfigModel(Instrument.GmosN)
 
-  object GmosNorth {
+  object GmosNorth extends GmosNorthOptics {
 
     implicit val EqGmosNorth: Eq[GmosNorth] =
-      Eq.by { a => (
-        a.static,
-        a.acquisition,
-        a.science
-      )}
+      Eq.by(_.manual)
 
   }
 
   sealed trait GmosNorthOptics { this: GmosNorth.type =>
 
-    val static: Lens[GmosNorth, GmosModel.NorthStatic] =
-      Lens[GmosNorth, GmosModel.NorthStatic](_.static)(a => _.copy(static = a))
-
-    val acquisition: Lens[GmosNorth, List[StepModel[GmosModel.NorthDynamic]]] =
-      Lens[GmosNorth, List[StepModel[GmosModel.NorthDynamic]]](_.acquisition)(a => _.copy(acquisition = a))
+    val manual: Lens[GmosNorth, ManualSequenceGmosNorth] =
+      Lens[GmosNorth, ManualSequenceGmosNorth](_.manual)(a => _.copy(manual = a))
 
   }
 
+  type ManualSequenceGmosSouth = ManualSequence[GmosModel.SouthStatic, GmosModel.SouthDynamic]
+
   final case class GmosSouth(
-    static:      GmosModel.SouthStatic,
-    acquisition: List[GmosModel.SouthDynamic],
-    science:     List[GmosModel.SouthDynamic]
+    manual: ManualSequenceGmosSouth
   ) extends ConfigModel(Instrument.GmosS)
+
+  object GmosSouth extends GmosSouthOptics {
+
+    implicit val EqGmosSouth: Eq[GmosSouth] =
+      Eq.by(_.manual)
+
+  }
+
+  sealed trait GmosSouthOptics { this: GmosSouth.type =>
+
+    val manual: Lens[GmosSouth, ManualSequenceGmosSouth] =
+      Lens[GmosSouth, ManualSequenceGmosSouth](_.manual)(a => _.copy(manual = a))
+
+  }
+
+
+  /**
+   * Input parameter used to create a configuration.  All optional but
+   * validation will check that exactly one is defined.
+   */
+  final case class Create(
+    gmosNorth: Option[CreateGmosNorth],
+    gmosSouth: Option[CreateGmosSouth]
+  ) {
+
+    def create: ValidatedInput[ConfigModel] =
+      ValidatedInput.requireOne("config",
+        gmosNorth.map(_.create),
+        gmosSouth.map(_.create)
+      )
+
+  }
+
+  object Create {
+
+    val Empty: Create = Create(
+      gmosNorth = None,
+      gmosSouth = None
+    )
+
+    def gmosNorth(gn: CreateGmosNorth): Create =
+      Empty.copy(gmosNorth = Some(gn))
+
+    def gmosSouth(gs: CreateGmosSouth): Create =
+      Empty.copy(gmosSouth = Some(gs))
+
+    implicit val DecoderCreate: Decoder[Create] =
+      deriveDecoder[Create]
+
+    implicit val EqCreate: Eq[Create] =
+      Eq.by { a => (
+        a.gmosNorth,
+        a.gmosSouth
+      )}
+
+    implicit val InputValidatorCreate: InputValidator[Create, ConfigModel] =
+      InputValidator.by(_.create)
+
+  }
+
+  final case class CreateGmosNorth(
+    manual: ManualSequence.Create[GmosModel.CreateNorthStatic, GmosModel.CreateNorthDynamic]
+  ) {
+
+    def create: ValidatedInput[GmosNorth] =
+      manual.create.map(GmosNorth(_))
+  }
+
+  object CreateGmosNorth {
+
+    implicit val DecoderCreateGmosNorth: Decoder[CreateGmosNorth] =
+      deriveDecoder[CreateGmosNorth]
+
+    implicit val EqCreateGmosNorth: Eq[CreateGmosNorth] =
+      Eq.by(_.manual)
+
+    implicit val ValidatorCreateGmosNorth: InputValidator[CreateGmosNorth, GmosNorth] =
+      InputValidator.by[CreateGmosNorth, GmosNorth](_.create)
+
+  }
+
+
+  final case class CreateGmosSouth(
+    manual: ManualSequence.Create[GmosModel.CreateSouthStatic, GmosModel.CreateSouthDynamic]
+  ) {
+
+    def create: ValidatedInput[GmosSouth] =
+      manual.create.map(GmosSouth(_))
+  }
+
+  object CreateGmosSouth {
+
+    implicit val DecoderCreateGmosSouth: Decoder[CreateGmosSouth] =
+      deriveDecoder[CreateGmosSouth]
+
+    implicit val EqCreateGmosSouth: Eq[CreateGmosSouth] =
+      Eq.by(_.manual)
+
+    implicit val ValidatorCreateGmosSouth: InputValidator[CreateGmosSouth, GmosSouth] =
+      InputValidator.by[CreateGmosSouth, GmosSouth](_.create)
+
+  }
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ConfigModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ConfigModel.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import cats.Eq
+import lucuma.core.`enum`.Instrument
+import monocle.Lens
+
+sealed abstract class ConfigModel[I](val instrument: I) extends Product with Serializable
+
+
+object ConfigModel {
+
+  final case class GmosNorth(
+    static:      GmosModel.NorthStatic,
+    acquisition: List[StepModel[GmosModel.NorthDynamic]],
+    science:     List[StepModel[GmosModel.NorthDynamic]]
+  ) extends ConfigModel(Instrument.GmosN)
+
+  object GmosNorth {
+
+    implicit val EqGmosNorth: Eq[GmosNorth] =
+      Eq.by { a => (
+        a.static,
+        a.acquisition,
+        a.science
+      )}
+
+  }
+
+  sealed trait GmosNorthOptics { this: GmosNorth.type =>
+
+    val static: Lens[GmosNorth, GmosModel.NorthStatic] =
+      Lens[GmosNorth, GmosModel.NorthStatic](_.static)(a => _.copy(static = a))
+
+    val acquisition: Lens[GmosNorth, List[StepModel[GmosModel.NorthDynamic]]] =
+      Lens[GmosNorth, List[StepModel[GmosModel.NorthDynamic]]](_.acquisition)(a => _.copy(acquisition = a))
+
+  }
+
+  final case class GmosSouth(
+    static:      GmosModel.SouthStatic,
+    acquisition: List[GmosModel.SouthDynamic],
+    science:     List[GmosModel.SouthDynamic]
+  ) extends ConfigModel(Instrument.GmosS)
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/FiniteDurationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/FiniteDurationModel.scala
@@ -1,0 +1,158 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.core.util.{Display, Enumerated}
+
+import cats.Eq
+import cats.syntax.option._
+import io.circe.Decoder
+import io.circe.generic.semiauto._
+import monocle.Prism
+
+import scala.concurrent.duration._
+import scala.math.BigDecimal.RoundingMode
+import scala.util.Try
+
+object FiniteDurationModel {
+
+  sealed abstract class Units(
+    val timeUnit: TimeUnit
+  ) extends Product with Serializable {
+
+    val long: Prism[Long, FiniteDuration] =
+      Prism[Long, FiniteDuration](l => Try(FiniteDuration(l, timeUnit)).toOption)(_.length)
+
+    def readLong(l: Long): ValidatedInput[FiniteDuration] =
+      long.getOption(l).toValidNec(
+        InputError.fromMessage(
+          s"Could not read $l ${timeUnit.toString} as a time amount"
+        )
+      )
+
+    val decimal: Prism[BigDecimal, FiniteDuration] =
+      Prism[BigDecimal, FiniteDuration](bd => Try(FiniteDuration(bd.setScale(0, RoundingMode.HALF_UP).longValue, timeUnit)).toOption)(fd => BigDecimal(fd.length))
+
+    def readDecimal(b: BigDecimal): ValidatedInput[FiniteDuration] =
+      decimal.getOption(b).toValidNec(
+        InputError.fromMessage(
+          s"Could not read $b ${timeUnit.toString} as a time amount"
+        )
+      )
+  }
+
+  object Units {
+    case object Nanoseconds  extends Units(NANOSECONDS)
+    case object Microseconds extends Units(MICROSECONDS)
+    case object Milliseconds extends Units(MILLISECONDS)
+    case object Seconds      extends Units(SECONDS)
+    case object Minutes      extends Units(MINUTES)
+    case object Hours        extends Units(HOURS)
+    case object Days         extends Units(DAYS)
+
+    val nanoseconds: Units  = Nanoseconds
+    val microseconds: Units = Microseconds
+    val milliseconds: Units = Milliseconds
+    val seconds: Units      = Seconds
+    val minutes: Units      = Minutes
+    val hours: Units        = Hours
+    val days: Units         = Days
+
+    implicit val EnumeratedUnits: Enumerated[Units] =
+      Enumerated.of(
+        Nanoseconds,
+        Microseconds,
+        Milliseconds,
+        Seconds,
+        Minutes,
+        Hours,
+        Days
+      )
+
+    implicit val DisplayUnits: Display[Units] =
+      Display.byShortName(_.timeUnit.name)
+  }
+
+  implicit val NumericUnitsFiniteDuration: NumericUnits[FiniteDuration, Units] =
+    NumericUnits.fromRead(_.readLong(_), _.readDecimal(_))
+
+  final case class Input(
+    nanoseconds:  Option[Long],
+    microseconds: Option[BigDecimal],
+    milliseconds: Option[BigDecimal],
+    seconds:      Option[BigDecimal],
+    minutes:      Option[BigDecimal],
+    hours:        Option[BigDecimal],
+    days:         Option[BigDecimal],
+    fromLong:     Option[NumericUnits.LongInput[Units]],
+    fromDecimal:  Option[NumericUnits.DecimalInput[Units]]
+  ) {
+
+    import Units._
+
+    def toFiniteDuration(n: String): ValidatedInput[FiniteDuration] =
+      ValidatedInput.requireOne(n,
+        nanoseconds .map(Nanoseconds.readLong),
+        microseconds.map(Microseconds.readDecimal),
+        milliseconds.map(Milliseconds.readDecimal),
+        seconds     .map(Seconds.readDecimal),
+        minutes     .map(Minutes.readDecimal),
+        hours       .map(Hours.readDecimal),
+        days        .map(Days.readDecimal),
+        fromLong    .map(_.read),
+        fromDecimal .map(_.read)
+      )
+
+  }
+
+  object Input {
+
+    val Empty: Input =
+      Input(None, None, None, None, None, None, None, None, None)
+
+    def fromNanoseconds(value: Long): Input =
+      Empty.copy(nanoseconds = Some(value))
+
+    def fromMicroseconds(value: BigDecimal): Input =
+      Empty.copy(microseconds = Some(value))
+
+    def fromMilliseconds(value: BigDecimal): Input =
+      Empty.copy(milliseconds = Some(value))
+
+    def fromSeconds(value: BigDecimal): Input =
+      Empty.copy(seconds = Some(value))
+
+    def fromMinutes(value: BigDecimal): Input =
+      Empty.copy(minutes = Some(value))
+
+    def fromHours(value: BigDecimal): Input =
+      Empty.copy(hours = Some(value))
+
+    def fromDays(value: BigDecimal): Input =
+      Empty.copy(days = Some(value))
+
+    def fromLong(value: NumericUnits.LongInput[Units]): Input =
+      Empty.copy(fromLong = Some(value))
+
+    def fromDecimal(value: NumericUnits.DecimalInput[Units]): Input =
+      Empty.copy(fromDecimal = Some(value))
+
+    implicit val DecoderInput: Decoder[Input] =
+      deriveDecoder[Input]
+
+    implicit val EqInput: Eq[Input] =
+      Eq.by(in => (
+        in.nanoseconds,
+        in.microseconds,
+        in.milliseconds,
+        in.seconds,
+        in.minutes,
+        in.hours,
+        in.days,
+        in.fromLong,
+        in.fromDecimal
+      ))
+  }
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
@@ -6,9 +6,7 @@ package lucuma.odb.api.model
 import lucuma.core.`enum`._
 import lucuma.core.math.{Offset, Wavelength}
 import lucuma.core.optics.syntax.lens._
-import lucuma.odb.api.model.StepModel.CreateStep
 import lucuma.odb.api.model.syntax.input._
-//import lucuma.odb.api.model.syntax.inputvalidator._
 
 import cats.Eq
 import cats.data.{State, Validated}
@@ -306,6 +304,9 @@ object GmosModel {
         a.stageMode
       )}
 
+    implicit val InputValidatorCreateNorthStatic: InputValidator[CreateNorthStatic, NorthStatic] =
+      InputValidator.by(_.create)
+
   }
 
   final case class SouthStatic(
@@ -353,6 +354,9 @@ object GmosModel {
         a.common,
         a.stageMode
       )}
+
+    implicit val InputValidatorCreateSouthStatic: InputValidator[CreateSouthStatic, SouthStatic] =
+      InputValidator.by(_.create)
 
   }
 
@@ -686,7 +690,7 @@ object GmosModel {
       )}
 
     implicit def ValidatorNorthDynamic: InputValidator[CreateNorthDynamic, NorthDynamic] =
-      InputValidator.from(_.create)
+      InputValidator.by(_.create)
 
   }
 
@@ -759,136 +763,8 @@ object GmosModel {
       deriveDecoder[CreateSouthDynamic]
 
     implicit def ValidatorSouthDynamic: InputValidator[CreateSouthDynamic, SouthDynamic] =
-      InputValidator.from(_.create)
+      InputValidator.by(_.create)
 
   }
-
-
-  final case class North(
-    static:      NorthStatic,
-    acquisition: List[StepModel[NorthDynamic]],
-    science:     List[StepModel[NorthDynamic]]
-  )
-
-  object North extends NorthOptics {
-
-    implicit def EqNorth: Eq[North] =
-      Eq.by { a => (
-        a.static,
-        a.acquisition,
-        a.science
-      )}
-
-  }
-
-  sealed trait NorthOptics { this: North.type =>
-
-    val static: Lens[North, NorthStatic] =
-      Lens[North, NorthStatic](_.static)(a => _.copy(static = a))
-
-    val acquisition: Lens[North, List[StepModel[NorthDynamic]]] =
-      Lens[North, List[StepModel[NorthDynamic]]](_.acquisition)(a => _.copy(acquisition = a))
-
-    val science: Lens[North, List[StepModel[NorthDynamic]]] =
-      Lens[North, List[StepModel[NorthDynamic]]](_.science)(a => _.copy(science = a))
-
-  }
-
-  final case class CreateNorth(
-    static:      CreateNorthStatic,
-    acquisition: List[CreateStep[CreateNorthDynamic]],
-    science:     List[CreateStep[CreateNorthDynamic]]
-  ) {
-
-    def create: ValidatedInput[North] =
-      (
-        static.create,
-        acquisition.traverse(_.create[NorthDynamic]),
-        science.traverse(_.create[NorthDynamic])
-      ).mapN { (ns, a, s) => North(ns, a, s) }
-
-  }
-
-  object CreateNorth {
-
-    implicit val EqCreateNorth: Eq[CreateNorth] =
-      Eq.by { a => (
-        a.static,
-        a.acquisition,
-        a.science
-      )}
-
-    implicit val DecoderCreateNorth: Decoder[CreateNorth] =
-      deriveDecoder[CreateNorth]
-
-    implicit def ValidatorCreateNorth: InputValidator[CreateNorth, North] =
-      InputValidator.from(_.create)
-
-  }
-
-
-  final case class South(
-    static:      SouthStatic,
-    acquisition: List[StepModel[SouthDynamic]],
-    science:     List[StepModel[SouthDynamic]]
-  )
-
-  object South extends SouthOptics {
-
-    implicit def EqSouth: Eq[South] =
-      Eq.by { a => (
-        a.static,
-        a.acquisition,
-        a.science
-      )}
-
-  }
-
-  sealed trait SouthOptics { this: South.type =>
-
-    val static: Lens[South, SouthStatic] =
-      Lens[South, SouthStatic](_.static)(a => _.copy(static = a))
-
-    val acquisition: Lens[South, List[StepModel[SouthDynamic]]] =
-      Lens[South, List[StepModel[SouthDynamic]]](_.acquisition)(a => _.copy(acquisition = a))
-
-    val science: Lens[South, List[StepModel[SouthDynamic]]] =
-      Lens[South, List[StepModel[SouthDynamic]]](_.science)(a => _.copy(science = a))
-
-  }
-
-  final case class CreateSouth(
-    static:      CreateSouthStatic,
-    acquisition: List[CreateStep[CreateSouthDynamic]],
-    science:     List[CreateStep[CreateSouthDynamic]]
-  ) {
-
-    def create: ValidatedInput[South] =
-      (
-        static.create,
-        acquisition.traverse(_.create[SouthDynamic]),
-        science.traverse(_.create[SouthDynamic])
-      ).mapN { (ss, a, s) => South(ss, a, s) }
-
-  }
-
-  object CreateSouth {
-
-    implicit val EqCreateSouth: Eq[CreateSouth] =
-      Eq.by { a => (
-        a.static,
-        a.acquisition,
-        a.science
-      )}
-
-    implicit val DecoderCreateSouth: Decoder[CreateSouth] =
-      deriveDecoder[CreateSouth]
-
-    implicit def ValidatorCreateSouth: InputValidator[CreateSouth, South] =
-      InputValidator.from(_.create)
-
-  }
-
-
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
@@ -1,0 +1,894 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.core.`enum`._
+import lucuma.core.math.{Offset, Wavelength}
+import lucuma.core.optics.syntax.lens._
+import lucuma.odb.api.model.StepModel.CreateStep
+import lucuma.odb.api.model.syntax.input._
+//import lucuma.odb.api.model.syntax.inputvalidator._
+
+import cats.Eq
+import cats.data.{State, Validated}
+import cats.syntax.all._
+import clue.data.Input
+import eu.timepit.refined.types.all._
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
+import io.circe.generic.extras.Configuration
+import monocle.Lens
+
+import scala.concurrent.duration._
+
+
+object GmosModel {
+
+  implicit val customConfig: Configuration = Configuration.default.withDefaults
+
+  // --- Static Configuration ---
+
+  final case class NodAndShuffle(
+    posA:          Offset,
+    posB:          Offset,
+    eOffset:       GmosEOffsetting,
+    shuffleOffset: Int,
+    shuffleCycles: Int
+  )
+
+  object NodAndShuffle extends NodAndShuffleOptics {
+
+    val Default: NodAndShuffle =
+      NodAndShuffle(
+        Offset.Zero,
+        Offset.Zero,
+        GmosEOffsetting.Off,
+        1,
+        1
+      )
+
+    implicit val EqNodAndShuffle: Eq[NodAndShuffle] =
+      Eq.by { a => (
+        a.posA,
+        a.posB,
+        a.eOffset,
+        a.shuffleOffset,
+        a.shuffleCycles
+      )}
+
+  }
+
+  sealed trait NodAndShuffleOptics { this: NodAndShuffle.type =>
+
+    val posA: Lens[NodAndShuffle, Offset] =
+      Lens[NodAndShuffle, Offset](_.posA)(a => _.copy(posA = a))
+
+    val posB: Lens[NodAndShuffle, Offset] =
+      Lens[NodAndShuffle, Offset](_.posB)(a => _.copy(posB = a))
+
+    val eOffset: Lens[NodAndShuffle, GmosEOffsetting] =
+      Lens[NodAndShuffle, GmosEOffsetting](_.eOffset)(a => _.copy(eOffset = a))
+
+    val shuffleOffset: Lens[NodAndShuffle, Int] =
+      Lens[NodAndShuffle, Int](_.shuffleOffset)(a => _.copy(shuffleOffset = a))
+
+    val shuffleCycles: Lens[NodAndShuffle, Int] =
+      Lens[NodAndShuffle, Int](_.shuffleCycles)(a => _.copy(shuffleCycles = a))
+
+  }
+
+  final case class CreateNodAndShuffle(
+    posA:          OffsetModel.Input,
+    posB:          OffsetModel.Input,
+    eOffset:       GmosEOffsetting,
+    shuffleOffset: Int,
+    shuffleCycles: Int
+  ) {
+
+    val create: ValidatedInput[NodAndShuffle] =
+      (posA.create,
+       posB.create,
+       Validated.condNec(shuffleOffset > 0, shuffleOffset, InputError.fromMessage("Shuffle offset must be >= 1")),
+       Validated.condNec(shuffleCycles > 0, shuffleCycles, InputError.fromMessage("Shuffle cycles must be >= 1"))
+      ).mapN { (a, b, so, sc) => NodAndShuffle(a, b, eOffset, so, sc) }
+
+  }
+
+  object CreateNodAndShuffle {
+
+    implicit val DecoderCreateNodAndShuffle: Decoder[CreateNodAndShuffle] =
+      deriveDecoder[CreateNodAndShuffle]
+
+    implicit val EqCreateNodAndShuffle: Eq[CreateNodAndShuffle] =
+      Eq.by { a => (
+        a.posA,
+        a.posB,
+        a.eOffset,
+        a.shuffleOffset,
+        a.shuffleCycles
+      )}
+
+  }
+
+  final case class EditNodAndShuffle(
+    posA:          Input[OffsetModel.Input] = Input.ignore,
+    posB:          Input[OffsetModel.Input] = Input.ignore,
+    eOffset:       Input[GmosEOffsetting]   = Input.ignore,
+    shuffleOffset: Input[Int]               = Input.ignore,
+    shuffleCycles: Input[Int]               = Input.ignore
+  ) {
+
+    val editor: ValidatedInput[State[NodAndShuffle, Unit]] =
+      (posA         .validateNotNullable("posA")(_.create),
+       posB         .validateNotNullable("posB")(_.create),
+       eOffset      .validateIsNotNull("eOffset"),
+       shuffleOffset.validateNotNullable("shuffleOffset")(so => Validated.condNec(so > 0, so, InputError.fromMessage("Shuffle offset must be >= 1"))),
+       shuffleCycles.validateNotNullable("shuffleCycles")(sc => Validated.condNec(sc > 0, sc, InputError.fromMessage("Shuffle cycles must be >= 1")))
+      ).mapN {(a, b, e, o, c) =>
+        for {
+          _ <- NodAndShuffle.posA          := a
+          _ <- NodAndShuffle.posB          := b
+          _ <- NodAndShuffle.eOffset       := e
+          _ <- NodAndShuffle.shuffleOffset := o
+          _ <- NodAndShuffle.shuffleCycles := c
+        } yield ()
+      }
+
+  }
+
+  object EditNodAndShuffle {
+
+    implicit val DecoderEditNodAndShuffle: Decoder[EditNodAndShuffle] =
+      deriveConfiguredDecoder[EditNodAndShuffle]
+
+    implicit val EqEditNodAndShuffle: Eq[EditNodAndShuffle] =
+      Eq.by { a => (
+        a.posA,
+        a.posB,
+        a.eOffset,
+        a.shuffleOffset,
+        a.shuffleCycles
+      )}
+
+  }
+
+  final case class CommonStatic(
+    detector:      GmosDetector,
+    mosPreImaging: MosPreImaging,
+    nodAndShuffle: Option[NodAndShuffle]
+    // insert customRois here
+  )
+
+  object CommonStatic extends CommonStaticLenses {
+
+    implicit val EqCommonStatic: Eq[CommonStatic] =
+      Eq.by { a => (
+        a.detector,
+        a.mosPreImaging,
+        a.nodAndShuffle
+      )}
+
+  }
+
+  sealed trait CommonStaticLenses { this: CommonStatic.type =>
+
+    val detector: Lens[CommonStatic, GmosDetector] =
+      Lens[CommonStatic, GmosDetector](_.detector)(a => _.copy(detector = a))
+
+    val mosPreImaging: Lens[CommonStatic, MosPreImaging] =
+      Lens[CommonStatic, MosPreImaging](_.mosPreImaging)(a => _.copy(mosPreImaging = a))
+
+    val nodAndShuffle: Lens[CommonStatic, Option[NodAndShuffle]] =
+      Lens[CommonStatic, Option[NodAndShuffle]](_.nodAndShuffle)(a => _.copy(nodAndShuffle = a))
+
+  }
+
+  final case class CreateCommonStatic(
+    detector:      GmosDetector                = GmosDetector.HAMAMATSU,
+    mosPreImaging: MosPreImaging               = MosPreImaging.IsNotMosPreImaging,
+    nodAndShuffle: Option[CreateNodAndShuffle] = None
+  ) {
+
+    def create: ValidatedInput[CommonStatic] =
+      nodAndShuffle.traverse(_.create).map { ns =>
+        CommonStatic(detector, mosPreImaging, ns)
+      }
+
+  }
+
+  object CreateCommonStatic {
+
+    implicit val Default: CreateCommonStatic =
+      CreateCommonStatic()
+
+    implicit val DecoderCreateCommonStatic: Decoder[CreateCommonStatic] =
+      deriveDecoder[CreateCommonStatic]
+
+    implicit val EqCreateCommonStatic: Eq[CreateCommonStatic] =
+      Eq.by { a => (
+        a.detector,
+        a.mosPreImaging,
+        a.nodAndShuffle
+      )}
+
+  }
+
+  /*
+
+  Not clear how to do an editor for a hierarchy.  For example if the config has
+  no NodAndShuffle to edit then what do you do?
+
+  final case class EditCommonStatic(
+    detector:      Input[GmosDetector]                                   = Input.ignore,
+    mosPreImaging: Input[MosPreImaging]                                  = Input.ignore,
+    nodAndShuffle: Input[Either[CreateNodAndShuffle, EditNodAndShuffle]] = Input.ignore
+  ) {
+
+    val editor: ValidatedInput[State[CommonStatic, Unit]] =
+      (detector     .validateIsNotNull("detector"),
+       mosPreImaging.validateIsNotNull("mosPreImaging"),
+       nodAndShuffle.validateNullable {
+         _.fold(
+           _.create.map(_.asLeft[State[NodAndShuffle, Unit]]), // ValidatedInput[Either[NodAndShuffle, State[NodAndShuffle, Unit]]
+           _.editor.map(_.asRight[NodAndShuffle])              // ValidatedInput[Either[NodAndShuffle, State[NodAndShuffle, Unit]]
+         )
+       }
+      ).mapN { (d, p, e) =>
+        for {
+          _ <- CommonStatic.detector      := d
+          _ <- CommonStatic.mosPreImaging := p
+          _ <- CommonStatic.nodAndShuffle.mod_ { nso => ??? }
+        } yield ()
+      }
+
+  }
+
+  object EditCommonStatic {
+
+    implicit val DecoderEditCommonStatic: Decoder[EditCommonStatic] =
+      deriveDecoder[EditCommonStatic]
+
+    implicit val EqEditCommonStatic: Eq[EditCommonStatic] =
+      Eq.by { e => (
+        e.detector,
+        e.mosPreImaging,
+        e.nodAndShuffle
+      )}
+
+  }
+   */
+
+  final case class NorthStatic(
+    common:    CommonStatic,
+    stageMode: GmosNorthStageMode
+  )
+
+  object NorthStatic extends NorthStaticOptics {
+
+    implicit val EqGmosNorthStatic: Eq[NorthStatic] =
+      Eq.by { a => (
+        a.common,
+        a.stageMode
+      )}
+
+  }
+
+  sealed trait NorthStaticOptics { this: NorthStatic.type =>
+
+    val common: Lens[NorthStatic, CommonStatic] =
+      Lens[NorthStatic, CommonStatic](_.common)(a => _.copy(common = a))
+
+    val stageMode: Lens[NorthStatic, GmosNorthStageMode] =
+      Lens[NorthStatic, GmosNorthStageMode](_.stageMode)(a => _.copy(stageMode = a))
+
+  }
+
+  final case class CreateNorthStatic(
+    common:    CreateCommonStatic = CreateCommonStatic.Default,
+    stageMode: GmosNorthStageMode = GmosNorthStageMode.FollowXy
+  ) {
+
+    val create: ValidatedInput[NorthStatic] =
+      common.create.map(NorthStatic(_, stageMode))
+
+  }
+
+  object CreateNorthStatic {
+
+    implicit val DecoderCreateNorthStatic: Decoder[CreateNorthStatic] =
+      deriveDecoder[CreateNorthStatic]
+
+    implicit val EqCreateNorthStatic: Eq[CreateNorthStatic] =
+      Eq.by { a => (
+        a.common,
+        a.stageMode
+      )}
+
+  }
+
+  final case class SouthStatic(
+    common:    CommonStatic,
+    stageMode: GmosSouthStageMode
+  )
+
+  object SouthStatic extends SouthStaticOptics {
+
+    implicit val EqGmosSouthStatic: Eq[SouthStatic] =
+      Eq.by{ a => (
+        a.common,
+        a.stageMode
+      )}
+
+  }
+
+  sealed trait SouthStaticOptics { this: SouthStatic.type =>
+
+    val common: Lens[SouthStatic, CommonStatic] =
+      Lens[SouthStatic, CommonStatic](_.common)(a => _.copy(common = a))
+
+    val stageMode: Lens[SouthStatic, GmosSouthStageMode] =
+      Lens[SouthStatic, GmosSouthStageMode](_.stageMode)(a => _.copy(stageMode = a))
+
+  }
+
+  final case class CreateSouthStatic(
+    common:    CreateCommonStatic = CreateCommonStatic.Default,
+    stageMode: GmosSouthStageMode = GmosSouthStageMode.FollowXy
+  ) {
+
+    val create: ValidatedInput[SouthStatic] =
+      common.create.map(SouthStatic(_, stageMode))
+
+  }
+
+  object CreateSouthStatic {
+
+    implicit val DecoderCreateSouthStatic: Decoder[CreateSouthStatic] =
+      deriveDecoder[CreateSouthStatic]
+
+    implicit val EqCreateSouthStatic: Eq[CreateSouthStatic] =
+      Eq.by { a => (
+        a.common,
+        a.stageMode
+      )}
+
+  }
+
+  // --- Dynamic Configuration ---
+
+  final case class CcdReadout(
+    xBin:     GmosXBinning,
+    yBin:     GmosYBinning,
+    ampCount: GmosAmpCount,
+    ampGain:  GmosAmpGain,
+    ampRead:  GmosAmpReadMode
+  )
+
+  object CcdReadout extends CcdReadoutOptics {
+
+    val Default: CcdReadout =
+      CcdReadout(
+        GmosXBinning.One,
+        GmosYBinning.One,
+        GmosAmpCount.Twelve,
+        GmosAmpGain.Low,
+        GmosAmpReadMode.Slow
+      )
+
+    implicit val EqCcdReadout: Eq[CcdReadout] =
+      Eq.by { a => (
+        a.xBin,
+        a.yBin,
+        a.ampCount,
+        a.ampGain,
+        a.ampRead
+      )}
+
+  }
+
+  sealed trait CcdReadoutOptics { this: CcdReadout.type =>
+
+    val xBin: Lens[CcdReadout, GmosXBinning] =
+      Lens[CcdReadout, GmosXBinning](_.xBin)(a => _.copy(xBin = a))
+
+    val yBin: Lens[CcdReadout, GmosYBinning] =
+      Lens[CcdReadout, GmosYBinning](_.yBin)(a => _.copy(yBin = a))
+
+    val ampCount: Lens[CcdReadout, GmosAmpCount] =
+      Lens[CcdReadout, GmosAmpCount](_.ampCount)(a => _.copy(ampCount = a))
+
+    val ampGain: Lens[CcdReadout, GmosAmpGain] =
+      Lens[CcdReadout, GmosAmpGain](_.ampGain)(a => _.copy(ampGain = a))
+
+    val ampRead: Lens[CcdReadout, GmosAmpReadMode] =
+      Lens[CcdReadout, GmosAmpReadMode](_.ampRead)(a => _.copy(ampRead = a))
+
+  }
+
+  final case class CreateCcdReadout(
+    xBin:     GmosXBinning    = GmosXBinning.One,
+    yBin:     GmosYBinning    = GmosYBinning.One,
+    ampCount: GmosAmpCount    = GmosAmpCount.Twelve,
+    ampGain:  GmosAmpGain     = GmosAmpGain.Low,
+    ampRead:  GmosAmpReadMode = GmosAmpReadMode.Slow
+  ) {
+
+    val create: ValidatedInput[CcdReadout] =
+      CcdReadout(xBin, yBin, ampCount, ampGain, ampRead).validNec[InputError]
+
+  }
+
+  object CreateCcdReadout {
+
+    implicit val DecoderCreateCcdReadout: Decoder[CreateCcdReadout] =
+      deriveDecoder[CreateCcdReadout]
+
+    implicit val EqCreateCcdReadout: Eq[CreateCcdReadout] =
+      Eq.by { a => (
+        a.xBin,
+        a.yBin,
+        a.ampCount,
+        a.ampGain,
+        a.ampRead
+      )}
+
+  }
+
+
+  final case class CommonDynamic(
+    readout:  CcdReadout,
+    dtax:     GmosDtax,
+    exposure: FiniteDuration,
+    roi:      GmosRoi
+  )
+
+  object CommonDynamic extends CommonDynamicOptics {
+
+    val Default: CommonDynamic =
+      CommonDynamic(
+        CcdReadout.Default,
+        GmosDtax.Zero,
+        300.seconds,
+        GmosRoi.FullFrame
+      )
+
+    implicit val EqCommonDynamic: Eq[CommonDynamic] =
+      Eq.by { a => (
+        a.readout,
+        a.dtax,
+        a.exposure,
+        a.roi
+      )}
+
+  }
+
+  sealed trait CommonDynamicOptics { this: CommonDynamic.type =>
+
+    val readout: Lens[CommonDynamic, CcdReadout] =
+      Lens[CommonDynamic, CcdReadout](_.readout)(a => _.copy(readout = a))
+
+    val dtax: Lens[CommonDynamic, GmosDtax] =
+      Lens[CommonDynamic, GmosDtax](_.dtax)(a => _.copy(dtax = a))
+
+    val exposure: Lens[CommonDynamic, FiniteDuration] =
+      Lens[CommonDynamic, FiniteDuration](_.exposure)(a => _.copy(exposure = a))
+
+    val roi: Lens[CommonDynamic, GmosRoi] =
+      Lens[CommonDynamic, GmosRoi](_.roi)(a => _.copy(roi = a))
+
+  }
+
+  final case class CreateCommonDynamic(
+    readout:  CreateCcdReadout          = CreateCcdReadout(),
+    dtax:     GmosDtax                  = GmosDtax.Zero,
+    exposure: FiniteDurationModel.Input = FiniteDurationModel.Input.fromSeconds(BigDecimal(300)),
+    roi:      GmosRoi                   = GmosRoi.FullFrame
+  ) {
+
+    val create: ValidatedInput[CommonDynamic] = {
+      (
+        readout.create,
+        exposure.toFiniteDuration("exposure")
+      ).mapN { (r, e) => CommonDynamic(r, dtax, e, roi) }
+    }
+
+  }
+
+  object CreateCommonDynamic {
+
+    implicit val DecoderCreateCommonDynamic: Decoder[CreateCommonDynamic] =
+      deriveDecoder[CreateCommonDynamic]
+
+    implicit val EqCreateCommonDynamic: Eq[CreateCommonDynamic] =
+      Eq.by { a => (
+        a.readout,
+        a.dtax,
+        a.exposure,
+        a.roi
+      )}
+
+  }
+
+  final case class CustomMask(
+    filename:  NonEmptyString,
+    slitWidth: GmosCustomSlitWidth
+  )
+
+  object CustomMask extends CustomMaskOptics {
+
+    implicit val EqCustomMask: Eq[CustomMask] =
+      Eq.by { a => (
+        a.filename.value,
+        a.slitWidth
+      )}
+
+  }
+
+  sealed trait CustomMaskOptics { this: CustomMask.type =>
+
+    val filename: Lens[CustomMask, NonEmptyString] =
+      Lens[CustomMask, NonEmptyString](_.filename)(a => _.copy(filename = a))
+
+    val slitWidth: Lens[CustomMask, GmosCustomSlitWidth] =
+      Lens[CustomMask, GmosCustomSlitWidth](_.slitWidth)(a => _.copy(slitWidth = a))
+
+  }
+
+  final case class CreateCustomMask(
+    filename:  String,
+    slitWidth: GmosCustomSlitWidth
+  ) {
+
+    val create: ValidatedInput[CustomMask] =
+      ValidatedInput.nonEmptyString("filename", filename).map(CustomMask(_, slitWidth))
+
+  }
+
+  object CreateCustomMask {
+
+    implicit val DecoderCreateCustomMask: Decoder[CreateCustomMask] =
+      deriveDecoder[CreateCustomMask]
+
+    implicit val EqCreateCustomMask: Eq[CreateCustomMask] =
+      Eq.by { a => (
+        a.filename,
+        a.slitWidth
+      )}
+
+  }
+
+
+  final case class Grating[D](
+    disperser:  D,
+    order:      GmosDisperserOrder,
+    wavelength: Wavelength
+  )
+
+  object Grating extends GratingOptics {
+
+    implicit def EqGmosGrating[D: Eq]: Eq[Grating[D]] =
+      Eq.by { a => (
+        a.disperser,
+        a.order,
+        a.wavelength
+      )}
+
+  }
+
+  sealed trait GratingOptics { this: Grating.type =>
+
+    def disperser[D]: Lens[Grating[D], D] =
+      Lens[Grating[D], D](_.disperser)(a => _.copy(disperser = a))
+
+    def order[D]: Lens[Grating[D], GmosDisperserOrder] =
+      Lens[Grating[D], GmosDisperserOrder](_.order)(a => _.copy(order = a))
+
+    def wavelength[D]: Lens[Grating[D], Wavelength] =
+      Lens[Grating[D], Wavelength](_.wavelength)(a => _.copy(wavelength = a))
+
+  }
+
+
+  final case class CreateGrating[D](
+    disperser:  D,
+    order:      GmosDisperserOrder,
+    wavelength: WavelengthModel.Input
+  ) {
+
+    val create: ValidatedInput[Grating[D]] =
+      wavelength.toWavelength("wavelength").map(Grating(disperser, order, _))
+
+  }
+
+  object CreateGrating {
+
+    implicit def DecoderCreateGrating[D: Decoder]: Decoder[CreateGrating[D]] =
+      deriveDecoder[CreateGrating[D]]
+
+    implicit def EqCreateGrating[D: Eq]: Eq[CreateGrating[D]] =
+      Eq.by { a => (
+        a.disperser,
+        a.order,
+        a.wavelength
+      )}
+
+  }
+
+
+  final case class NorthDynamic(
+    common:  CommonDynamic,
+    grating: Option[Grating[GmosNorthDisperser]],
+    filter:  Option[GmosNorthFilter],
+    fpu:     Option[Either[CustomMask, GmosNorthFpu]]
+  )
+
+  object NorthDynamic extends NorthDynamicOptics {
+
+    implicit def EqNorthDynamic: Eq[NorthDynamic] =
+      Eq.by { a => (
+        a.common,
+        a.grating,
+        a.filter,
+        a.fpu
+      )}
+
+  }
+
+  sealed trait NorthDynamicOptics { this: NorthDynamic.type =>
+
+    val common: Lens[NorthDynamic, CommonDynamic] =
+      Lens[NorthDynamic, CommonDynamic](_.common)(a => _.copy(common = a))
+
+    val grating: Lens[NorthDynamic, Option[Grating[GmosNorthDisperser]]] =
+      Lens[NorthDynamic, Option[Grating[GmosNorthDisperser]]](_.grating)(a => _.copy(grating = a))
+
+    val filter: Lens[NorthDynamic, Option[GmosNorthFilter]] =
+      Lens[NorthDynamic, Option[GmosNorthFilter]](_.filter)(a => _.copy(filter = a))
+
+    val fpu: Lens[NorthDynamic, Option[Either[CustomMask, GmosNorthFpu]]] =
+      Lens[NorthDynamic, Option[Either[CustomMask, GmosNorthFpu]]](_.fpu)(a => _.copy(fpu = a))
+
+  }
+
+
+  implicit val DecoderNorthFpu: Decoder[Either[CreateCustomMask, GmosNorthFpu]] =
+    Decoder[CreateCustomMask].either(Decoder[GmosNorthFpu])
+
+  final case class CreateNorthDynamic(
+    common:  CreateCommonDynamic,
+    grating: Option[CreateGrating[GmosNorthDisperser]],
+    filter:  Option[GmosNorthFilter],
+    fpu:     Option[Either[CreateCustomMask, GmosNorthFpu]]
+  ) {
+
+    val create: ValidatedInput[NorthDynamic] =
+      (
+        common.create,
+        grating.traverse(_.create),
+        fpu.traverse(_.fold(_.create.map(_.asLeft[GmosNorthFpu]), _.asRight[CustomMask].validNec[InputError]))
+      ).mapN { (c, g, u) => NorthDynamic(c, g, filter, u) }
+
+  }
+
+  object CreateNorthDynamic {
+
+    implicit def DecoderCreateNorthDynamic: Decoder[CreateNorthDynamic] =
+      deriveDecoder[CreateNorthDynamic]
+
+    implicit def EqCreateNorthDynamic: Eq[CreateNorthDynamic] =
+      Eq.by { a => (
+        a.common,
+        a.grating,
+        a.filter,
+        a.fpu
+      )}
+
+    implicit def ValidatorNorthDynamic: InputValidator[CreateNorthDynamic, NorthDynamic] =
+      InputValidator.from(_.create)
+
+  }
+
+  final case class SouthDynamic(
+    common:  CommonDynamic,
+    grating: Option[Grating[GmosSouthDisperser]],
+    filter:  Option[GmosSouthFilter],
+    fpu:     Option[Either[CustomMask, GmosSouthFpu]]
+  )
+
+  object SouthDynamic extends SouthDynamicOptics {
+
+    implicit def EqSouthDynamic: Eq[SouthDynamic] =
+      Eq.by { a => (
+        a.common,
+        a.grating,
+        a.filter,
+        a.fpu
+      )}
+
+  }
+
+  sealed trait SouthDynamicOptics { this: SouthDynamic.type =>
+
+    val common: Lens[SouthDynamic, CommonDynamic] =
+      Lens[SouthDynamic, CommonDynamic](_.common)(a => _.copy(common = a))
+
+    val grating: Lens[SouthDynamic, Option[Grating[GmosSouthDisperser]]] =
+      Lens[SouthDynamic, Option[Grating[GmosSouthDisperser]]](_.grating)(a => _.copy(grating = a))
+
+    val filter: Lens[SouthDynamic, Option[GmosSouthFilter]] =
+      Lens[SouthDynamic, Option[GmosSouthFilter]](_.filter)(a => _.copy(filter = a))
+
+    val fpu: Lens[SouthDynamic, Option[Either[CustomMask, GmosSouthFpu]]] =
+      Lens[SouthDynamic, Option[Either[CustomMask, GmosSouthFpu]]](_.fpu)(a => _.copy(fpu = a))
+
+  }
+
+
+  implicit val DecoderSouthFpu: Decoder[Either[CreateCustomMask, GmosSouthFpu]] =
+    Decoder[CreateCustomMask].either(Decoder[GmosSouthFpu])
+
+  final case class CreateSouthDynamic(
+    common:  CreateCommonDynamic,
+    grating: Option[CreateGrating[GmosSouthDisperser]],
+    filter:  Option[GmosSouthFilter],
+    fpu:     Option[Either[CreateCustomMask, GmosSouthFpu]]
+  ) {
+
+    val create: ValidatedInput[SouthDynamic] =
+      (
+        common.create,
+        grating.traverse(_.create),
+        fpu.traverse(_.fold(_.create.map(_.asLeft[GmosSouthFpu]), _.asRight[CustomMask].validNec[InputError]))
+      ).mapN { (c, g, u) => SouthDynamic(c, g, filter, u) }
+
+  }
+
+  object CreateSouthDynamic {
+
+    implicit def EqCreateSouthDynamic: Eq[CreateSouthDynamic] =
+      Eq.by { a => (
+        a.common,
+        a.grating,
+        a.filter,
+        a.fpu
+      )}
+
+    implicit def DecoderCreateSouthDynamic: Decoder[CreateSouthDynamic] =
+      deriveDecoder[CreateSouthDynamic]
+
+    implicit def ValidatorSouthDynamic: InputValidator[CreateSouthDynamic, SouthDynamic] =
+      InputValidator.from(_.create)
+
+  }
+
+
+  final case class North(
+    static:      NorthStatic,
+    acquisition: List[StepModel[NorthDynamic]],
+    science:     List[StepModel[NorthDynamic]]
+  )
+
+  object North extends NorthOptics {
+
+    implicit def EqNorth: Eq[North] =
+      Eq.by { a => (
+        a.static,
+        a.acquisition,
+        a.science
+      )}
+
+  }
+
+  sealed trait NorthOptics { this: North.type =>
+
+    val static: Lens[North, NorthStatic] =
+      Lens[North, NorthStatic](_.static)(a => _.copy(static = a))
+
+    val acquisition: Lens[North, List[StepModel[NorthDynamic]]] =
+      Lens[North, List[StepModel[NorthDynamic]]](_.acquisition)(a => _.copy(acquisition = a))
+
+    val science: Lens[North, List[StepModel[NorthDynamic]]] =
+      Lens[North, List[StepModel[NorthDynamic]]](_.science)(a => _.copy(science = a))
+
+  }
+
+  final case class CreateNorth(
+    static:      CreateNorthStatic,
+    acquisition: List[CreateStep[CreateNorthDynamic]],
+    science:     List[CreateStep[CreateNorthDynamic]]
+  ) {
+
+    def create: ValidatedInput[North] =
+      (
+        static.create,
+        acquisition.traverse(_.create[NorthDynamic]),
+        science.traverse(_.create[NorthDynamic])
+      ).mapN { (ns, a, s) => North(ns, a, s) }
+
+  }
+
+  object CreateNorth {
+
+    implicit val EqCreateNorth: Eq[CreateNorth] =
+      Eq.by { a => (
+        a.static,
+        a.acquisition,
+        a.science
+      )}
+
+    implicit val DecoderCreateNorth: Decoder[CreateNorth] =
+      deriveDecoder[CreateNorth]
+
+    implicit def ValidatorCreateNorth: InputValidator[CreateNorth, North] =
+      InputValidator.from(_.create)
+
+  }
+
+
+  final case class South(
+    static:      SouthStatic,
+    acquisition: List[StepModel[SouthDynamic]],
+    science:     List[StepModel[SouthDynamic]]
+  )
+
+  object South extends SouthOptics {
+
+    implicit def EqSouth: Eq[South] =
+      Eq.by { a => (
+        a.static,
+        a.acquisition,
+        a.science
+      )}
+
+  }
+
+  sealed trait SouthOptics { this: South.type =>
+
+    val static: Lens[South, SouthStatic] =
+      Lens[South, SouthStatic](_.static)(a => _.copy(static = a))
+
+    val acquisition: Lens[South, List[StepModel[SouthDynamic]]] =
+      Lens[South, List[StepModel[SouthDynamic]]](_.acquisition)(a => _.copy(acquisition = a))
+
+    val science: Lens[South, List[StepModel[SouthDynamic]]] =
+      Lens[South, List[StepModel[SouthDynamic]]](_.science)(a => _.copy(science = a))
+
+  }
+
+  final case class CreateSouth(
+    static:      CreateSouthStatic,
+    acquisition: List[CreateStep[CreateSouthDynamic]],
+    science:     List[CreateStep[CreateSouthDynamic]]
+  ) {
+
+    def create: ValidatedInput[South] =
+      (
+        static.create,
+        acquisition.traverse(_.create[SouthDynamic]),
+        science.traverse(_.create[SouthDynamic])
+      ).mapN { (ss, a, s) => South(ss, a, s) }
+
+  }
+
+  object CreateSouth {
+
+    implicit val EqCreateSouth: Eq[CreateSouth] =
+      Eq.by { a => (
+        a.static,
+        a.acquisition,
+        a.science
+      )}
+
+    implicit val DecoderCreateSouth: Decoder[CreateSouth] =
+      deriveDecoder[CreateSouth]
+
+    implicit def ValidatorCreateSouth: InputValidator[CreateSouth, South] =
+      InputValidator.from(_.create)
+
+  }
+
+
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/InputValidator.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/InputValidator.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import cats.syntax.validated._
+
+trait InputValidator[A, B] { self =>
+
+  def validateAndCreate(a: A): ValidatedInput[B]
+
+}
+
+object InputValidator {
+
+  def apply[A, B](implicit ev: InputValidator[A, B]): InputValidator[A, B] =
+    ev
+
+  def success[A, B](f: A => B): InputValidator[A, B] =
+    (a: A) => f(a).validNec[InputError]
+
+  def from[A, B](f: A => ValidatedInput[B]): InputValidator[A, B] =
+    (a: A) => f(a)
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/InputValidator.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/InputValidator.scala
@@ -5,6 +5,16 @@ package lucuma.odb.api.model
 
 import cats.syntax.validated._
 
+// This is probably sketchy.  It's basically a function from input type to
+// a ValidatedNec of the the corresponding model type. I needed a way to
+// do this generically in ManualSequence.  Perhaps there are better ideas?
+
+/**
+ * Validates an input type and creates the corresponding model type.
+ *
+ * @tparam A input type
+ * @tparam B model type to (hopefully) create from the inputs
+ */
 trait InputValidator[A, B] { self =>
 
   def validateAndCreate(a: A): ValidatedInput[B]
@@ -16,10 +26,17 @@ object InputValidator {
   def apply[A, B](implicit ev: InputValidator[A, B]): InputValidator[A, B] =
     ev
 
+  /**
+   * Creates an InputValidator from a function.
+   */
+  def by[A, B](f: A => ValidatedInput[B]): InputValidator[A, B] =
+    (a: A) => f(a)
+
+  /**
+   * Creates an InputValidator that will always successfully create the
+   * corresponding model type.
+   */
   def success[A, B](f: A => B): InputValidator[A, B] =
     (a: A) => f(a).validNec[InputError]
-
-  def from[A, B](f: A => ValidatedInput[B]): InputValidator[A, B] =
-    (a: A) => f(a)
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ManualSequence.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ManualSequence.scala
@@ -1,0 +1,89 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.odb.api.model.syntax.inputvalidator._
+
+import cats.Eq
+import cats.syntax.all._
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import monocle.Lens
+
+/**
+ * Manual or explicit sequence representation.
+ * @param static static configuration
+ * @param acquisition acquisition steps
+ * @param science science steps
+ * @tparam S static configuration type
+ * @tparam D dynamic (step) configuration type
+ */
+final case class ManualSequence[S, D](
+  static:      S,
+  acquisition: List[StepModel[D]],
+  science:     List[StepModel[D]]
+)
+
+object ManualSequence extends ManualSequenceOptics {
+
+  implicit def EqManualSequence[S: Eq, D: Eq]: Eq[ManualSequence[S, D]] =
+    Eq.by { a => (
+      a.static,
+      a.acquisition,
+      a.science
+    )}
+
+  /**
+   * Input for manual sequence creation.
+   */
+  final case class Create[CS, CD](
+    static:      CS,
+    acquisition: List[StepModel.CreateStep[CD]],
+    science:     List[StepModel.CreateStep[CD]]
+  ) {
+
+    def create[S, D](
+      implicit ev1: InputValidator[CS, S], ev2: InputValidator[CD, D]
+    ): ValidatedInput[ManualSequence[S, D]] =
+      (
+        static.validateAndCreate[S],
+        acquisition.traverse(_.create),
+        science.traverse(_.create)
+      ).mapN { (st, aq, sc) => ManualSequence(st, aq, sc) }
+
+  }
+
+  object Create {
+
+    implicit def EdCreate[S: Eq, D: Eq]: Eq[Create[S, D]] =
+      Eq.by { a => (
+        a.static,
+        a.acquisition,
+        a.science
+      )}
+
+    implicit def DecoderCreate[S: Decoder, D: Decoder]:Decoder[Create[S, D]] =
+      deriveDecoder[Create[S, D]]
+
+    implicit def ValidatorCreate[CS, S, CD, D](
+      implicit ev1: InputValidator[CS, S], ev2: InputValidator[CD, D]
+    ): InputValidator[Create[CS, CD], ManualSequence[S, D]] =
+      InputValidator.by[Create[CS, CD], ManualSequence[S, D]](_.create)
+
+  }
+
+}
+
+sealed trait ManualSequenceOptics { this: ManualSequence.type =>
+
+  def static[S, D]: Lens[ManualSequence[S, D], S] =
+    Lens[ManualSequence[S, D], S](_.static)(a => _.copy(static = a))
+
+  def acquisition[S, D]: Lens[ManualSequence[S, D], List[StepModel[D]]] =
+    Lens[ManualSequence[S, D], List[StepModel[D]]](_.acquisition)(a => _.copy(acquisition = a))
+
+  def science[S, D]: Lens[ManualSequence[S, D], List[StepModel[D]]] =
+    Lens[ManualSequence[S, D], List[StepModel[D]]](_.science)(a => _.copy(science = a))
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/OffsetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/OffsetModel.scala
@@ -1,0 +1,161 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import cats.Eq
+import lucuma.core.math.{Angle, Axis, Offset}
+import lucuma.core.optics.SplitMono
+import cats.syntax.apply._
+import cats.syntax.validated._
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import lucuma.core.util.{Display, Enumerated}
+
+
+object OffsetModel {
+
+  sealed abstract class Units(
+    val angleUnit: AngleModel.Units
+  ) extends Product with Serializable {
+
+    private def angleToComponent[A, B](m: SplitMono[Angle, B]): SplitMono[Offset.Component[A], B] =
+      m.imapA(Offset.Component.apply[A], _.toAngle)
+
+    def long[A]: SplitMono[Offset.Component[A], Long] =
+      angleToComponent[A, Long](angleUnit.signedLong)
+
+    def readLong[A](l: Long): ValidatedInput[Offset.Component[A]] =
+      long[A].reverseGet(l).validNec[InputError]
+
+    def decimal[A]: SplitMono[Offset.Component[A], BigDecimal] =
+      angleToComponent[A, BigDecimal](angleUnit.signedDecimal)
+
+    def readDecimal[A](b: BigDecimal): ValidatedInput[Offset.Component[A]] =
+      decimal[A].reverseGet(b).validNec[InputError]
+  }
+
+  object Units {
+
+    case object Microarcseconds extends Units(AngleModel.Units.Microarcseconds)
+    case object Milliarcseconds extends Units(AngleModel.Units.Milliarcseconds)
+    case object Arcseconds      extends Units(AngleModel.Units.Arcseconds)
+
+    val microarcseconds: Units = Microarcseconds
+    val milliarcseconds: Units = Milliarcseconds
+    val arcseconds: Units      = Arcseconds
+
+    implicit def EnumeratedUnits: Enumerated[Units] =
+      Enumerated.of(
+        Microarcseconds,
+        Milliarcseconds,
+        Arcseconds
+      )
+
+    implicit def DisplayUnits: Display[Units] =
+      Display.byShortName(_.angleUnit.abbreviation)
+
+  }
+
+  implicit def NumericUnitsOffsetComponent[A]: NumericUnits[Offset.Component[A], Units] =
+    NumericUnits.fromRead(_.readLong(_), _.readDecimal(_))
+
+  final case class ComponentInput(
+    microarcseconds: Option[Long],
+    milliarcseconds: Option[BigDecimal],
+    arcseconds:      Option[BigDecimal],
+    fromLong:        Option[NumericUnits.LongInput[Units]],
+    fromDecimal:     Option[NumericUnits.DecimalInput[Units]]
+  ) {
+
+    def toComponent[A]: ValidatedInput[Offset.Component[A]] =
+      ValidatedInput.requireOne("offset component",
+        microarcseconds.map(Units.Milliarcseconds.readLong[A]),
+        milliarcseconds.map(Units.Milliarcseconds.readDecimal[A]),
+        arcseconds     .map(Units.Arcseconds.readDecimal[A]),
+        fromLong       .map(_.read),
+        fromDecimal    .map(_.read)
+      )
+
+  }
+
+  object ComponentInput {
+
+    def Empty: ComponentInput =
+      ComponentInput(None, None, None, None, None)
+
+    def fromMicroarcseconds[A](value: Long): ComponentInput =
+      Empty.copy(microarcseconds = Some(value))
+
+    def fromMilliarcseconds[A](value: BigDecimal): ComponentInput =
+      Empty.copy(milliarcseconds = Some(value))
+
+    def fromArcseconds[A](value: BigDecimal): ComponentInput =
+      Empty.copy(arcseconds = Some(value))
+
+    def fromLong(value: NumericUnits.LongInput[Units]): ComponentInput =
+      Empty.copy(fromLong = Some(value))
+
+    def fromDecimal(value: NumericUnits.DecimalInput[Units]): ComponentInput =
+      Empty.copy(fromDecimal = Some(value))
+
+    implicit def DecoderComponentInput: Decoder[ComponentInput] =
+      deriveDecoder[ComponentInput]
+
+    implicit def EqComponentInput: Eq[ComponentInput] =
+      Eq.by(in => (
+        in.microarcseconds,
+        in.milliarcseconds,
+        in.arcseconds,
+        in.fromLong,
+        in.fromDecimal
+      ))
+  }
+
+  final case class Input(
+    p: ComponentInput,
+    q: ComponentInput
+  ) {
+
+    val create: ValidatedInput[Offset] =
+      (p.toComponent[Axis.P], q.toComponent[Axis.Q]).mapN { case (p, q) =>
+        Offset(p, q)
+      }
+
+  }
+
+  object Input {
+
+    def fromMicroarcseconds(p: Long, q: Long): Input =
+      Input(
+        ComponentInput.fromMicroarcseconds(p),
+        ComponentInput.fromMicroarcseconds(q)
+      )
+
+    def fromMilliarcseconds(p: BigDecimal, q: BigDecimal): Input =
+      Input(
+        ComponentInput.fromMilliarcseconds(p),
+        ComponentInput.fromMilliarcseconds(q)
+      )
+
+    def fromArcseconds(p: BigDecimal, q: BigDecimal): Input =
+      Input(
+        ComponentInput.fromArcseconds(p),
+        ComponentInput.fromArcseconds(q)
+      )
+
+    implicit val DecoderInput: Decoder[Input]=
+      deriveDecoder[Input]
+
+    implicit val EqInput: Eq[Input] =
+      Eq.by(in => (
+        in.p,
+        in.q
+      ))
+
+    implicit val ValidatorInput: InputValidator[Input, Offset] = {
+      (in: Input) => in.create
+    }
+  }
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
@@ -1,0 +1,190 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.core.math.Offset
+import lucuma.odb.api.model.syntax.inputvalidator._
+
+import cats.Eq
+import cats.syntax.all._
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+sealed abstract class StepModel[A] extends Product with Serializable {
+  def dynamicConfig: A
+
+  def fold[B](
+    biasFn:    StepModel.Bias[A]    => B,
+    darkFn:    StepModel.Dark[A]    => B,
+    scienceFn: StepModel.Science[A] => B
+  ): B =
+    this match {
+      case b @ StepModel.Bias(_)       => biasFn(b)
+      case d @ StepModel.Dark(_)       => darkFn(d)
+      case s @ StepModel.Science(_, _) => scienceFn(s)
+    }
+
+  def bias: Option[StepModel.Bias[A]] =
+    this match {
+      case b @ StepModel.Bias(_) => Some(b)
+      case _                     => None
+    }
+
+  def dark: Option[StepModel.Dark[A]] =
+    this match {
+      case d @ StepModel.Dark(_) => Some(d)
+      case _                     => None
+    }
+
+  def science: Option[StepModel.Science[A]] =
+    this match {
+      case s @ StepModel.Science(_, _) => Some(s)
+      case _                           => None
+    }
+
+}
+
+object StepModel {
+
+  final case class Bias     [A](dynamicConfig: A)                 extends StepModel[A]
+  final case class Dark     [A](dynamicConfig: A)                 extends StepModel[A]
+  final case class Science  [A](dynamicConfig: A, offset: Offset) extends StepModel[A]
+
+  def bias[A](dynamicConfig: A): StepModel[A] =
+    Bias(dynamicConfig)
+
+  def dark[A](dynamicConfig: A): StepModel[A] =
+    Dark(dynamicConfig)
+
+  def science[A](dynamicConfig: A, offset: Offset): StepModel[A] =
+    Science(dynamicConfig, offset)
+
+
+  implicit def EqStepModel[A: Eq]: Eq[StepModel[A]] =
+    Eq.instance {
+      case (Bias(a), Bias(b))               => a === b
+      case (Dark(a), Dark(b))               => a === b
+      case (Science(a, oa), Science(b, ob)) => (a === b) && (oa === ob)
+      case _                                => false
+    }
+
+  final case class CreateScience[A](
+    config: A,
+    offset: OffsetModel.Input
+  ) {
+
+    def create[B](implicit V: InputValidator[A, B]): ValidatedInput[Science[B]] =
+      (config.validateAndCreate, offset.create).mapN { (c, o) => Science(c, o) }
+
+  }
+
+  object CreateScience {
+
+    implicit def EqCreateScience[A: Eq]: Eq[CreateScience[A]] =
+      Eq.by { a => (
+        a.config,
+        a.offset
+      )}
+
+    implicit def DecoderCreateScience[A: Decoder]: Decoder[CreateScience[A]] =
+      deriveDecoder[CreateScience[A]]
+
+    implicit def ValidatorCreateScience[A, B](implicit V: InputValidator[A, B]): InputValidator[CreateScience[A], Science[B]] =
+      (csa: CreateScience[A]) => csa.create[B]
+
+  }
+
+  final case class CreateBias[A](config: A) {
+
+    def create[B](implicit V: InputValidator[A, B]): ValidatedInput[Bias[B]] =
+      config.validateAndCreate.map(Bias(_))
+
+  }
+
+  object CreateBias {
+
+    implicit def EqCreateBias[A: Eq]: Eq[CreateBias[A]] =
+      Eq.by(_.config)
+
+    implicit def DecoderCreateBias[A: Decoder]: Decoder[CreateBias[A]] =
+      deriveDecoder[CreateBias[A]]
+
+    implicit def ValidateCreateBias[A, B](implicit V: InputValidator[A, B]): InputValidator[CreateBias[A], Bias[B]] =
+      (cba: CreateBias[A]) => cba.create[B]
+
+  }
+
+  final case class CreateDark[A](config: A) {
+
+    def create[B](implicit V: InputValidator[A, B]): ValidatedInput[Dark[B]] =
+      config.validateAndCreate.map(Dark(_))
+
+  }
+
+  object CreateDark {
+
+    implicit def EqCreateDark[A: Eq]: Eq[CreateDark[A]] =
+      Eq.by(_.config)
+
+    implicit def DecoderCreateDark[A: Decoder]: Decoder[CreateDark[A]] =
+      deriveDecoder[CreateDark[A]]
+
+    implicit def ValidateCreateDark[A, B](implicit V: InputValidator[A, B]): InputValidator[CreateDark[A], Dark[B]] =
+      (cda: CreateDark[A]) => cda.create[B]
+
+  }
+
+  final case class CreateStep[A](
+    bias:    Option[CreateBias[A]],
+    dark:    Option[CreateDark[A]],
+    science: Option[CreateScience[A]]
+  ) {
+
+    def create[B](implicit V: InputValidator[A, B]): ValidatedInput[StepModel[B]] =
+      ValidatedInput.requireOne(
+        "step",
+        bias.map    { _.validateAndCreate },
+        dark.map    { _.validateAndCreate },
+        science.map { _.validateAndCreate }
+      )
+
+  }
+
+  object CreateStep {
+
+    implicit def EqCreateStep[A: Eq]: Eq[CreateStep[A]] =
+      Eq.by { a => (
+        a.bias,
+        a.dark,
+        a.science
+      )}
+
+    implicit def DecoderCreateStep[A: Decoder]: Decoder[CreateStep[A]] =
+      deriveDecoder[CreateStep[A]]
+
+    implicit def ValidateCreateStep[A, B](implicit V: InputValidator[A, B]): InputValidator[CreateStep[A], StepModel[B]] =
+      (csa: CreateStep[A]) => csa.create[B]
+
+  }
+
+  /*
+  val x =
+    """
+      |"gmos": {
+      |  "static": ...
+      |  "acquisition": [
+      |
+      |  ],
+      |  "sequence": [
+      |    {
+      |      "bias": {
+      |        "filter" : ...
+      |      }
+      |    }
+      |  ]
+      |
+      |}
+      |""".stripMargin
+   */
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
@@ -11,6 +11,8 @@ import cats.syntax.all._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 
+// For now, just bias, dark, and science.  Pending smart-gcal and gcal.
+
 sealed abstract class StepModel[A] extends Product with Serializable {
   def dynamicConfig: A
 
@@ -130,7 +132,7 @@ object StepModel {
     implicit def DecoderCreateDark[A: Decoder]: Decoder[CreateDark[A]] =
       deriveDecoder[CreateDark[A]]
 
-    implicit def ValidateCreateDark[A, B](implicit V: InputValidator[A, B]): InputValidator[CreateDark[A], Dark[B]] =
+    implicit def ValidateCreateDark[A, B](implicit ev: InputValidator[A, B]): InputValidator[CreateDark[A], Dark[B]] =
       (cda: CreateDark[A]) => cda.create[B]
 
   }
@@ -163,7 +165,7 @@ object StepModel {
     implicit def DecoderCreateStep[A: Decoder]: Decoder[CreateStep[A]] =
       deriveDecoder[CreateStep[A]]
 
-    implicit def ValidateCreateStep[A, B](implicit V: InputValidator[A, B]): InputValidator[CreateStep[A], StepModel[B]] =
+    implicit def ValidateCreateStep[A, B](implicit ev: InputValidator[A, B]): InputValidator[CreateStep[A], StepModel[B]] =
       (csa: CreateStep[A]) => csa.create[B]
 
   }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/WavelengthModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/WavelengthModel.scala
@@ -1,0 +1,124 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.core.math.Wavelength
+import lucuma.core.optics.Format
+import lucuma.core.util.{Display, Enumerated}
+
+import cats.Eq
+import cats.syntax.option._
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+
+object WavelengthModel {
+
+  sealed abstract class Units(
+    val abbr:      String,
+    decimalFormat: Format[BigDecimal, Wavelength]
+  ) extends Product with Serializable {
+
+    def readLong(l: Long): ValidatedInput[Wavelength] =
+      decimalFormat.getOption(BigDecimal(l)).toValidNec(
+        InputError.fromMessage(
+          s"Could not read $l $abbr as a wavelength"
+        )
+      )
+
+    def readDecimal(b: BigDecimal): ValidatedInput[Wavelength] =
+      decimalFormat.getOption(b).toValidNec(
+        InputError.fromMessage(
+          s"Could not read $b $abbr as a wavelength"
+        )
+      )
+  }
+
+  object Units {
+    case object Picometers  extends Units("pm", Wavelength.decimalPicometers)
+    case object Angstroms   extends Units("Å",  Wavelength.decimalAngstroms)
+    case object Nanometers  extends Units("nm", Wavelength.decimalNanometers)
+    case object Micrometers extends Units("µm", Wavelength.decimalMicrometers)
+
+    val picometers: Units  = Picometers
+    val angstroms: Units   = Angstroms
+    val nanometers: Units  = Nanometers
+    val micrometers: Units = Micrometers
+
+    implicit val EnumeratedUnits: Enumerated[Units] =
+      Enumerated.of(
+        Picometers,
+        Angstroms,
+        Nanometers,
+        Micrometers
+      )
+
+    implicit val DisplayUnits: Display[Units] =
+      Display.byShortName(_.abbr)
+  }
+
+  implicit val NumericUnitsWavelength: NumericUnits[Wavelength, Units] =
+    NumericUnits.fromRead(_.readLong(_), _.readDecimal(_))
+
+  final case class Input(
+    picometers:  Option[Long],
+    angstroms:   Option[BigDecimal],
+    nanometers:  Option[BigDecimal],
+    micrometers: Option[BigDecimal],
+    fromLong:    Option[NumericUnits.LongInput[Units]],
+    fromDecimal: Option[NumericUnits.DecimalInput[Units]]
+  ) {
+
+    import Units._
+
+    def toWavelength(n: String): ValidatedInput[Wavelength] =
+      ValidatedInput.requireOne(n,
+        picometers .map(Picometers.readLong),
+        angstroms  .map(Angstroms.readDecimal),
+        nanometers .map(Nanometers.readDecimal),
+        micrometers.map(Micrometers.readDecimal),
+        fromLong   .map(_.read),
+        fromDecimal.map(_.read)
+      )
+
+  }
+
+  object Input {
+
+    val Empty: Input =
+      Input(None, None, None, None, None, None)
+
+    def fromPicometers(value: Long): Input =
+      Empty.copy(picometers = Some(value))
+
+    def fromAngstroms(value: BigDecimal): Input =
+      Empty.copy(angstroms = Some(value))
+
+    def fromNanometers(value: BigDecimal): Input =
+      Empty.copy(nanometers = Some(value))
+
+    def fromMicrometers(value: BigDecimal): Input =
+      Empty.copy(micrometers = Some(value))
+
+    def fromLong(value: NumericUnits.LongInput[Units]): Input =
+      Empty.copy(fromLong = Some(value))
+
+    def fromDecimal(value: NumericUnits.DecimalInput[Units]): Input =
+      Empty.copy(fromDecimal = Some(value))
+
+    implicit val DecoderInput: Decoder[Input] =
+      deriveDecoder[Input]
+
+    implicit val EqInput: Eq[Input] =
+      Eq.by(in => (
+        in.picometers,
+        in.angstroms,
+        in.nanometers,
+        in.micrometers,
+        in.fromLong,
+        in.fromDecimal
+      ))
+  }
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/syntax/InputValidatorOps.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/syntax/InputValidatorOps.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+package syntax
+
+final class InputValidatorOps[A](a: A) {
+
+  def validateAndCreate[B](implicit V: InputValidator[A, B]): ValidatedInput[B] =
+    V.validateAndCreate(a)
+
+}
+
+trait ToInputValidatorOps {
+
+  implicit def toInputValidatorOps[A](a: A): InputValidatorOps[A] =
+    new InputValidatorOps[A](a)
+
+}
+
+object inputvalidator extends ToInputValidatorOps

--- a/modules/core/src/main/scala/lucuma/odb/api/model/syntax/package.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/syntax/package.scala
@@ -6,6 +6,7 @@ package lucuma.odb.api.model
 package object syntax {
 
   object all extends ToInputOps
+                with ToInputValidatorOps
                 with ToTopLevelOps
                 with ToValidatedInputOps
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -25,7 +25,8 @@ trait ObservationMutation {
   val InputObjectTypeObservationCreate: InputObjectType[ObservationModel.Create] =
     deriveInputObjectType[ObservationModel.Create](
       InputObjectTypeName("CreateObservationInput"),
-      InputObjectTypeDescription("Observation creation parameters")
+      InputObjectTypeDescription("Observation creation parameters"),
+      ExcludeInputFields("config")  // TODO
     )
 
   val ArgumentObservationCreate: Argument[ObservationModel.Create] =

--- a/modules/core/src/test/scala/lucuma/odb/api/model/ConfigModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/ConfigModelSuite.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.odb.api.model.arb._
+
+import cats.kernel.laws.discipline.EqTests
+import monocle.law.discipline._
+import munit.DisciplineSuite
+
+final class ConfigModelSuite extends DisciplineSuite {
+
+  import ArbConfigModel._
+  import ArbManualSequence._
+  import ArbGmosModel._
+
+  checkAll("ConfigModel",           EqTests[ConfigModel].eqv)
+  checkAll("ConfigModel.Create",    EqTests[ConfigModel.Create].eqv)
+  checkAll("ConfigModel.GmosNorth", EqTests[ConfigModel.GmosNorth].eqv)
+  checkAll("ConfigModel.GmosSouth", EqTests[ConfigModel.GmosSouth].eqv)
+
+  checkAll("ConfigModel.GmosNorth.manual", LensTests(ConfigModel.GmosNorth.manual))
+  checkAll("ConfigModel.GmosSouth.manual", LensTests(ConfigModel.GmosSouth.manual))
+}

--- a/modules/core/src/test/scala/lucuma/odb/api/model/FiniteDurationModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/FiniteDurationModelSuite.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.odb.api.model.arb._
+
+import cats.kernel.laws.discipline.EqTests
+import munit.DisciplineSuite
+
+
+final class FiniteDurationModelSuite extends DisciplineSuite {
+
+  import ArbFiniteDurationModel._
+
+  checkAll("FiniteDurationModel.Input", EqTests[FiniteDurationModel.Input].eqv)
+
+}

--- a/modules/core/src/test/scala/lucuma/odb/api/model/GmosModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/GmosModelSuite.scala
@@ -12,15 +12,14 @@ import lucuma.core.util.arb.ArbEnumerated
 import cats.kernel.laws.discipline.EqTests
 import eu.timepit.refined.cats._
 import eu.timepit.refined.scalacheck.all._
-import munit.DisciplineSuite
 import monocle.law.discipline._
+import munit.DisciplineSuite
 
 final class GmosModelSuite extends DisciplineSuite {
 
   import ArbEnumerated._
   import ArbGmosModel._
   import ArbOffset._
-  import ArbStepModel._
   import ArbWavelength._
 
   checkAll("GmosModel.NodAndShuffle",               EqTests[GmosModel.NodAndShuffle].eqv)
@@ -88,16 +87,5 @@ final class GmosModelSuite extends DisciplineSuite {
   checkAll("GmosModel.SouthDynamic.filter",         LensTests(GmosModel.SouthDynamic.filter))
   checkAll("GmosModel.SouthDynamic.fpu",            LensTests(GmosModel.SouthDynamic.fpu))
   checkAll("GmosModel.CreateSouthDynamic",          EqTests[GmosModel.CreateSouthDynamic].eqv)
-
-  checkAll("GmosModel.North",                       EqTests[GmosModel.North].eqv)
-  checkAll("GmosModel.North.static",                LensTests(GmosModel.North.static))
-  checkAll("GmosModel.North.acquisition",           LensTests(GmosModel.North.acquisition))
-  checkAll("GmosModel.North.science",               LensTests(GmosModel.North.science))
-  checkAll("GmosModel.South",                       EqTests[GmosModel.South].eqv)
-  checkAll("GmosModel.South.static",                LensTests(GmosModel.South.static))
-  checkAll("GmosModel.South.acquisition",           LensTests(GmosModel.South.acquisition))
-  checkAll("GmosModel.South.science",               LensTests(GmosModel.South.science))
-  checkAll("GmosModel.CreateNorth",                 EqTests[GmosModel.CreateNorth].eqv)
-  checkAll("GmosModel.CreateSouth",                 EqTests[GmosModel.CreateSouth].eqv)
 
 }

--- a/modules/core/src/test/scala/lucuma/odb/api/model/GmosModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/GmosModelSuite.scala
@@ -1,0 +1,103 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.odb.api.model.arb._
+import lucuma.core.`enum`.GmosNorthDisperser
+import lucuma.core.math.arb.ArbOffset
+import lucuma.core.math.arb.ArbWavelength
+import lucuma.core.util.arb.ArbEnumerated
+
+import cats.kernel.laws.discipline.EqTests
+import eu.timepit.refined.cats._
+import eu.timepit.refined.scalacheck.all._
+import munit.DisciplineSuite
+import monocle.law.discipline._
+
+final class GmosModelSuite extends DisciplineSuite {
+
+  import ArbEnumerated._
+  import ArbGmosModel._
+  import ArbOffset._
+  import ArbStepModel._
+  import ArbWavelength._
+
+  checkAll("GmosModel.NodAndShuffle",               EqTests[GmosModel.NodAndShuffle].eqv)
+  checkAll("GmosModel.NodAndShuffle.posA",          LensTests(GmosModel.NodAndShuffle.posA))
+  checkAll("GmosModel.NodAndShuffle.posB",          LensTests(GmosModel.NodAndShuffle.posB))
+  checkAll("GmosModel.NodAndShuffle.eOffset",       LensTests(GmosModel.NodAndShuffle.eOffset))
+  checkAll("GmosModel.NodAndShuffle.shuffleOffset", LensTests(GmosModel.NodAndShuffle.shuffleOffset))
+  checkAll("GmosModel.NodAndShuffle.shuffleCycles", LensTests(GmosModel.NodAndShuffle.shuffleCycles))
+  checkAll("GmosModel.CreateNodAndShuffle",         EqTests[GmosModel.CreateNodAndShuffle].eqv)
+  checkAll("GmosModel.EditNodAndShuffle",           EqTests[GmosModel.EditNodAndShuffle].eqv)
+
+
+  checkAll("GmosModel.CommonStatic",                EqTests[GmosModel.CommonStatic].eqv)
+  checkAll("GmosModel.CommonStatic.detector",       LensTests(GmosModel.CommonStatic.detector))
+  checkAll("GmosModel.CommonStatic.mosPreImaging",  LensTests(GmosModel.CommonStatic.mosPreImaging))
+  checkAll("GmosModel.CommonStatic.nodAndShuffle",  LensTests(GmosModel.CommonStatic.nodAndShuffle))
+  checkAll("GmosModel.CreateCommonStatic",          EqTests[GmosModel.CreateCommonStatic].eqv)
+
+  checkAll("GmosModel.NorthStatic",                 EqTests[GmosModel.NorthStatic].eqv)
+  checkAll("GmosModel.NorthStatic.common",          LensTests(GmosModel.NorthStatic.common))
+  checkAll("GmosModel.NorthStatic.stageMode",       LensTests(GmosModel.NorthStatic.stageMode))
+  checkAll("GmosModel.CreateNorthStatic",           EqTests[GmosModel.CreateNorthStatic].eqv)
+
+  checkAll("GmosModel.SouthStatic",                 EqTests[GmosModel.SouthStatic].eqv)
+  checkAll("GmosModel.SouthStatic.common",          LensTests(GmosModel.SouthStatic.common))
+  checkAll("GmosModel.SouthStatic.stageMode",       LensTests(GmosModel.SouthStatic.stageMode))
+  checkAll("GmosModel.CreateSouthStatic",           EqTests[GmosModel.CreateSouthStatic].eqv)
+
+  checkAll("GmosModel.CcdReadout",                  EqTests[GmosModel.CcdReadout].eqv)
+  checkAll("GmosModel.CcdReadout.xBin",             LensTests(GmosModel.CcdReadout.xBin))
+  checkAll("GmosModel.CcdReadout.yBin",             LensTests(GmosModel.CcdReadout.yBin))
+  checkAll("GmosModel.CcdReadout.ampCount",         LensTests(GmosModel.CcdReadout.ampCount))
+  checkAll("GmosModel.CcdReadout.ampGrain",         LensTests(GmosModel.CcdReadout.ampGain))
+  checkAll("GmosModel.CcdReadout.ampRead ",         LensTests(GmosModel.CcdReadout.ampRead))
+  checkAll("GmosModel.CreateCcdReadout",            EqTests[GmosModel.CreateCcdReadout].eqv)
+
+  checkAll("GmosModel.CommonDynamic",               EqTests[GmosModel.CommonDynamic].eqv)
+  checkAll("GmosModel.CommonDynamic.readout",       LensTests(GmosModel.CommonDynamic.readout))
+  checkAll("GmosModel.CommonDynamic.dtax",          LensTests(GmosModel.CommonDynamic.dtax))
+  checkAll("GmosModel.CommonDynamic.exposure",      LensTests(GmosModel.CommonDynamic.exposure))
+  checkAll("GmosModel.CommonDynamic.roi",           LensTests(GmosModel.CommonDynamic.roi))
+  checkAll("GmosModel.CreateCommonDynamic",         EqTests[GmosModel.CreateCommonDynamic].eqv)
+
+  checkAll("GmosModel.CustomMask",                  EqTests[GmosModel.CustomMask].eqv)
+  checkAll("GmosModel.CustomMask.filename",         LensTests(GmosModel.CustomMask.filename))
+  checkAll("GmosModel.CustomMask.slitWidth",        LensTests(GmosModel.CustomMask.slitWidth))
+  checkAll("GmosModel.CreateCustomMask",            EqTests[GmosModel.CreateCustomMask].eqv)
+
+  checkAll("GmosModel.Grating",                     EqTests[GmosModel.Grating[GmosNorthDisperser]].eqv)
+  checkAll("GmosModel.Grating.disperser",           LensTests(GmosModel.Grating.disperser[GmosNorthDisperser]))
+  checkAll("GmosModel.Grating.order",               LensTests(GmosModel.Grating.order[GmosNorthDisperser]))
+  checkAll("GmosModel.Grating.wavelength",          LensTests(GmosModel.Grating.wavelength[GmosNorthDisperser]))
+  checkAll("GmosModel.CreateGrating",               EqTests[GmosModel.CreateGrating[GmosNorthDisperser]].eqv)
+
+  checkAll("GmosModel.NorthDynamic",                EqTests[GmosModel.NorthDynamic].eqv)
+  checkAll("GmosModel.NorthDynamic.common",         LensTests(GmosModel.NorthDynamic.common))
+  checkAll("GmosModel.NorthDynamic.grating",        LensTests(GmosModel.NorthDynamic.grating))
+  checkAll("GmosModel.NorthDynamic.filter",         LensTests(GmosModel.NorthDynamic.filter))
+  checkAll("GmosModel.NorthDynamic.fpu",            LensTests(GmosModel.NorthDynamic.fpu))
+  checkAll("GmosModel.CreateNorthDynamic",          EqTests[GmosModel.CreateNorthDynamic].eqv)
+
+  checkAll("GmosModel.SouthDynamic",                EqTests[GmosModel.SouthDynamic].eqv)
+  checkAll("GmosModel.SouthDynamic.common",         LensTests(GmosModel.SouthDynamic.common))
+  checkAll("GmosModel.SouthDynamic.grating",        LensTests(GmosModel.SouthDynamic.grating))
+  checkAll("GmosModel.SouthDynamic.filter",         LensTests(GmosModel.SouthDynamic.filter))
+  checkAll("GmosModel.SouthDynamic.fpu",            LensTests(GmosModel.SouthDynamic.fpu))
+  checkAll("GmosModel.CreateSouthDynamic",          EqTests[GmosModel.CreateSouthDynamic].eqv)
+
+  checkAll("GmosModel.North",                       EqTests[GmosModel.North].eqv)
+  checkAll("GmosModel.North.static",                LensTests(GmosModel.North.static))
+  checkAll("GmosModel.North.acquisition",           LensTests(GmosModel.North.acquisition))
+  checkAll("GmosModel.North.science",               LensTests(GmosModel.North.science))
+  checkAll("GmosModel.South",                       EqTests[GmosModel.South].eqv)
+  checkAll("GmosModel.South.static",                LensTests(GmosModel.South.static))
+  checkAll("GmosModel.South.acquisition",           LensTests(GmosModel.South.acquisition))
+  checkAll("GmosModel.South.science",               LensTests(GmosModel.South.science))
+  checkAll("GmosModel.CreateNorth",                 EqTests[GmosModel.CreateNorth].eqv)
+  checkAll("GmosModel.CreateSouth",                 EqTests[GmosModel.CreateSouth].eqv)
+
+}

--- a/modules/core/src/test/scala/lucuma/odb/api/model/ManualSequenceSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/ManualSequenceSuite.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.odb.api.model.arb._
+
+import cats.kernel.laws.discipline.EqTests
+import monocle.law.discipline._
+import munit.DisciplineSuite
+
+
+final class ManualSequenceSuite extends DisciplineSuite {
+
+  import ArbManualSequence._
+  import ArbStepModel._
+
+  checkAll("ManualSequence",        EqTests[ManualSequence[Int, String]].eqv)
+  checkAll("ManualSequence.Create", EqTests[ManualSequence.Create[Int, String]].eqv)
+
+  checkAll("GmosModel.North.static",      LensTests(ManualSequence.static[Int, String]))
+  checkAll("GmosModel.North.acquisition", LensTests(ManualSequence.acquisition[Int, String]))
+  checkAll("GmosModel.North.science",     LensTests(ManualSequence.science[Int, String]))
+
+}

--- a/modules/core/src/test/scala/lucuma/odb/api/model/OffsetModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/OffsetModelSuite.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.odb.api.model.arb._
+
+import cats.kernel.laws.discipline.EqTests
+import munit.DisciplineSuite
+
+final class OffsetModelSuite extends DisciplineSuite {
+
+  import ArbOffsetModel._
+
+  checkAll("OffsetModel.Input", EqTests[OffsetModel.Input].eqv)
+
+}

--- a/modules/core/src/test/scala/lucuma/odb/api/model/StepModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/StepModelSuite.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.odb.api.model.arb._
+
+import cats.kernel.laws.discipline.EqTests
+import munit.DisciplineSuite
+//import monocle.law.discipline._
+
+final class StepModelSuite extends DisciplineSuite {
+
+  import ArbStepModel._
+
+  checkAll("StepModel.StepModel", EqTests[StepModel[Int]].eqv)
+  checkAll("StepModel.CreateStep", EqTests[StepModel.CreateStep[Int]].eqv)
+
+}

--- a/modules/core/src/test/scala/lucuma/odb/api/model/StepModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/StepModelSuite.scala
@@ -7,7 +7,6 @@ import lucuma.odb.api.model.arb._
 
 import cats.kernel.laws.discipline.EqTests
 import munit.DisciplineSuite
-//import monocle.law.discipline._
 
 final class StepModelSuite extends DisciplineSuite {
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/WavelengthModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/WavelengthModelSuite.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.odb.api.model.arb._
+
+import cats.kernel.laws.discipline.EqTests
+import munit.DisciplineSuite
+
+final class WavelengthModelSuite extends DisciplineSuite {
+
+  import ArbWavelengthModel._
+
+  checkAll("WavelengthModel.Input", EqTests[WavelengthModel.Input].eqv)
+
+}

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbConfigModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbConfigModel.scala
@@ -1,0 +1,92 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+package arb
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
+
+trait ArbConfigModel {
+
+  import ArbGmosModel._
+  import ArbManualSequence._
+
+  implicit val arbGmosNorth: Arbitrary[ConfigModel.GmosNorth] =
+    Arbitrary {
+      arbitrary[ManualSequence[GmosModel.NorthStatic, GmosModel.NorthDynamic]]
+        .map(ConfigModel.GmosNorth(_))
+    }
+
+  implicit val arbGmosSouth: Arbitrary[ConfigModel.GmosSouth] =
+    Arbitrary {
+      arbitrary[ManualSequence[GmosModel.SouthStatic, GmosModel.SouthDynamic]]
+        .map(ConfigModel.GmosSouth(_))
+    }
+
+  implicit val cogGmosNorth: Cogen[ConfigModel.GmosNorth] =
+    Cogen[ManualSequence[GmosModel.NorthStatic, GmosModel.NorthDynamic]]
+      .contramap(_.manual)
+
+  implicit val cogGmosSouth: Cogen[ConfigModel.GmosSouth] =
+    Cogen[ManualSequence[GmosModel.SouthStatic, GmosModel.SouthDynamic]]
+      .contramap(_.manual)
+
+  implicit val arbCreateGmosNorth: Arbitrary[ConfigModel.CreateGmosNorth] =
+    Arbitrary {
+      arbitrary[ManualSequence.Create[GmosModel.CreateNorthStatic, GmosModel.CreateNorthDynamic]]
+        .map(ConfigModel.CreateGmosNorth(_))
+    }
+
+  implicit val arbCreateGmosSouth: Arbitrary[ConfigModel.CreateGmosSouth] =
+    Arbitrary {
+      arbitrary[ManualSequence.Create[GmosModel.CreateSouthStatic, GmosModel.CreateSouthDynamic]]
+        .map(ConfigModel.CreateGmosSouth(_))
+    }
+
+  implicit val cogCreateGmosNorth: Cogen[ConfigModel.CreateGmosNorth] =
+    Cogen[ManualSequence.Create[GmosModel.CreateNorthStatic, GmosModel.CreateNorthDynamic]]
+      .contramap(_.manual)
+
+  implicit val cogCreateGmosSouth: Cogen[ConfigModel.CreateGmosSouth] =
+    Cogen[ManualSequence.Create[GmosModel.CreateSouthStatic, GmosModel.CreateSouthDynamic]]
+      .contramap(_.manual)
+
+  implicit val arbConfigModel: Arbitrary[ConfigModel] =
+    Arbitrary {
+      Gen.oneOf(
+        arbitrary[ConfigModel.GmosNorth],
+        arbitrary[ConfigModel.GmosSouth]
+      )
+    }
+
+  implicit val cogConfigModel: Cogen[ConfigModel] =
+    Cogen[(
+      Option[ConfigModel.GmosNorth],
+      Option[ConfigModel.GmosSouth]
+    )].contramap { in => (
+      in.gmosNorth,
+      in.gmosSouth
+    )}
+
+  implicit val arbConfigModelCreate: Arbitrary[ConfigModel.Create] =
+    Arbitrary {
+      Gen.oneOf(
+        arbitrary[ConfigModel.CreateGmosNorth].map(ConfigModel.Create.gmosNorth),
+        arbitrary[ConfigModel.CreateGmosSouth].map(ConfigModel.Create.gmosSouth)
+      )
+    }
+
+  implicit val cogConfigModelCreate: Cogen[ConfigModel.Create] =
+    Cogen[(
+      Option[ConfigModel.CreateGmosNorth],
+      Option[ConfigModel.CreateGmosSouth]
+    )].contramap { in => (
+      in.gmosNorth,
+      in.gmosSouth
+    )}
+
+}
+
+object ArbConfigModel extends ArbConfigModel
+

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbDeclinationModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbDeclinationModel.scala
@@ -10,6 +10,7 @@ import NumericUnits.{LongInput, DecimalInput}
 import lucuma.core.math.Declination
 import lucuma.core.util.arb.ArbEnumerated
 import lucuma.core.math.arb.ArbDeclination
+
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbFiniteDurationModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbFiniteDurationModel.scala
@@ -1,0 +1,107 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+package arb
+
+import FiniteDurationModel.{Input, Units}
+import NumericUnits.{LongInput, DecimalInput}
+
+import lucuma.core.util.arb.ArbEnumerated
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
+
+
+trait ArbFiniteDurationModel {
+
+  import ArbEnumerated._
+  import GenNumericUnitsInput._
+
+  private[this] val nanoseconds: Gen[Long] =
+    arbitrary[Long]
+
+  private[this] val microseconds: Gen[BigDecimal] =
+    nanoseconds.map(n => BigDecimal(n)/1000)
+
+  private[this] val milliseconds: Gen[BigDecimal] =
+    microseconds.map(_/1000)
+
+  private[this] val seconds: Gen[BigDecimal] =
+    milliseconds.map(_/1000)
+
+  private[this] val minutes: Gen[BigDecimal] =
+    seconds.map(_/60)
+
+  private[this] val hours: Gen[BigDecimal] =
+    minutes.map(_/60)
+
+  private[this] val days: Gen[BigDecimal] =
+    hours.map(_/24)
+
+  val genFiniteDurationModelInputFromLong: Gen[Input] =
+    Gen.oneOf(
+      genLongInput(nanoseconds,  Units.nanoseconds),
+      genLongInput(microseconds, Units.microseconds),
+      genLongInput(milliseconds, Units.milliseconds),
+      genLongInput(seconds,      Units.seconds),
+      genLongInput(minutes,      Units.minutes),
+      genLongInput(hours,        Units.hours),
+      genLongInput(days,         Units.days)
+    ).map(Input.fromLong)
+
+  val genFiniteDurationModelInputFromDecimal: Gen[Input] =
+    Gen.oneOf(
+      genDecimalInput(nanoseconds,  Units.nanoseconds),
+      genDecimalInput(microseconds, Units.microseconds),
+      genDecimalInput(milliseconds, Units.milliseconds),
+      genDecimalInput(seconds,      Units.seconds),
+      genDecimalInput(minutes,      Units.minutes),
+      genDecimalInput(hours,        Units.hours),
+      genDecimalInput(days,         Units.days)
+    ).map(Input.fromDecimal)
+
+
+  implicit val arbFiniteDurationModelInput: Arbitrary[FiniteDurationModel.Input] =
+    Arbitrary {
+      Gen.oneOf(
+        nanoseconds.map(Input.fromNanoseconds),
+        microseconds.map(Input.fromMicroseconds),
+        milliseconds.map(Input.fromMilliseconds),
+        seconds.map(Input.fromSeconds),
+        minutes.map(Input.fromMinutes),
+        hours.map(Input.fromHours),
+        days.map(Input.fromDays),
+        genFiniteDurationModelInputFromLong,
+        genFiniteDurationModelInputFromDecimal
+      )
+    }
+
+  implicit val cogFiniteDurationModelInput: Cogen[FiniteDurationModel.Input] =
+    Cogen[(
+      Option[Long],        // ns
+      Option[BigDecimal],  // µs
+      Option[BigDecimal],  // ms
+      Option[BigDecimal],  // s
+      Option[BigDecimal],  // m
+      Option[BigDecimal],  // h
+      Option[BigDecimal],  // d
+      Option[LongInput[Units]],
+      Option[DecimalInput[Units]]
+    )].contramap { in =>
+      (
+        in.nanoseconds,
+        in.microseconds,
+        in.milliseconds,
+        in.seconds,
+        in.minutes,
+        in.hours,
+        in.days,
+        in.fromLong,
+        in.fromDecimal
+      )
+    }
+
+}
+
+object ArbFiniteDurationModel extends ArbFiniteDurationModel

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbGmosModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbGmosModel.scala
@@ -26,7 +26,6 @@ trait ArbGmosModel {
   import ArbInput._
   import ArbOffset._
   import ArbOffsetModel._
-  import ArbStepModel._
   import ArbWavelength._
   import ArbWavelengthModel._
 
@@ -506,87 +505,6 @@ trait ArbGmosModel {
         in.fpu
       )
     }
-
-  implicit val arbNorth: Arbitrary[GmosModel.North] =
-    Arbitrary {
-      for {
-        st <- arbitrary[GmosModel.NorthStatic]
-        aq <- arbitrary[List[StepModel[GmosModel.NorthDynamic]]]
-        sc <- arbitrary[List[StepModel[GmosModel.NorthDynamic]]]
-      } yield GmosModel.North(st, aq, sc)
-    }
-
-  implicit val cogNorth: Cogen[GmosModel.North] =
-    Cogen[(
-      GmosModel.NorthStatic,
-      List[StepModel[GmosModel.NorthDynamic]],
-      List[StepModel[GmosModel.NorthDynamic]]
-    )].contramap { in => (
-      in.static,
-      in.acquisition,
-      in.science
-    )}
-
-  implicit val arbCreateNorth: Arbitrary[GmosModel.CreateNorth] =
-    Arbitrary {
-      for {
-        st <- arbitrary[GmosModel.CreateNorthStatic]
-        aq <- arbitrary[List[StepModel.CreateStep[GmosModel.CreateNorthDynamic]]]
-        sc <- arbitrary[List[StepModel.CreateStep[GmosModel.CreateNorthDynamic]]]
-      } yield GmosModel.CreateNorth(st, aq, sc)
-    }
-
-  implicit val cogCreateNorth: Cogen[GmosModel.CreateNorth] =
-    Cogen[(
-      GmosModel.CreateNorthStatic,
-      List[StepModel.CreateStep[GmosModel.CreateNorthDynamic]],
-      List[StepModel.CreateStep[GmosModel.CreateNorthDynamic]]
-    )].contramap { in => (
-      in.static,
-      in.acquisition,
-      in.science
-    )}
-
-  implicit val arbSouth: Arbitrary[GmosModel.South] =
-    Arbitrary {
-      for {
-        st <- arbitrary[GmosModel.SouthStatic]
-        aq <- arbitrary[List[StepModel[GmosModel.SouthDynamic]]]
-        sc <- arbitrary[List[StepModel[GmosModel.SouthDynamic]]]
-      } yield GmosModel.South(st, aq, sc)
-    }
-
-  implicit val cogSouth: Cogen[GmosModel.South] =
-    Cogen[(
-      GmosModel.SouthStatic,
-      List[StepModel[GmosModel.SouthDynamic]],
-      List[StepModel[GmosModel.SouthDynamic]]
-    )].contramap { in => (
-      in.static,
-      in.acquisition,
-      in.science
-    )}
-
-  implicit val arbCreateSouth: Arbitrary[GmosModel.CreateSouth] =
-    Arbitrary {
-      for {
-        st <- arbitrary[GmosModel.CreateSouthStatic]
-        aq <- arbitrary[List[StepModel.CreateStep[GmosModel.CreateSouthDynamic]]]
-        sc <- arbitrary[List[StepModel.CreateStep[GmosModel.CreateSouthDynamic]]]
-      } yield GmosModel.CreateSouth(st, aq, sc)
-    }
-
-  implicit val cogCreateSouth: Cogen[GmosModel.CreateSouth] =
-    Cogen[(
-      GmosModel.CreateSouthStatic,
-      List[StepModel.CreateStep[GmosModel.CreateSouthDynamic]],
-      List[StepModel.CreateStep[GmosModel.CreateSouthDynamic]]
-    )].contramap { in => (
-      in.static,
-      in.acquisition,
-      in.science
-    )}
-
 
 }
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbGmosModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbGmosModel.scala
@@ -1,0 +1,593 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+package arb
+
+import lucuma.core.`enum`._
+import lucuma.core.math.{Offset, Wavelength}
+import lucuma.core.math.arb.ArbOffset
+import lucuma.core.math.arb.ArbWavelength
+import lucuma.core.util.arb.ArbEnumerated
+import clue.data.Input
+import eu.timepit.refined.types.all.NonEmptyString
+import eu.timepit.refined.scalacheck.string._
+import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
+
+import scala.concurrent.duration.FiniteDuration
+
+
+
+trait ArbGmosModel {
+
+  import ArbEnumerated._
+  import ArbFiniteDurationModel._
+  import ArbInput._
+  import ArbOffset._
+  import ArbOffsetModel._
+  import ArbStepModel._
+  import ArbWavelength._
+  import ArbWavelengthModel._
+
+  implicit val arbNodAndShuffle: Arbitrary[GmosModel.NodAndShuffle] =
+    Arbitrary {
+      for {
+        a <- arbitrary[Offset]
+        b <- arbitrary[Offset]
+        e <- arbitrary[GmosEOffsetting]
+        o <- Gen.posNum[Int]
+        c <- Gen.posNum[Int]
+      } yield GmosModel.NodAndShuffle(a, b, e, o, c)
+    }
+
+  implicit val cogNodAndShuffle: Cogen[GmosModel.NodAndShuffle] =
+    Cogen[(
+      Offset,
+      Offset,
+      GmosEOffsetting,
+      Int,
+      Int
+    )].contramap { in => (
+      in.posA,
+      in.posB,
+      in.eOffset,
+      in.shuffleOffset,
+      in.shuffleCycles
+    )}
+
+  implicit val arbCreateNodAndShuffle: Arbitrary[GmosModel.CreateNodAndShuffle] =
+    Arbitrary {
+      for {
+        a <- arbitrary[OffsetModel.Input]
+        b <- arbitrary[OffsetModel.Input]
+        e <- arbitrary[GmosEOffsetting]
+        o <- Gen.posNum[Int]
+        c <- Gen.posNum[Int]
+      } yield GmosModel.CreateNodAndShuffle(a, b, e, o, c)
+    }
+
+  implicit val cogCreateNodAndShuffle: Cogen[GmosModel.CreateNodAndShuffle] =
+    Cogen[(
+      OffsetModel.Input,
+      OffsetModel.Input,
+      GmosEOffsetting,
+      Int,
+      Int
+    )].contramap { in => (
+      in.posA,
+      in.posB,
+      in.eOffset,
+      in.shuffleOffset,
+      in.shuffleCycles
+    )}
+
+  implicit val arbEditNodAndShuffle: Arbitrary[GmosModel.EditNodAndShuffle] =
+    Arbitrary {
+      for {
+        a <- arbNotNullableInput[OffsetModel.Input].arbitrary
+        b <- arbNotNullableInput[OffsetModel.Input].arbitrary
+        e <- arbNotNullableInput[GmosEOffsetting].arbitrary
+        o <- arbNotNullableInput[Int].arbitrary.map(_.map(_.abs))
+        c <- arbNotNullableInput[Int].arbitrary.map(_.map(_.abs))
+      } yield GmosModel.EditNodAndShuffle(a, b, e, o, c)
+    }
+
+  implicit val cogEditNodAndShuffle: Cogen[GmosModel.EditNodAndShuffle] =
+    Cogen[(
+      Input[OffsetModel.Input],
+      Input[OffsetModel.Input],
+      Input[GmosEOffsetting],
+      Input[Int],
+      Input[Int]
+    )].contramap { in => (
+      in.posA,
+      in.posB,
+      in.eOffset,
+      in.shuffleOffset,
+      in.shuffleCycles
+    )}
+
+
+  implicit val arbCommonStatic: Arbitrary[GmosModel.CommonStatic] =
+    Arbitrary {
+      for {
+        d <- arbitrary[GmosDetector]
+        m <- arbitrary[MosPreImaging]
+        n <- arbitrary[Option[GmosModel.NodAndShuffle]]
+      } yield GmosModel.CommonStatic(d, m, n)
+    }
+
+  implicit val cogCommonStatic: Cogen[GmosModel.CommonStatic] =
+    Cogen[(
+      GmosDetector,
+      MosPreImaging,
+      Option[GmosModel.NodAndShuffle]
+    )].contramap { in => (
+      in.detector,
+      in.mosPreImaging,
+      in.nodAndShuffle
+    )}
+
+  implicit val arbCreateCommonStatic: Arbitrary[GmosModel.CreateCommonStatic] =
+    Arbitrary {
+      for {
+        d <- arbitrary[GmosDetector]
+        m <- arbitrary[MosPreImaging]
+        n <- arbitrary[Option[GmosModel.CreateNodAndShuffle]]
+      } yield GmosModel.CreateCommonStatic(d, m, n)
+    }
+
+  implicit val cogCreateCommonStatic: Cogen[GmosModel.CreateCommonStatic] =
+    Cogen[(
+      GmosDetector,
+      MosPreImaging,
+      Option[GmosModel.CreateNodAndShuffle]
+    )].contramap { in => (
+      in.detector,
+      in.mosPreImaging,
+      in.nodAndShuffle
+    )}
+
+  implicit val arbNorthStatic: Arbitrary[GmosModel.NorthStatic] =
+    Arbitrary {
+      for {
+        c <- arbitrary[GmosModel.CommonStatic]
+        s <- arbitrary[GmosNorthStageMode]
+      } yield GmosModel.NorthStatic(c, s)
+    }
+
+  implicit val cogNorthStatic: Cogen[GmosModel.NorthStatic] =
+    Cogen[(
+      GmosModel.CommonStatic,
+      GmosNorthStageMode
+    )].contramap { in => (
+      in.common,
+      in.stageMode
+    )}
+
+  implicit val arbCreateNorthStatic: Arbitrary[GmosModel.CreateNorthStatic] =
+    Arbitrary {
+      for {
+        c <- arbitrary[GmosModel.CreateCommonStatic]
+        s <- arbitrary[GmosNorthStageMode]
+      } yield GmosModel.CreateNorthStatic(c, s)
+    }
+
+  implicit val cogCreateNorthStatic: Cogen[GmosModel.CreateNorthStatic] =
+    Cogen[(
+      GmosModel.CreateCommonStatic,
+      GmosNorthStageMode
+    )].contramap { in => (
+      in.common,
+      in.stageMode
+    )}
+
+  implicit val arbSouthStatic: Arbitrary[GmosModel.SouthStatic] =
+    Arbitrary {
+      for {
+        c <- arbitrary[GmosModel.CommonStatic]
+        s <- arbitrary[GmosSouthStageMode]
+      } yield GmosModel.SouthStatic(c, s)
+    }
+
+  implicit val cogSouthStatic: Cogen[GmosModel.SouthStatic] =
+    Cogen[(
+      GmosModel.CommonStatic,
+      GmosSouthStageMode
+    )].contramap { in => (
+      in.common,
+      in.stageMode
+    )}
+
+  implicit val arbCreateSouthStatic: Arbitrary[GmosModel.CreateSouthStatic] =
+    Arbitrary {
+      for {
+        c <- arbitrary[GmosModel.CreateCommonStatic]
+        s <- arbitrary[GmosSouthStageMode]
+      } yield GmosModel.CreateSouthStatic(c, s)
+    }
+
+  implicit val cogCreateSouthStatic: Cogen[GmosModel.CreateSouthStatic] =
+    Cogen[(
+      GmosModel.CreateCommonStatic,
+      GmosSouthStageMode
+    )].contramap { in => (
+      in.common,
+      in.stageMode
+    )}
+
+
+  implicit val arbCcdReadout: Arbitrary[GmosModel.CcdReadout] =
+    Arbitrary {
+      for {
+        x <- arbitrary[GmosXBinning]
+        y <- arbitrary[GmosYBinning]
+        c <- arbitrary[GmosAmpCount]
+        g <- arbitrary[GmosAmpGain]
+        r <- arbitrary[GmosAmpReadMode]
+      } yield GmosModel.CcdReadout(x, y, c, g, r)
+    }
+
+  implicit val cogCcdReadout: Cogen[GmosModel.CcdReadout] =
+    Cogen[(
+      GmosXBinning,
+      GmosYBinning,
+      GmosAmpCount,
+      GmosAmpGain,
+      GmosAmpReadMode
+    )].contramap { in =>
+      (
+        in.xBin,
+        in.yBin,
+        in.ampCount,
+        in.ampGain,
+        in.ampRead
+      )
+    }
+
+  implicit val arbCreateCcdReadout: Arbitrary[GmosModel.CreateCcdReadout] =
+    Arbitrary {
+      for {
+        x <- arbitrary[GmosXBinning]
+        y <- arbitrary[GmosYBinning]
+        c <- arbitrary[GmosAmpCount]
+        g <- arbitrary[GmosAmpGain]
+        r <- arbitrary[GmosAmpReadMode]
+      } yield GmosModel.CreateCcdReadout(x, y, c, g, r)
+    }
+
+  implicit val cogCreateCcdReadout: Cogen[GmosModel.CreateCcdReadout] =
+    Cogen[(
+      GmosXBinning,
+      GmosYBinning,
+      GmosAmpCount,
+      GmosAmpGain,
+      GmosAmpReadMode
+    )].contramap { in =>
+      (
+        in.xBin,
+        in.yBin,
+        in.ampCount,
+        in.ampGain,
+        in.ampRead
+      )
+    }
+
+
+  implicit val arbCommonDynamic: Arbitrary[GmosModel.CommonDynamic] =
+    Arbitrary {
+      for {
+        c <- arbitrary[GmosModel.CcdReadout]
+        x <- arbitrary[GmosDtax]
+        e <- arbitrary[FiniteDuration]
+        r <- arbitrary[GmosRoi]
+      } yield GmosModel.CommonDynamic(c, x, e, r)
+    }
+
+  implicit val cogCommonDynamic: Cogen[GmosModel.CommonDynamic] =
+    Cogen[(
+      GmosModel.CcdReadout,
+      GmosDtax,
+      FiniteDuration,
+      GmosRoi
+    )].contramap { in =>
+      (
+        in.readout,
+        in.dtax,
+        in.exposure,
+        in.roi
+      )
+    }
+
+  implicit val arbCreateCommonDynamic: Arbitrary[GmosModel.CreateCommonDynamic] =
+    Arbitrary {
+      for {
+        c <- arbitrary[GmosModel.CreateCcdReadout]
+        x <- arbitrary[GmosDtax]
+        e <- arbitrary[FiniteDurationModel.Input]
+        r <- arbitrary[GmosRoi]
+      } yield GmosModel.CreateCommonDynamic(c, x, e, r)
+    }
+
+  implicit val cogCreateCommonDynamic: Cogen[GmosModel.CreateCommonDynamic] =
+    Cogen[(
+      GmosModel.CreateCcdReadout,
+      GmosDtax,
+      FiniteDurationModel.Input,
+      GmosRoi
+    )].contramap { in =>
+      (
+        in.readout,
+        in.dtax,
+        in.exposure,
+        in.roi
+      )
+    }
+
+  implicit val arbCustomMask: Arbitrary[GmosModel.CustomMask] =
+    Arbitrary {
+      for {
+        f <- arbitrary[NonEmptyString]
+        w <- arbitrary[GmosCustomSlitWidth]
+      } yield GmosModel.CustomMask(f, w)
+    }
+
+  implicit val cogCustomMask: Cogen[GmosModel.CustomMask] =
+    Cogen[(
+      String,
+      GmosCustomSlitWidth
+    )].contramap { in =>
+      (
+        in.filename.value,
+        in.slitWidth
+      )
+    }
+
+  implicit val arbCreateCustomMask: Arbitrary[GmosModel.CreateCustomMask] =
+    Arbitrary {
+      for {
+        f <- arbitrary[NonEmptyString]
+        w <- arbitrary[GmosCustomSlitWidth]
+      } yield GmosModel.CreateCustomMask(f.value, w)
+    }
+
+  implicit val cogCreateCustomMask: Cogen[GmosModel.CreateCustomMask] =
+    Cogen[(
+      String,
+      GmosCustomSlitWidth
+    )].contramap { in =>
+      (
+        in.filename,
+        in.slitWidth
+      )
+    }
+
+  implicit def arbGrating[D: Arbitrary]: Arbitrary[GmosModel.Grating[D]] =
+    Arbitrary {
+      for {
+        d <- arbitrary[D]
+        o <- arbitrary[GmosDisperserOrder]
+        w <- arbitrary[Wavelength]
+      } yield GmosModel.Grating(d, o, w)
+    }
+
+  implicit def cogGrating[D: Cogen]: Cogen[GmosModel.Grating[D]] =
+    Cogen[(
+      D,
+      GmosDisperserOrder,
+      Wavelength
+    )].contramap { in =>
+      (
+        in.disperser,
+        in.order,
+        in.wavelength
+      )
+    }
+
+  implicit def arbCreateGrating[D: Arbitrary]: Arbitrary[GmosModel.CreateGrating[D]] =
+    Arbitrary {
+      for {
+        d <- arbitrary[D]
+        o <- arbitrary[GmosDisperserOrder]
+        w <- arbitrary[WavelengthModel.Input]
+      } yield GmosModel.CreateGrating(d, o, w)
+    }
+
+  implicit def cogCreateGrating[D: Cogen]: Cogen[GmosModel.CreateGrating[D]] =
+    Cogen[(
+      D,
+      GmosDisperserOrder,
+      WavelengthModel.Input
+    )].contramap { in =>
+      (
+        in.disperser,
+        in.order,
+        in.wavelength
+      )
+    }
+
+  implicit val arbNorthDynamic: Arbitrary[GmosModel.NorthDynamic] =
+    Arbitrary {
+      for {
+        c <- arbitrary[GmosModel.CommonDynamic]
+        g <- arbitrary[Option[GmosModel.Grating[GmosNorthDisperser]]]
+        f <- arbitrary[Option[GmosNorthFilter]]
+        u <- arbitrary[Option[Either[GmosModel.CustomMask, GmosNorthFpu]]]
+      } yield GmosModel.NorthDynamic(c, g, f, u)
+    }
+
+  implicit val cogNorthDynamic: Cogen[GmosModel.NorthDynamic] =
+    Cogen[(
+      GmosModel.CommonDynamic,
+      Option[GmosModel.Grating[GmosNorthDisperser]],
+      Option[GmosNorthFilter],
+      Option[Either[GmosModel.CustomMask, GmosNorthFpu]]
+    )].contramap { in =>
+      (
+        in.common,
+        in.grating,
+        in.filter,
+        in.fpu
+      )
+    }
+
+  implicit val arbCreateNorthDynamic: Arbitrary[GmosModel.CreateNorthDynamic] =
+    Arbitrary {
+      for {
+        c <- arbitrary[GmosModel.CreateCommonDynamic]
+        g <- arbitrary[Option[GmosModel.CreateGrating[GmosNorthDisperser]]]
+        f <- arbitrary[Option[GmosNorthFilter]]
+        u <- arbitrary[Option[Either[GmosModel.CreateCustomMask, GmosNorthFpu]]]
+      } yield GmosModel.CreateNorthDynamic(c, g, f, u)
+    }
+
+  implicit val cogCreateNorthDynamic: Cogen[GmosModel.CreateNorthDynamic] =
+    Cogen[(
+      GmosModel.CreateCommonDynamic,
+      Option[GmosModel.CreateGrating[GmosNorthDisperser]],
+      Option[GmosNorthFilter],
+      Option[Either[GmosModel.CreateCustomMask, GmosNorthFpu]]
+    )].contramap { in =>
+      (
+        in.common,
+        in.grating,
+        in.filter,
+        in.fpu
+      )
+    }
+
+  implicit val arbSouthDynamic: Arbitrary[GmosModel.SouthDynamic] =
+    Arbitrary {
+      for {
+        c <- arbitrary[GmosModel.CommonDynamic]
+        g <- arbitrary[Option[GmosModel.Grating[GmosSouthDisperser]]]
+        f <- arbitrary[Option[GmosSouthFilter]]
+        u <- arbitrary[Option[Either[GmosModel.CustomMask, GmosSouthFpu]]]
+      } yield GmosModel.SouthDynamic(c, g, f, u)
+    }
+
+  implicit val cogSouthDynamic: Cogen[GmosModel.SouthDynamic] =
+    Cogen[(
+      GmosModel.CommonDynamic,
+      Option[GmosModel.Grating[GmosSouthDisperser]],
+      Option[GmosSouthFilter],
+      Option[Either[GmosModel.CustomMask, GmosSouthFpu]]
+    )].contramap { in =>
+      (
+        in.common,
+        in.grating,
+        in.filter,
+        in.fpu
+      )
+    }
+
+  implicit val arbCreateSouthDynamic: Arbitrary[GmosModel.CreateSouthDynamic] =
+    Arbitrary {
+      for {
+        c <- arbitrary[GmosModel.CreateCommonDynamic]
+        g <- arbitrary[Option[GmosModel.CreateGrating[GmosSouthDisperser]]]
+        f <- arbitrary[Option[GmosSouthFilter]]
+        u <- arbitrary[Option[Either[GmosModel.CreateCustomMask, GmosSouthFpu]]]
+      } yield GmosModel.CreateSouthDynamic(c, g, f, u)
+    }
+
+  implicit val cogCreateSouthDynamic: Cogen[GmosModel.CreateSouthDynamic] =
+    Cogen[(
+      GmosModel.CreateCommonDynamic,
+      Option[GmosModel.CreateGrating[GmosSouthDisperser]],
+      Option[GmosSouthFilter],
+      Option[Either[GmosModel.CreateCustomMask, GmosSouthFpu]]
+    )].contramap { in =>
+      (
+        in.common,
+        in.grating,
+        in.filter,
+        in.fpu
+      )
+    }
+
+  implicit val arbNorth: Arbitrary[GmosModel.North] =
+    Arbitrary {
+      for {
+        st <- arbitrary[GmosModel.NorthStatic]
+        aq <- arbitrary[List[StepModel[GmosModel.NorthDynamic]]]
+        sc <- arbitrary[List[StepModel[GmosModel.NorthDynamic]]]
+      } yield GmosModel.North(st, aq, sc)
+    }
+
+  implicit val cogNorth: Cogen[GmosModel.North] =
+    Cogen[(
+      GmosModel.NorthStatic,
+      List[StepModel[GmosModel.NorthDynamic]],
+      List[StepModel[GmosModel.NorthDynamic]]
+    )].contramap { in => (
+      in.static,
+      in.acquisition,
+      in.science
+    )}
+
+  implicit val arbCreateNorth: Arbitrary[GmosModel.CreateNorth] =
+    Arbitrary {
+      for {
+        st <- arbitrary[GmosModel.CreateNorthStatic]
+        aq <- arbitrary[List[StepModel.CreateStep[GmosModel.CreateNorthDynamic]]]
+        sc <- arbitrary[List[StepModel.CreateStep[GmosModel.CreateNorthDynamic]]]
+      } yield GmosModel.CreateNorth(st, aq, sc)
+    }
+
+  implicit val cogCreateNorth: Cogen[GmosModel.CreateNorth] =
+    Cogen[(
+      GmosModel.CreateNorthStatic,
+      List[StepModel.CreateStep[GmosModel.CreateNorthDynamic]],
+      List[StepModel.CreateStep[GmosModel.CreateNorthDynamic]]
+    )].contramap { in => (
+      in.static,
+      in.acquisition,
+      in.science
+    )}
+
+  implicit val arbSouth: Arbitrary[GmosModel.South] =
+    Arbitrary {
+      for {
+        st <- arbitrary[GmosModel.SouthStatic]
+        aq <- arbitrary[List[StepModel[GmosModel.SouthDynamic]]]
+        sc <- arbitrary[List[StepModel[GmosModel.SouthDynamic]]]
+      } yield GmosModel.South(st, aq, sc)
+    }
+
+  implicit val cogSouth: Cogen[GmosModel.South] =
+    Cogen[(
+      GmosModel.SouthStatic,
+      List[StepModel[GmosModel.SouthDynamic]],
+      List[StepModel[GmosModel.SouthDynamic]]
+    )].contramap { in => (
+      in.static,
+      in.acquisition,
+      in.science
+    )}
+
+  implicit val arbCreateSouth: Arbitrary[GmosModel.CreateSouth] =
+    Arbitrary {
+      for {
+        st <- arbitrary[GmosModel.CreateSouthStatic]
+        aq <- arbitrary[List[StepModel.CreateStep[GmosModel.CreateSouthDynamic]]]
+        sc <- arbitrary[List[StepModel.CreateStep[GmosModel.CreateSouthDynamic]]]
+      } yield GmosModel.CreateSouth(st, aq, sc)
+    }
+
+  implicit val cogCreateSouth: Cogen[GmosModel.CreateSouth] =
+    Cogen[(
+      GmosModel.CreateSouthStatic,
+      List[StepModel.CreateStep[GmosModel.CreateSouthDynamic]],
+      List[StepModel.CreateStep[GmosModel.CreateSouthDynamic]]
+    )].contramap { in => (
+      in.static,
+      in.acquisition,
+      in.science
+    )}
+
+
+}
+
+object ArbGmosModel extends ArbGmosModel

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbManualSequence.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbManualSequence.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+package arb
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
+
+trait ArbManualSequence {
+
+  import ArbStepModel._
+
+  implicit def arbManualSequence[S: Arbitrary, D: Arbitrary]: Arbitrary[ManualSequence[S, D]] =
+    Arbitrary {
+      for {
+        st <- arbitrary[S]
+        aq <- arbitrary[List[StepModel[D]]]
+        sc <- arbitrary[List[StepModel[D]]]
+      } yield ManualSequence(st, aq, sc)
+    }
+
+  implicit def cogManualSequence[S: Cogen, D: Cogen]: Cogen[ManualSequence[S, D]] =
+    Cogen[(
+      S,
+      List[StepModel[D]],
+      List[StepModel[D]]
+    )].contramap { in => (
+      in.static,
+      in.acquisition,
+      in.science
+    )}
+
+  implicit def arbCreateManualSequence[S: Arbitrary, D: Arbitrary]: Arbitrary[ManualSequence.Create[S, D]] =
+    Arbitrary {
+      for {
+        st <- arbitrary[S]
+        aq <- arbitrary[List[StepModel.CreateStep[D]]]
+        sc <- arbitrary[List[StepModel.CreateStep[D]]]
+      } yield ManualSequence.Create(st, aq, sc)
+    }
+
+  implicit def cogCreateManualSequence[S: Cogen, D: Cogen]: Cogen[ManualSequence.Create[S, D]] =
+    Cogen[(
+      S,
+      List[StepModel.CreateStep[D]],
+      List[StepModel.CreateStep[D]]
+    )].contramap { in => (
+      in.static,
+      in.acquisition,
+      in.science
+    )}
+
+}
+
+object ArbManualSequence extends ArbManualSequence

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbOffsetModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbOffsetModel.scala
@@ -1,0 +1,88 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+package arb
+
+import NumericUnits.{DecimalInput, LongInput}
+import OffsetModel.{ComponentInput, Input, Units}
+import lucuma.core.math.{Angle, Offset}
+import lucuma.core.util.arb.ArbEnumerated
+import lucuma.core.math.arb.ArbOffset
+import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
+
+
+trait ArbOffsetModel {
+
+  import ArbEnumerated._
+  import ArbOffset._
+  import GenNumericUnitsInput._
+
+  private[this] def microarcseconds: Gen[Long] =
+    arbitrary[Offset.Component[Unit]].map(c => Angle.signedMicroarcseconds.get(c.toAngle))
+
+  private[this] def milliseconds: Gen[BigDecimal] =
+    arbitrary[Offset.Component[Unit]].map(c => Angle.signedDecimalMilliarcseconds.get(c.toAngle))
+
+  private[this] def arcseconds: Gen[BigDecimal] =
+    arbitrary[Offset.Component[Unit]].map(c => Angle.signedDecimalArcseconds.get(c.toAngle))
+
+  val genOffsetComponentInputFromLong: Gen[ComponentInput] =
+    Gen.oneOf(
+      genLongInput(microarcseconds, Units.microarcseconds),
+      genLongInput(milliseconds, Units.milliarcseconds),
+      genLongInput(arcseconds, Units.arcseconds),
+    ).map(ComponentInput.fromLong)
+
+  val genOffsetComponentInputFromDecimal: Gen[ComponentInput] =
+    Gen.oneOf(
+      genDecimalInput(microarcseconds, Units.microarcseconds),
+      genDecimalInput(milliseconds, Units.milliarcseconds),
+      genDecimalInput(arcseconds, Units.arcseconds),
+    ).map(ComponentInput.fromDecimal)
+
+  implicit val arbOffsetComponentInput: Arbitrary[ComponentInput] =
+    Arbitrary {
+      Gen.oneOf(
+        microarcseconds.map(ComponentInput.fromMicroarcseconds),
+        milliseconds.map(ComponentInput.fromMilliarcseconds),
+        arcseconds.map(ComponentInput.fromArcseconds),
+        genOffsetComponentInputFromLong,
+        genOffsetComponentInputFromDecimal
+      )
+    }
+
+  implicit val cogOffsetComponentInput: Cogen[ComponentInput] =
+    Cogen[(
+      Option[Long],
+      Option[BigDecimal],
+      Option[BigDecimal],
+      Option[LongInput[Units]],
+      Option[DecimalInput[Units]]
+    )].contramap { in =>
+      (
+        in.microarcseconds,
+        in.milliarcseconds,
+        in.arcseconds,
+        in.fromLong,
+        in.fromDecimal
+      )
+    }
+
+  implicit val arbOffsetModelInput: Arbitrary[Input] =
+    Arbitrary {
+      for {
+        p <- arbitrary[ComponentInput]
+        q <- arbitrary[ComponentInput]
+      } yield Input(p, q)
+    }
+
+  implicit val cogOffsetModelInput: Cogen[Input] =
+    Cogen[(ComponentInput, ComponentInput)].contramap { in =>
+      (in.p, in.q)
+    }
+
+}
+
+object ArbOffsetModel extends ArbOffsetModel

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbStepModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbStepModel.scala
@@ -1,0 +1,117 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+package arb
+
+import lucuma.core.math.Offset
+import lucuma.core.math.arb.ArbOffset
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
+
+trait ArbStepModel {
+
+  import ArbOffset._
+  import ArbOffsetModel._
+
+  implicit def arbBias[A: Arbitrary]: Arbitrary[StepModel.Bias[A]] =
+    Arbitrary {
+      arbitrary[A].map(StepModel.Bias(_))
+    }
+
+  implicit def cogBias[A: Cogen]: Cogen[StepModel.Bias[A]] =
+    Cogen[A].contramap(_.dynamicConfig)
+
+  implicit def arbDark[A: Arbitrary]: Arbitrary[StepModel.Dark[A]] =
+    Arbitrary {
+      arbitrary[A].map(StepModel.Dark(_))
+    }
+
+  implicit def cogDark[A: Cogen]: Cogen[StepModel.Dark[A]] =
+    Cogen[A].contramap(_.dynamicConfig)
+
+  implicit def arbScience[A: Arbitrary]: Arbitrary[StepModel.Science[A]] =
+    Arbitrary {
+      for {
+        a <- arbitrary[A]
+        o <- arbitrary[Offset]
+      } yield StepModel.Science(a, o)
+    }
+
+  implicit def cogScience[A: Cogen]: Cogen[StepModel.Science[A]] =
+    Cogen[(A, Offset)].contramap { in => (
+      in.dynamicConfig,
+      in.offset
+    )}
+
+  implicit def arbStep[A: Arbitrary]: Arbitrary[StepModel[A]] =
+    Arbitrary {
+      Gen.oneOf(
+        arbitrary[StepModel.Bias[A]],
+        arbitrary[StepModel.Dark[A]],
+        arbitrary[StepModel.Science[A]]
+      )
+    }
+
+  implicit def cogStep[A: Cogen]: Cogen[StepModel[A]] =
+    Cogen[(
+      Option[StepModel.Bias[A]],
+      Option[StepModel.Dark[A]],
+      Option[StepModel.Science[A]]
+    )].contramap { in => (in.bias, in.dark, in.science) }
+
+
+  implicit def arbCreateBias[A: Arbitrary]: Arbitrary[StepModel.CreateBias[A]] =
+    Arbitrary {
+      arbitrary[A].map(StepModel.CreateBias(_))
+    }
+
+  implicit def cogCreateBias[A: Cogen]: Cogen[StepModel.CreateBias[A]] =
+    Cogen[A].contramap(_.config)
+
+  implicit def arbCreateDark[A: Arbitrary]: Arbitrary[StepModel.CreateDark[A]] =
+    Arbitrary {
+      arbitrary[A].map(StepModel.CreateDark(_))
+    }
+
+  implicit def cogCreateDark[A: Cogen]: Cogen[StepModel.CreateDark[A]] =
+    Cogen[A].contramap(_.config)
+
+  implicit def arbCreateScience[A: Arbitrary]: Arbitrary[StepModel.CreateScience[A]] =
+    Arbitrary {
+      for {
+        a <- arbitrary[A]
+        o <- arbitrary[OffsetModel.Input]
+      } yield StepModel.CreateScience(a, o)
+    }
+
+  implicit def cogCreateScience[A: Cogen]: Cogen[StepModel.CreateScience[A]] =
+    Cogen[(A, OffsetModel.Input)].contramap { in => (
+      in.config,
+      in.offset
+    )}
+
+  implicit def arbCreateStep[A: Arbitrary]: Arbitrary[StepModel.CreateStep[A]] =
+    Arbitrary {
+      Gen.oneOf(
+        arbitrary[StepModel.CreateBias[A]].map(   b => StepModel.CreateStep(Some(b), None, None)),
+        arbitrary[StepModel.CreateDark[A]].map(   d => StepModel.CreateStep(None, Some(d), None)),
+        arbitrary[StepModel.CreateScience[A]].map(s => StepModel.CreateStep(None, None, Some(s)))
+      )
+    }
+
+  implicit def cogCreateStep[A: Cogen]: Cogen[StepModel.CreateStep[A]] =
+    Cogen[(
+      Option[StepModel.CreateBias[A]],
+      Option[StepModel.CreateDark[A]],
+      Option[StepModel.CreateScience[A]]
+    )].contramap { in => (
+      in.bias,
+      in.dark,
+      in.science
+    )}
+
+}
+
+object ArbStepModel extends ArbStepModel

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbWavelengthModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbWavelengthModel.scala
@@ -1,0 +1,84 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+package arb
+
+import WavelengthModel.{Input, Units}
+import NumericUnits.{LongInput, DecimalInput}
+
+import lucuma.core.util.arb.ArbEnumerated
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
+
+
+trait ArbWavelengthModel {
+
+  import ArbEnumerated._
+  import GenNumericUnitsInput._
+
+  private[this] val picometers: Gen[Long] =
+    arbitrary[Int].map(_.toLong)
+
+  private[this] val angstroms: Gen[BigDecimal] =
+    picometers.map(n => BigDecimal(n)/100)
+
+  private[this] val nanometers: Gen[BigDecimal] =
+    angstroms.map(_/10)
+
+  private[this] val micrometers: Gen[BigDecimal] =
+    nanometers.map(_/1000)
+
+  val genWavelengthModelInputFromLong: Gen[Input] =
+    Gen.oneOf(
+      genLongInput(picometers,  Units.picometers),
+      genLongInput(angstroms,   Units.angstroms),
+      genLongInput(nanometers,  Units.nanometers),
+      genLongInput(micrometers, Units.micrometers)
+    ).map(Input.fromLong)
+
+  val genWavelengthModelInputFromDecimal: Gen[Input] =
+    Gen.oneOf(
+      genDecimalInput(picometers,  Units.picometers),
+      genDecimalInput(angstroms,   Units.angstroms),
+      genDecimalInput(nanometers,  Units.nanometers),
+      genDecimalInput(micrometers, Units.micrometers)
+    ).map(Input.fromDecimal)
+
+  implicit val arbWavelengthModelInput: Arbitrary[WavelengthModel.Input] =
+    Arbitrary {
+      Gen.oneOf(
+        picometers.map(Input.fromPicometers),
+        angstroms.map(Input.fromAngstroms),
+        nanometers.map(Input.fromNanometers),
+        micrometers.map(Input.fromMicrometers),
+        genWavelengthModelInputFromLong,
+        genWavelengthModelInputFromDecimal
+      )
+    }
+
+  implicit val cogWavelengthModelInput: Cogen[WavelengthModel.Input] =
+    Cogen[(
+      Option[Long],       // pm
+      Option[BigDecimal], // A
+      Option[BigDecimal], // nm
+      Option[BigDecimal], // µm
+      Option[LongInput[Units]],
+      Option[DecimalInput[Units]]
+    )].contramap { in =>
+      (
+        in.picometers,
+        in.angstroms,
+        in.nanometers,
+        in.micrometers,
+        in.fromLong,
+        in.fromDecimal
+      )
+    }
+
+}
+
+object ArbWavelengthModel extends ArbWavelengthModel
+
+

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -105,7 +105,8 @@ object Init {
                 p.id,
                 Some("First Observation"),
                 Some(a0.id),
-                Some(ObsStatus.New)
+                Some(ObsStatus.New),
+                None
               )
             )
     } yield ()


### PR DESCRIPTION
Adds basic GMOS (North and South) static and dynamic configuration (filters, dispersers, etc.) along with a subset of sequence steps.  This has not yet been tied into the GraphQL schema.  There is no editing support (only initial creation).

In most cases you will see (a) simple model class that holds the data and (b) a `Create` class that will be used as a GraphQL input parameter.  The input parameter is similar in structure but holds different values.  For example whereas a wavelength is a single value a wavelength input has options in various units.

* Low-level input types introduced here are: `FiniteDurationModel`, `OffsetModel`, `WavelengthModel`.
* GMOS-specific definition in `GmosModel`
* Sequence definition in: `ConfigModel`, `StepModel`, `ManualSequence`.
* `ObservationModel` connects to all of this via a new `config` parameter.
* `InputValidator` is probably sketchy.  Comments welcome.
