### PR TITLE
Handle graph QL protocol-level reinitialization

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/api/service/Routes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Routes.scala
@@ -148,7 +148,7 @@ object Routes {
                )
 
              case Close(_)   =>
-               connection.receive(FromClient.ConnectionTerminate)
+               connection.close
 
              case f          =>
                M.raiseError[Unit](new RuntimeException(s"Expected a Text WebSocketFrame from Client, but got $f"))

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Subscriptions.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Subscriptions.scala
@@ -41,7 +41,7 @@ trait Subscriptions[F[_]] {
   /**
    * Removes all subscriptions.
    */
-  def terminate: F[Unit]
+  def removeAll: F[Unit]
 
 }
 
@@ -107,7 +107,7 @@ object Subscriptions {
             _ <- m.get(id).fold(().pure[F])(s => s.stop *> send(Some(Complete(s.id))))
           } yield ()
 
-        override def terminate: F[Unit] =
+        override def removeAll: F[Unit] =
           for {
             m <- subscriptions.getAndSet(Map.empty[String, Subscription[F]])
             _ <- m.values.toList.traverse_(s => s.stop *> send(Some(Complete(s.id))))


### PR DESCRIPTION
This PR purports to handle reinitialization without requiring a new web socket connection.  Fair warning, it will require some testing and may not in fact, um, work.