### PR TITLE
Creation Payload

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/schema/AsterismMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/AsterismMutation.scala
@@ -7,7 +7,6 @@ import lucuma.odb.api.model.AsterismModel
 import lucuma.odb.api.repo.OdbRepo
 
 import cats.effect.Effect
-import cats.syntax.all._
 
 import sangria.macros.derive._
 import sangria.marshalling.circe._
@@ -60,7 +59,7 @@ trait AsterismMutation extends TargetScalars {
       arguments = List(ArgumentAsterismCreate),
       resolve   = c =>
         c.asterism(
-          _.insert(c.arg(ArgumentAsterismCreate)).map(_.toEither)
+          _.insert(c.arg(ArgumentAsterismCreate))
         )
     )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetMutation.scala
@@ -9,7 +9,6 @@ import lucuma.odb.api.repo.OdbRepo
 import lucuma.odb.api.schema.syntax.inputtype._
 
 import cats.effect.Effect
-import cats.syntax.all._
 
 import sangria.macros.derive._
 import sangria.marshalling.circe._
@@ -85,7 +84,7 @@ trait ConstraintSetMutation {
       arguments = List(ArgumentConstraintSetCreate),
       resolve   = c =>
         c.constraintSet(
-          _.insert(c.arg(ArgumentConstraintSetCreate)).map(_.toEither)
+          _.insert(c.arg(ArgumentConstraintSetCreate))
         )
     )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetMutation.scala
@@ -9,6 +9,8 @@ import lucuma.odb.api.repo.OdbRepo
 import lucuma.odb.api.schema.syntax.inputtype._
 
 import cats.effect.Effect
+import cats.syntax.all._
+
 import sangria.macros.derive._
 import sangria.marshalling.circe._
 import sangria.schema._
@@ -18,6 +20,7 @@ trait ConstraintSetMutation {
 
   import GeneralSchema.EnumTypeExistence
   import ConstraintSetSchema._
+  import MutationSchema._
   import ProgramSchema.ProgramIdType
   import context._
   import syntax.inputobjecttype._
@@ -78,9 +81,12 @@ trait ConstraintSetMutation {
   def create[F[_]: Effect]: Field[OdbRepo[F], Unit] =
     Field(
       name      = "createConstraintSet",
-      fieldType = OptionType(ConstraintSetType[F]),
+      fieldType = SimpleCreatePayloadUnionType[F, ConstraintSetModel]("constraintSet", ConstraintSetType[F]),
       arguments = List(ArgumentConstraintSetCreate),
-      resolve   = c => c.constraintSet(_.insert(c.arg(ArgumentConstraintSetCreate)))
+      resolve   = c =>
+        c.constraintSet(
+          _.insert(c.arg(ArgumentConstraintSetCreate)).map(_.toEither)
+        )
     )
 
   def update[F[_]: Effect]: Field[OdbRepo[F], Unit] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/MutationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/MutationSchema.scala
@@ -3,9 +3,9 @@
 
 package lucuma.odb.api.schema
 
-import lucuma.odb.api.model.InputError
+import lucuma.odb.api.model.{InputError, ValidatedInput}
 import lucuma.odb.api.repo.OdbRepo
-import cats.data.{Chain, NonEmptyChain}
+import cats.data.Chain
 import cats.effect.Effect
 import sangria.schema._
 
@@ -67,13 +67,13 @@ object MutationSchema {
   def SimpleCreatePayloadUnionType[F[_]: Effect, T: ClassTag](
     name:       String,
     resultType: ObjectType[OdbRepo[F], T]
-  ): OutputType[Either[NonEmptyChain[InputError], T]] =
+  ): OutputType[ValidatedInput[T]] =
 
     UnionType(
       name        = s"Create${name.capitalize}Payload",
       description = Some(s"Result of calling create${name.capitalize}"),
       types       = List(SimpleCreateSuccessType[F, T](name, resultType), InputErrorType[F])
-    ).mapValue[Either[NonEmptyChain[InputError], T]](
+    ).mapValue[ValidatedInput[T]](
       _.fold(
         nec => nec: Any,
         suc => suc: Any

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/MutationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/MutationSchema.scala
@@ -1,0 +1,83 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.schema
+
+import lucuma.odb.api.model.InputError
+import lucuma.odb.api.repo.OdbRepo
+import cats.data.{Chain, NonEmptyChain}
+import cats.effect.Effect
+import sangria.schema._
+
+import scala.reflect.ClassTag
+
+
+object MutationSchema {
+
+  // We could create typed errors like "MissingReference" for each specific
+  // case which would allow a script writer to handle the issues more easily.
+  // As is, InputErrors just has a list of String messages
+
+  /**
+   * A generic input error type with a String "messages" list.
+   */
+  def InputErrorType[F[_]]: ObjectType[OdbRepo[F], Chain[InputError]] =
+    ObjectType(
+      name = "InputErrors",
+      fieldsFn = () => fields(
+
+        Field(
+          name        = "messages",
+          fieldType   = ListType(StringType),
+          description = Some("Errors in the input to a mutation"),
+          resolve     = _.value.map(_.message).toList
+        )
+      )
+
+    )
+
+  // If we want to add more information to a success payload, it would need
+  // to become specific to the individual case. The type created by this method
+  // simply has an appropriately named field (e.g., "observation") that
+  // contains the object that was created.
+
+  /**
+   * A success payload type that simply wraps the created object.
+   */
+  def SimpleCreateSuccessType[F[_]: Effect, T: ClassTag](
+    name:       String,
+    resultType: ObjectType[OdbRepo[F], T]
+  ): ObjectType[OdbRepo[F], T] =
+
+    ObjectType(
+      name = s"Create${name.capitalize}Success",
+      fieldsFn = () => fields(
+        Field(
+          name        = name,
+          fieldType   = resultType,
+          description = Some(s"The new $name that was successfully created."),
+          resolve     = _.value
+        )
+      )
+    )
+
+  /**
+   * Create payload type that is either an input error or else a success.
+   */
+  def SimpleCreatePayloadUnionType[F[_]: Effect, T: ClassTag](
+    name:       String,
+    resultType: ObjectType[OdbRepo[F], T]
+  ): OutputType[Either[NonEmptyChain[InputError], T]] =
+
+    UnionType(
+      name        = s"Create${name.capitalize}Payload",
+      description = Some(s"Result of calling create${name.capitalize}"),
+      types       = List(SimpleCreateSuccessType[F, T](name, resultType), InputErrorType[F])
+    ).mapValue[Either[NonEmptyChain[InputError], T]](
+      _.fold(
+        nec => nec: Any,
+        suc => suc: Any
+      )
+    )
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -9,7 +9,6 @@ import lucuma.odb.api.repo.OdbRepo
 import lucuma.odb.api.schema.syntax.inputtype._
 
 import cats.effect.Effect
-import cats.syntax.all._
 
 import sangria.macros.derive._
 import sangria.marshalling.circe._
@@ -63,7 +62,7 @@ trait ObservationMutation {
       arguments = List(ArgumentObservationCreate),
       resolve   = c =>
         c.observation(
-          _.insert(c.arg(ArgumentObservationCreate)).map(_.toEither)
+          _.insert(c.arg(ArgumentObservationCreate))
         )
     )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
@@ -9,7 +9,6 @@ import lucuma.odb.api.schema.syntax.`enum`._
 import lucuma.core.`enum`.MagnitudeSystem
 
 import cats.effect.Effect
-import cats.syntax.all._
 
 import sangria.macros.derive._
 import sangria.marshalling.circe._
@@ -177,7 +176,7 @@ trait TargetMutation extends TargetScalars {
       arguments = List(ArgumentTargetCreateNonsidereal),
       resolve   = c =>
         c.target(
-          _.insertNonsidereal(c.arg(ArgumentTargetCreateNonsidereal)).map(_.toEither)
+          _.insertNonsidereal(c.arg(ArgumentTargetCreateNonsidereal))
         )
     )
 
@@ -188,7 +187,7 @@ trait TargetMutation extends TargetScalars {
       arguments = List(ArgumentTargetCreateSidereal),
       resolve   = c =>
         c.target(
-          _.insertSidereal(c.arg(ArgumentTargetCreateSidereal)).map(_.toEither)
+          _.insertSidereal(c.arg(ArgumentTargetCreateSidereal))
         )
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -302,20 +302,20 @@ object Init {
    */
   def initialize[F[_]: Sync: Applicative](repo: OdbRepo[F]): F[Unit] =
     for {
-      p  <- repo.program.insert(
+      p  <- repo.program.unsafeInsert(
               ProgramModel.Create(
                 None,
                 Some("The real dark matter was the friends we made along the way")
               )
             )
-      _  <- repo.program.insert(
+      _  <- repo.program.unsafeInsert(
               ProgramModel.Create(
                 None,
                 Some("An Empty Placeholder Program")
               )
             )
       cs <- targets.liftTo[F]
-      ts <- cs.map(_.copy(programIds = Some(List(p.id)))).traverse(repo.target.insertSidereal)
+      ts <- cs.map(_.copy(programIds = Some(List(p.id)))).traverse(repo.target.unsafeInsertSidereal)
 //      a0 <- repo.asterism.insert(
 //              AsterismModel.Create(
 //                None,


### PR DESCRIPTION
Introduces a `Payload` type for the object creation mutations.  The idea is to make it easier to evolve the API by nesting the result of a mutation, in this case creation of objects, in a containing object.  The `Payload` types are unions of a successful result or an `InputError`.  For example:

```
mutation CreateObservation($createObservation: CreateObservationInput!) {
  createObservation(input: $createObservation) {
    ... on CreateObservationSuccess {
      observation {
        name
        id
      }
    }
    ... on InputErrors {
      messages
    }
  }
}
```

As you can see this raises some errors to the level of the schema itself.  In particular problems with the input that validate according to the schema but are nonetheless illegal.  For example, references to objects that don't exist or, say, an observation associated with _both_ an asterism and a target.

I'm convinced by the `Payload` concept but on the fence about the error stuff.  Comments very welcome.  If merged, the remaining mutations would get their own `Payload` result types.