### PR TITLE
Allows for unsetting the constraint set to observation link

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
@@ -3,13 +3,16 @@
 
 package lucuma.odb.api.repo
 
-import lucuma.odb.api.model.{ObservationModel, PlannedTimeSummaryModel}
+import lucuma.odb.api.model.{InputError, ObservationModel, PlannedTimeSummaryModel}
+import lucuma.odb.api.model.syntax.validatedinput._
 import lucuma.core.model.{Asterism, ConstraintSet, Observation, Program, Target}
 import lucuma.odb.api.model.ObservationModel.ObservationEvent
+import cats.MonadError
 import cats.effect.Sync
 import cats.effect.concurrent.Ref
 import cats.implicits._
 import lucuma.odb.api.model.ConstraintSetModel
+import monocle.Lens
 
 sealed trait ObservationRepo[F[_]] extends TopLevelRepo[F, Observation.Id, ObservationModel] {
 
@@ -48,6 +51,8 @@ sealed trait ObservationRepo[F[_]] extends TopLevelRepo[F, Observation.Id, Obser
   def shareWithConstraintSet(oid: Observation.Id, csid: ConstraintSet.Id): F[ObservationModel]
 
   def unshareWithConstraintSet(oid: Observation.Id, csid: ConstraintSet.Id): F[ObservationModel]
+
+  def unsetConstraintSet(oid: Observation.Id)(implicit F: MonadError[F, Throwable]): F[ObservationModel]
 }
 
 object ObservationRepo {
@@ -154,5 +159,31 @@ object ObservationRepo {
           Tables.constraintSetObservation,
           ConstraintSetModel.ConstraintSetEvent.updated
         )
+
+      override def unsetConstraintSet(oid: Observation.Id)(implicit F: MonadError[F, Throwable]): F[ObservationModel] = {
+        val focusObsLens = focusOn(oid)
+
+        val obsLens: Lens[Tables, Option[ObservationModel]] =
+          Lens[Tables, Option[ObservationModel]](focusObsLens.get)(oo => focusObsLens.set(oo))
+
+
+        val doUpdate: F[(ObservationModel, Option[ConstraintSetModel])] = 
+          tablesRef.modify { oldTables => 
+            val obs = obsLens.get(oldTables).toValidNec(InputError.missingReference("id", oid.show))
+            val cs  = 
+              obs.fold(
+                _ => None,
+                o => oldTables.constraintSetObservation.selectLeft(o.id).flatMap(csId => Tables.constraintSet(csId).get(oldTables))
+              )
+            val tables = cs.fold(oldTables)(_ => Tables.constraintSetObservation.modify(_.removeRight(oid))(oldTables))
+            (tables, obs.map(o => (o, cs)))
+          }.flatMap(_.liftTo[F])
+          
+          for {
+            t         <- doUpdate
+            (obs, cs)  = t
+            _         <- cs.fold(F.unit)(c => eventService.publish(ConstraintSetModel.ConstraintSetEvent.updated(c)))
+          } yield obs
+      }
     }
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetMutation.scala
@@ -93,7 +93,7 @@ trait ConstraintSetMutation {
 
   def delete[F[_]: Effect]: Field[OdbRepo[F], Unit] =
     Field(
-      name      = "deleteContraintSet",
+      name      = "deleteConstraintSet",
       fieldType = ConstraintSetType[F],
       arguments = List(ConstraintSetIdArgument),
       resolve   = c => c.constraintSet(_.delete(c.constraintSetId))

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -85,12 +85,21 @@ trait ObservationMutation {
       resolve   = c => c.observation(_.undelete(c.observationId))
     )
 
+  def unsetConstraintSet[F[_]: Effect]: Field[OdbRepo[F], Unit] =
+    Field(
+      name      = "unsetConstraintSet",
+      fieldType = ObservationType[F],
+      arguments = List(ObservationIdArgument),
+      resolve   = c => c.observation(_.unsetConstraintSet(c.observationId))
+    )
+
   def allFields[F[_]: Effect]: List[Field[OdbRepo[F], Unit]] =
     List(
       create,
       update,
       delete,
-      undelete
+      undelete,
+      unsetConstraintSet
     )
 
 }


### PR DESCRIPTION
This is a temporary fix to make the constraint set UI work until the `observation`  <-> `pointing` api revamp has been completed (#186). At that point the API for `observation` <-> `constraint` set will  be reworked to match.