### PR TITLE
Nonempty string scalar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,7 @@ lazy val core = project
       "io.circe"                   %% "circe-parser"              % circeVersion,
       "io.circe"                   %% "circe-generic"             % circeVersion,
       "io.circe"                   %% "circe-generic-extras"      % circeVersion,
+      "io.circe"                   %% "circe-refined"             % circeVersion,
       "org.typelevel"              %% "jawn-parser"               % jawnVersion,
       "org.typelevel"              %% "log4cats-slf4j"            % log4catsVersion,
       "ch.qos.logback"             %  "logback-classic"           % logbackVersion,

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ConstraintSetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ConstraintSetModel.scala
@@ -10,6 +10,7 @@ import clue.data.Input
 import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Decoder
 import io.circe.generic.semiauto._
+import io.circe.refined._
 import lucuma.core.enum._
 import lucuma.core.model.{ ConstraintSet, Program }
 import lucuma.core.optics.syntax.lens._
@@ -40,7 +41,7 @@ object ConstraintSetModel extends ConstraintSetModelOptics {
   final case class Create(
     constraintSetId: Option[ConstraintSet.Id],
     programId:       Program.Id,
-    name:            String,
+    name:            NonEmptyString,
     imageQuality:    ImageQuality,
     cloudExtinction: CloudExtinction,
     skyBackground:   SkyBackground,
@@ -49,11 +50,11 @@ object ConstraintSetModel extends ConstraintSetModelOptics {
   ) {
 
     def withId: ValidatedInput[ConstraintSet.Id => ConstraintSetModel] =
-      (ValidatedInput.nonEmptyString("name", name), elevationRange.create).mapN { (n, er) => csid =>
+      elevationRange.create.map { er => csid =>
         ConstraintSetModel(csid,
                            Present,
                            programId,
-                           n,
+                           name,
                            imageQuality,
                            cloudExtinction,
                            skyBackground,
@@ -73,7 +74,7 @@ object ConstraintSetModel extends ConstraintSetModelOptics {
   final case class Edit(
     constraintSetId: ConstraintSet.Id,
     existence:       Input[Existence] = Input.ignore,
-    name:            Input[String] = Input.ignore,
+    name:            Input[NonEmptyString] = Input.ignore,
     imageQuality:    Input[ImageQuality] = Input.ignore,
     cloudExtinction: Input[CloudExtinction] = Input.ignore,
     skyBackground:   Input[SkyBackground] = Input.ignore,
@@ -85,7 +86,7 @@ object ConstraintSetModel extends ConstraintSetModelOptics {
 
     def editor: ValidatedInput[State[ConstraintSetModel, Unit]] =
       (existence.validateIsNotNull("existence"),
-       name.validateNotNullable("name")(n => ValidatedInput.nonEmptyString("name", n)),
+       name.validateIsNotNull("name"),
        imageQuality.validateIsNotNull("imageQuality"),
        cloudExtinction.validateIsNotNull("cloudExtinction"),
        skyBackground.validateIsNotNull("skyBackground"),

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -18,7 +18,6 @@ import io.circe.Decoder
 import io.circe.generic.semiauto._
 import io.circe.refined._
 import monocle.{Lens, Optional}
-import monocle.state.all._
 
 
 final case class ObservationModel(

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -16,7 +16,9 @@ import eu.timepit.refined.cats._
 import eu.timepit.refined.types.string._
 import io.circe.Decoder
 import io.circe.generic.semiauto._
+import io.circe.refined._
 import monocle.{Lens, Optional}
+import monocle.state.all._
 
 
 final case class ObservationModel(
@@ -50,7 +52,7 @@ object ObservationModel extends ObservationOptics {
   final case class Create(
     observationId: Option[Observation.Id],
     programId:     Program.Id,
-    name:          Option[String],
+    name:          Option[NonEmptyString],
     asterismId:    Option[Asterism.Id],
     targetId:      Option[Target.Id],
     status:        Option[ObsStatus],
@@ -59,15 +61,14 @@ object ObservationModel extends ObservationOptics {
 
     def withId(s: PlannedTimeSummaryModel): ValidatedInput[Observation.Id => ObservationModel] =
       (
-        name.traverse(ValidatedInput.nonEmptyString("name", _)),
         ValidatedInput.optionEither("asterismId", "targetId", asterismId.map(_.validNec), targetId.map(_.validNec)),
         config.traverse(_.create)
-      ).mapN { (n, t, c) => oid =>
+      ).mapN { (t, c) => oid =>
         ObservationModel(
           oid,
           Present,
           programId,
-          n,
+          name,
           status.getOrElse(ObsStatus.New),
           t,
           s,
@@ -96,11 +97,11 @@ object ObservationModel extends ObservationOptics {
 
   final case class Edit(
     observationId: Observation.Id,
-    existence:     Input[Existence]   = Input.ignore,
-    name:          Input[String]      = Input.ignore,
-    status:        Input[ObsStatus]   = Input.ignore,
-    asterismId:    Input[Asterism.Id] = Input.ignore,
-    targetId:      Input[Target.Id]   = Input.ignore
+    existence:     Input[Existence]      = Input.ignore,
+    name:          Input[NonEmptyString] = Input.ignore,
+    status:        Input[ObsStatus]      = Input.ignore,
+    asterismId:    Input[Asterism.Id]    = Input.ignore,
+    targetId:      Input[Target.Id]      = Input.ignore
   ) {
 
     def id: Observation.Id =
@@ -114,12 +115,11 @@ object ObservationModel extends ObservationOptics {
 
     def editor: ValidatedInput[State[ObservationModel, Unit]] =
       (existence.validateIsNotNull("existence"),
-       name     .validateNullable(n => ValidatedInput.nonEmptyString("name", n)),
        status   .validateIsNotNull("status")
-      ).mapN { (e, n, s) =>
+      ).mapN { (e, s) =>
         for {
           _ <- ObservationModel.existence  := e
-          _ <- ObservationModel.name       := n
+          _ <- ObservationModel.name       := name.toOptionOption
           _ <- ObservationModel.status     := s
         } yield ()
       }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
@@ -5,8 +5,11 @@ package lucuma.odb.api.model
 
 import lucuma.core.model.Program
 import cats.Eq
+import eu.timepit.refined.cats._
+import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Decoder
 import io.circe.generic.semiauto._
+import io.circe.refined._
 import monocle.Lens
 
 
@@ -16,7 +19,7 @@ import monocle.Lens
 final case class ProgramModel(
   id:        Program.Id,
   existence: Existence,
-  name:      Option[String]
+  name:      Option[NonEmptyString]
 )
 
 object ProgramModel extends ProgramOptics {
@@ -32,7 +35,7 @@ object ProgramModel extends ProgramOptics {
    */
   final case class Create(
     programId: Option[Program.Id],
-    name:      Option[String]
+    name:      Option[NonEmptyString]
   )
 
   object Create {
@@ -67,7 +70,7 @@ trait ProgramOptics { self: ProgramModel.type =>
   val existence: Lens[ProgramModel, Existence] =
     Lens[ProgramModel, Existence](_.existence)(a => b => b.copy(existence = a))
 
-  val name: Lens[ProgramModel, Option[String]] =
-    Lens[ProgramModel, Option[String]](_.name)(a => b => b.copy(name = a))
+  val name: Lens[ProgramModel, Option[NonEmptyString]] =
+    Lens[ProgramModel, Option[NonEmptyString]](_.name)(a => b => b.copy(name = a))
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/AsterismMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/AsterismMutation.scala
@@ -14,7 +14,7 @@ import sangria.schema._
 trait AsterismMutation extends TargetScalars {
 
   import AsterismSchema.{AsterismIdType, AsterismIdArgument, AsterismType}
-  import GeneralSchema.EnumTypeExistence
+  import GeneralSchema.{EnumTypeExistence, NonEmptyStringType}
   import ProgramSchema.ProgramIdType
   import TargetMutation.InputObjectTypeCoordinates
 
@@ -39,7 +39,7 @@ trait AsterismMutation extends TargetScalars {
       InputObjectTypeName("EditAsterismInput"),
       InputObjectTypeDescription("Asterism edit"),
         ReplaceInputField("existence",    EnumTypeExistence.notNullableField("existence")),
-        ReplaceInputField("name",         StringType.nullableField("name")),
+        ReplaceInputField("name",         NonEmptyStringType.nullableField("name")),
         ReplaceInputField("explicitBase", InputObjectTypeCoordinates.nullableField("explicitBase"))
     )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/AsterismSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/AsterismSchema.scala
@@ -11,7 +11,7 @@ import sangria.schema._
 
 object AsterismSchema {
 
-  import GeneralSchema.{EnumTypeExistence, ArgumentIncludeDeleted}
+  import GeneralSchema.{ArgumentIncludeDeleted, EnumTypeExistence, NonEmptyStringType}
   import ObservationSchema.ObservationConnectionType
   import Paging._
   import ProgramSchema.{OptionalProgramIdArgument, ProgramConnectionType}
@@ -57,9 +57,9 @@ object AsterismSchema {
 
         Field(
           name        = "name",
-          fieldType   = OptionType(StringType),
+          fieldType   = OptionType(NonEmptyStringType),
           description = Some("Asterism name, if any."),
-          resolve     = _.value.name.map(_.value)
+          resolve     = _.value.name
         ),
 
         Field(

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetMutation.scala
@@ -16,7 +16,7 @@ import lucuma.odb.api.model.{AirmassRange, ElevationRangeModel, HourAngleRange}
 
 trait ConstraintSetMutation {
 
-  import GeneralSchema.EnumTypeExistence
+  import GeneralSchema.{EnumTypeExistence, NonEmptyStringType}
   import ConstraintSetSchema._
   import ProgramSchema.ProgramIdType
   import context._
@@ -57,7 +57,7 @@ trait ConstraintSetMutation {
       InputObjectTypeName("EditConstraintSetInput"),
       InputObjectTypeDescription("Edit constraint set"),
       ReplaceInputField("existence", EnumTypeExistence.notNullableField("existence")),
-      ReplaceInputField("name", StringType.notNullableField("name")),
+      ReplaceInputField("name", NonEmptyStringType.notNullableField("name")),
       ReplaceInputField("imageQuality", EnumTypeImageQuality.notNullableField("imageQuality")),
       ReplaceInputField("cloudExtinction",
                         EnumTypeCloudExtinction.notNullableField("cloudExtinction")

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetSchema.scala
@@ -13,7 +13,7 @@ import lucuma.odb.api.model.ConstraintSetModel
 import sangria.schema._
 
 object ConstraintSetSchema {
-  import GeneralSchema.{ ArgumentIncludeDeleted, EnumTypeExistence}
+  import GeneralSchema.{ ArgumentIncludeDeleted, EnumTypeExistence, NonEmptyStringType }
   import ObservationSchema.ObservationConnectionType
   import Paging._
   import ProgramSchema.ProgramType
@@ -122,9 +122,9 @@ object ConstraintSetSchema {
           ),
           Field(
             name        = "name",
-            fieldType   = StringType,
+            fieldType   = NonEmptyStringType,
             description = Some("Constraint set name"),
-            resolve     = _.value.name.value
+            resolve     = _.value.name
           ),
           Field(
             name        = "imageQuality",
@@ -177,7 +177,7 @@ object ConstraintSetSchema {
               ArgumentPagingCursor,
               ArgumentIncludeDeleted
             ),
-            resolve     = c => 
+            resolve     = c =>
               unsafeSelectPageFuture(c.pagingObservationId) { gid =>
                 c.ctx.observation.selectPageForConstraintSet(c.value.id, c.pagingFirst, gid, c.includeDeleted)
               }
@@ -185,10 +185,10 @@ object ConstraintSetSchema {
         )
     )
 
-    def ConstraintSetEdgeType[F[_]: Effect]: ObjectType[OdbRepo[F], Paging.Edge[ConstraintSetModel]] = 
+    def ConstraintSetEdgeType[F[_]: Effect]: ObjectType[OdbRepo[F], Paging.Edge[ConstraintSetModel]] =
       Paging.EdgeType(
-        "ContraintSetEdge", 
-        "A Constraint Set and its cursor", 
+        "ContraintSetEdge",
+        "A Constraint Set and its cursor",
         ConstraintSetType[F]
       )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -14,7 +14,7 @@ import sangria.schema._
 trait ObservationMutation {
 
   import AsterismSchema.AsterismIdType
-  import GeneralSchema.EnumTypeExistence
+  import GeneralSchema.{EnumTypeExistence, NonEmptyStringType}
   import ObservationSchema.{ObservationIdType, ObservationIdArgument, ObsStatusType, ObservationType}
   import ProgramSchema.ProgramIdType
   import TargetSchema.TargetIdType
@@ -39,7 +39,7 @@ trait ObservationMutation {
       InputObjectTypeName("EditObservationInput"),
       InputObjectTypeDescription("Edit observation"),
       ReplaceInputField("existence",  EnumTypeExistence.notNullableField("existence")),
-      ReplaceInputField("name",       StringType.nullableField("name")),
+      ReplaceInputField("name",       NonEmptyStringType.nullableField("name")),
       ReplaceInputField("status",     ObsStatusType.notNullableField("status")),
       ReplaceInputField("asterismId", AsterismIdType.nullableField("asterismId")),
       ReplaceInputField("targetId",   TargetIdType.nullableField("targetId"))

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
@@ -18,7 +18,7 @@ object ObservationSchema {
 
   import AsterismSchema.AsterismType
   import ConstraintSetSchema.ConstraintSetType
-  import GeneralSchema.{ArgumentIncludeDeleted, EnumTypeExistence, PlannedTimeSummaryType}
+  import GeneralSchema.{ArgumentIncludeDeleted, EnumTypeExistence, NonEmptyStringType, PlannedTimeSummaryType}
   import ProgramSchema.ProgramType
   import TargetSchema.TargetType
 
@@ -76,9 +76,9 @@ object ObservationSchema {
 
         Field(
           name        = "name",
-          fieldType   = OptionType(StringType),
+          fieldType   = OptionType(NonEmptyStringType),
           description = Some("Observation name"),
-          resolve     = _.value.name.map(_.value)
+          resolve     = _.value.name
         ),
 
         Field(

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
@@ -14,7 +14,7 @@ import sangria.schema._
 object ProgramSchema {
 
   import AsterismSchema.AsterismConnectionType
-  import GeneralSchema.{EnumTypeExistence, ArgumentIncludeDeleted, PlannedTimeSummaryType}
+  import GeneralSchema.{ArgumentIncludeDeleted, EnumTypeExistence, NonEmptyStringType, PlannedTimeSummaryType}
   import ObservationSchema.ObservationConnectionType
   import Paging._
   import TargetSchema.TargetConnectionType
@@ -58,7 +58,7 @@ object ProgramSchema {
 
         Field(
           name        = "name",
-          fieldType   = OptionType(StringType),
+          fieldType   = OptionType(NonEmptyStringType),
           description = Some("Program name"),
           resolve     = _.value.name
         ),

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
@@ -12,9 +12,10 @@ import sangria.macros.derive._
 import sangria.marshalling.circe._
 import sangria.schema._
 
+
 trait TargetMutation extends TargetScalars {
 
-  import GeneralSchema.EnumTypeExistence
+  import GeneralSchema.{EnumTypeExistence, NonEmptyStringType}
   import NumericUnitsSchema._
   import ProgramSchema.ProgramIdType
   import TargetSchema.{EnumTypeCatalogName, EphemerisKeyType, EnumTypeMagnitudeBand, EnumTypeMagnitudeSystem, TargetIdArgument, TargetIdType, TargetType}

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetSchema.scala
@@ -15,7 +15,7 @@ import sangria.schema._
 object TargetSchema extends TargetScalars {
 
   import AsterismSchema.AsterismConnectionType
-  import GeneralSchema.{EnumTypeExistence, ArgumentIncludeDeleted}
+  import GeneralSchema.{ArgumentIncludeDeleted, EnumTypeExistence, NonEmptyStringType}
   import ObservationSchema.ObservationConnectionType
   import Paging._
   import ProgramSchema.{OptionalProgramIdArgument, ProgramConnectionType}
@@ -444,9 +444,9 @@ object TargetSchema extends TargetScalars {
 
         Field(
           name        = "name",
-          fieldType   = StringType,
+          fieldType   = NonEmptyStringType,
           description = Some("Target name."),
-          resolve     = _.value.target.name.value
+          resolve     = _.value.target.name
         ),
 
         Field(

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbAsterismModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbAsterismModel.scala
@@ -12,6 +12,7 @@ import lucuma.core.util.arb.ArbEnumerated
 
 import clue.data.Input
 import eu.timepit.refined.types.all.NonEmptyString
+import eu.timepit.refined.scalacheck.string._
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 
@@ -28,7 +29,7 @@ trait ArbAsterismModel {
       for {
         id <- arbitrary[Asterism.Id]
         ex <- arbitrary[Existence]
-        nm <- Gen.option(Gen.alphaNumStr.suchThat(!_.isEmpty).map(NonEmptyString.unsafeFrom))
+        nm <- arbitrary[Option[NonEmptyString]]
         eb <- arbitrary[Option[Coordinates]]
       } yield AsterismModel(id, ex, nm, eb)
     }
@@ -50,7 +51,7 @@ trait ArbAsterismModel {
     Arbitrary {
       for {
         id <- arbitrary[Option[Asterism.Id]]
-        nm <- Gen.option(Gen.alphaNumStr.suchThat(!_.isEmpty))
+        nm <- arbitrary[Option[NonEmptyString]]
         ps <- arbitrary[List[Program.Id]]
         eb <- arbitrary[Option[CoordinatesModel.Input]]
       } yield Create(
@@ -69,7 +70,7 @@ trait ArbAsterismModel {
       Option[CoordinatesModel.Input]
     )].contramap { in => (
       in.asterismId,
-      in.name,
+      in.name.map(_.value),
       in.programIds,
       in.explicitBase
     )}
@@ -79,7 +80,7 @@ trait ArbAsterismModel {
       for {
         id <- arbitrary[Asterism.Id]
         ex <- arbNotNullableInput[Existence].arbitrary
-        nm <- arbitrary[Input[String]]
+        nm <- arbitrary[Input[NonEmptyString]]
         eb <- arbitrary[Input[CoordinatesModel.Input]]
       } yield Edit(
         id,
@@ -98,7 +99,7 @@ trait ArbAsterismModel {
     )].contramap { in => (
       in.asterismId,
       in.existence,
-      in.name,
+      in.name.map(_.value),
       in.explicitBase
     )}
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbConstraintSetModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbConstraintSetModel.scala
@@ -67,7 +67,7 @@ trait ArbConstraintSetModel {
       for {
         id   <- arbitrary[Option[ConstraintSet.Id]]
         pid  <- arbitrary[Program.Id]
-        name <- arbitrary[String]
+        name <- arbitrary[NonEmptyString]
         iq   <- arbitrary[ImageQuality]
         ce   <- arbitrary[CloudExtinction]
         sb   <- arbitrary[SkyBackground]
@@ -91,7 +91,7 @@ trait ArbConstraintSetModel {
     ].contramap(cs =>
       (cs.constraintSetId,
        cs.programId,
-       cs.name,
+       cs.name.value,
        cs.imageQuality,
        cs.cloudExtinction,
        cs.skyBackground,
@@ -105,7 +105,7 @@ trait ArbConstraintSetModel {
       for {
         csid <- arbitrary[ConstraintSet.Id]
         ex   <- arbitrary[Input[Existence]]
-        n    <- arbitrary[Input[String]]
+        n    <- arbitrary[Input[NonEmptyString]]
         iq   <- arbitrary[Input[ImageQuality]]
         c    <- arbitrary[Input[CloudExtinction]]
         sb   <- arbitrary[Input[SkyBackground]]
@@ -129,7 +129,7 @@ trait ArbConstraintSetModel {
     ].contramap(cse =>
       (cse.constraintSetId,
        cse.existence,
-       cse.name,
+       cse.name.map(_.value),
        cse.imageQuality,
        cse.cloudExtinction,
        cse.skyBackground,

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
@@ -66,7 +66,7 @@ trait ArbObservationModel {
       } yield ObservationModel.Create(
         id,
         pd,
-        nm.map(_.value),
+        nm,
         ts.flatMap(_.swap.toOption),
         ts.flatMap(_.toOption),
         st,
@@ -84,7 +84,7 @@ trait ArbObservationModel {
     )].contramap { in => (
       in.observationId,
       in.programId,
-      in.name,
+      in.name.map(_.value),
       in.asterismId,
       in.targetId,
     )}

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbProgramModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbProgramModel.scala
@@ -6,6 +6,8 @@ package arb
 
 import lucuma.core.model.Program
 import lucuma.core.util.arb.{ArbEnumerated, ArbGid}
+import eu.timepit.refined.types.string.NonEmptyString
+import eu.timepit.refined.scalacheck.string._
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 
@@ -20,7 +22,7 @@ trait ArbProgramModel {
       for {
         id <- arbitrary[Program.Id]
         ex <- arbitrary[Existence]
-        nm <- arbitrary[Option[String]]
+        nm <- arbitrary[Option[NonEmptyString]]
       } yield ProgramModel(id, ex, nm)
     }
 
@@ -32,14 +34,14 @@ trait ArbProgramModel {
     )].contramap { in => (
       in.id,
       in.existence,
-      in.name
+      in.name.map(_.value)
     )}
 
   implicit val arbProgramModelCreate: Arbitrary[ProgramModel.Create] =
     Arbitrary {
       for {
         id <- arbitrary[Option[Program.Id]]
-        nm <- arbitrary[Option[String]]
+        nm <- arbitrary[Option[NonEmptyString]]
       } yield ProgramModel.Create(id, nm)
     }
 
@@ -49,7 +51,7 @@ trait ArbProgramModel {
       Option[String]
     )].contramap { in => (
       in.programId,
-      in.name
+      in.name.map(_.value)
     )}
 }
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbTargetModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbTargetModel.scala
@@ -13,6 +13,8 @@ import lucuma.core.math.arb.ArbEpoch
 import lucuma.core.util.arb.ArbEnumerated
 
 import clue.data.Input
+import eu.timepit.refined.types.string.NonEmptyString
+import eu.timepit.refined.scalacheck.string._
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 
@@ -38,7 +40,7 @@ trait ArbTargetModel {
       for {
         id    <- arbitrary[Option[Target.Id]]
         pids  <- arbitrary[Option[List[Program.Id]]]
-        name  <- Gen.alphaNumStr.suchThat(!_.isEmpty)
+        name  <- arbitrary[NonEmptyString]
         cat   <- arbitrary[Option[CatalogIdModel.Input]]
         ra    <- arbitrary[RightAscensionModel.Input]
         dec   <- arbitrary[DeclinationModel.Input]
@@ -78,7 +80,7 @@ trait ArbTargetModel {
     )].contramap { in => (
       in.targetId,
       in.programIds,
-      in.name,
+      in.name.value,
       in.catalogId,
       in.ra,
       in.dec,
@@ -94,16 +96,16 @@ trait ArbTargetModel {
       for {
         id   <- arbitrary[Option[Target.Id]]
         pids <- arbitrary[Option[List[Program.Id]]]
-        name <- Gen.alphaNumStr.suchThat(!_.isEmpty)
+        name <- arbitrary[NonEmptyString]
         key  <- arbitrary[EphemerisKeyType]
-        des  <- Gen.alphaNumStr.suchThat(!_.isEmpty)
+        des  <- arbitrary[NonEmptyString]
         mags <- arbitrary[Option[List[MagnitudeModel.Input]]]
       } yield CreateNonsidereal(
         id,
         pids,
         name,
         key,
-        des,
+        des.value,
         mags
       )
     }
@@ -117,7 +119,7 @@ trait ArbTargetModel {
       String,
       Option[List[MagnitudeModel.Input]]
     )].contramap { in => (
-      (in.targetId, in.programIds, in.name, in.key, in.des, in.magnitudes)
+      in.targetId, in.programIds, in.name.value, in.key, in.des, in.magnitudes
     )}
 
   implicit val arbEditSidereal: Arbitrary[EditSidereal] =
@@ -125,7 +127,7 @@ trait ArbTargetModel {
       for {
         id    <- arbitrary[Target.Id]
         ex    <- arbNotNullableInput[Existence].arbitrary
-        name  <- arbNotNullableInput[String](Arbitrary(Gen.nonEmptyListOf(Gen.alphaNumChar).map(_.mkString))).arbitrary
+        name  <- arbNotNullableInput[NonEmptyString].arbitrary
         cat   <- arbitrary[Input[CatalogIdModel.Input]]
         ra    <- arbNotNullableInput[RightAscensionModel.Input].arbitrary
         dec   <- arbNotNullableInput[DeclinationModel.Input].arbitrary
@@ -168,7 +170,7 @@ trait ArbTargetModel {
     )].contramap { in => (
       in.targetId,
       in.existence,
-      in.name,
+      in.name.map(_.value),
       in.catalogId,
       in.ra,
       in.dec,
@@ -183,7 +185,7 @@ trait ArbTargetModel {
       for {
         id   <- arbitrary[Target.Id]
         ex   <- arbitrary[Option[Existence]]
-        name <- Gen.option(Gen.alphaNumStr.suchThat(!_.isEmpty))
+        name <- arbitrary[Option[NonEmptyString]]
         key  <- arbitrary[Option[EphemerisKey]]
       } yield EditNonsidereal(
         id,
@@ -200,7 +202,7 @@ trait ArbTargetModel {
       Option[String],
       Option[EphemerisKey]
     )].contramap { in => (
-      (in.targetId, in.existence, in.name, in.key)
+      in.targetId, in.existence, in.name.map(_.value), in.key
     )}
 
   implicit val arbTargetModel: Arbitrary[TargetModel] =

--- a/modules/core/src/test/scala/lucuma/odb/api/repo/ObservationRepoSpec.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/repo/ObservationRepoSpec.scala
@@ -67,7 +67,7 @@ final class ObservationRepoSpec extends ScalaCheckSuite with OdbRepoTest {
 
     forAll { (t: Tables) =>
       val (_, obs) = runEditTest(t) { o =>
-        ObservationModel.Edit(o.id, name = Input("Biff"))
+        ObservationModel.Edit(o.id, name = Input(NonEmptyString.unsafeFrom("Biff")))
       }
       assert(obs.name.contains(NonEmptyString.unsafeFrom("Biff")))
     }
@@ -75,10 +75,9 @@ final class ObservationRepoSpec extends ScalaCheckSuite with OdbRepoTest {
   }
 
   property("simple non-edit") {
-
     forAll { (t: Tables) =>
       val (before, after) = runEditTest(t) { o =>
-        ObservationModel.Edit(o.id, name = o.name.fold(Input.ignore[String])(n => Input(n.value)))
+        ObservationModel.Edit(o.id, name = o.name.fold(Input.ignore[NonEmptyString])(n => Input(n)))
       }
       assertEquals(after, before)
     }

--- a/modules/core/src/test/scala/lucuma/odb/api/repo/TargetRepoSpec.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/repo/TargetRepoSpec.scala
@@ -3,12 +3,23 @@
 
 package lucuma.odb.api.repo
 
-import lucuma.odb.api.model.{ProgramModel, TargetModel}
-import lucuma.core.model.{Program, Target}
+import lucuma.odb.api.model.{DeclinationModel, ObservationModel, ProgramModel, RightAscensionModel, TargetModel}
+import lucuma.odb.api.model.arb._
+import lucuma.odb.api.repo.arb._
+import lucuma.core.model.{Observation, Program, Target}
 
-import munit.DisciplineSuite
+import cats.syntax.all._
+import clue.data.Input
+import eu.timepit.refined.scalacheck.string._
+import eu.timepit.refined.types.string.NonEmptyString
+import org.scalacheck.Prop.forAll
+import munit.ScalaCheckSuite
 
-final class TargetRepoSpec extends DisciplineSuite with OdbRepoTest {
+final class TargetRepoSpec extends ScalaCheckSuite with OdbRepoTest {
+
+  import ArbDeclinationModel._
+  import ArbRightAscensionModel._
+  import ArbTables._
 
   test("shareWithPrograms") {
 
@@ -19,6 +30,40 @@ final class TargetRepoSpec extends DisciplineSuite with OdbRepoTest {
         odb.target.unshareWithPrograms,
         odb.program.selectPageForTarget(_, includeObservations = false)
     )}
+
+  }
+
+  property("simple create") {
+
+    forAll { (tables: Tables, name: NonEmptyString, ra: RightAscensionModel.Input, dec: DeclinationModel.Input) =>
+
+      val target = runTest(tables) { odb =>
+        odb.target.insertSidereal(TargetModel.CreateSidereal.fromRaDec(name, ra, dec))
+      }
+
+      assertEquals(target.target.name, name)
+      assertEquals(target.target.track.map(_.baseCoordinates.ra).toOption, ra.toRightAscension.toOption)
+      assertEquals(target.target.track.map(_.baseCoordinates.dec).toOption, dec.toDeclination.toOption)
+
+    }
+
+  }
+
+  property("simple edit") {
+
+    forAll { (tables: Tables, name: NonEmptyString) =>
+
+      val target = runTest(tables) { odb =>
+
+        val edit = tables.targets.values.headOption.filter(_.target.track.isRight).map { t =>
+          TargetModel.EditSidereal(t.id, name = Input(name), magnitudes = None, modifyMagnitudes = None, deleteMagnitudes = None)
+        }
+
+        edit.traverse(odb.target.edit)
+      }
+
+      assert(target.forall(_.target.name == name))
+    }
 
   }
 

--- a/modules/core/src/test/scala/lucuma/odb/api/repo/TargetRepoSpec.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/repo/TargetRepoSpec.scala
@@ -3,10 +3,10 @@
 
 package lucuma.odb.api.repo
 
-import lucuma.odb.api.model.{DeclinationModel, ObservationModel, ProgramModel, RightAscensionModel, TargetModel}
+import lucuma.odb.api.model.{DeclinationModel, ProgramModel, RightAscensionModel, TargetModel}
 import lucuma.odb.api.model.arb._
 import lucuma.odb.api.repo.arb._
-import lucuma.core.model.{Observation, Program, Target}
+import lucuma.core.model.{Program, Target}
 
 import cats.syntax.all._
 import clue.data.Input
@@ -59,7 +59,7 @@ final class TargetRepoSpec extends ScalaCheckSuite with OdbRepoTest {
           TargetModel.EditSidereal(t.id, name = Input(name), magnitudes = None, modifyMagnitudes = None, deleteMagnitudes = None)
         }
 
-        edit.traverse(odb.target.edit)
+        edit.traverse(e => odb.target.edit(e.id, e.editor))
       }
 
       assert(target.forall(_.target.name == name))

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -3,16 +3,18 @@
 
 package lucuma.odb.api.service
 
-import cats.Applicative
-import cats.data.State
 import lucuma.odb.api.model._
 import lucuma.odb.api.model.SequenceModel._
 import lucuma.odb.api.repo.OdbRepo
 import lucuma.core.`enum`._
 import lucuma.core.optics.syntax.all._
 import lucuma.core.math.syntax.int._
+
+import cats.Applicative
+import cats.data.State
 import cats.effect.Sync
 import cats.syntax.all._
+import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.parser.decode
 import lucuma.core.model.Program
 import lucuma.odb.api.model.OffsetModel.ComponentInput
@@ -280,7 +282,7 @@ object Init {
     ObservationModel.Create(
       observationId = None,
       programId     = pid,
-      name          = target.map(_.target.name.value) orElse Some("Observation"),
+      name          = target.map(_.target.name) orElse NonEmptyString.from("Observation").toOption,
       asterismId    = None,
       targetId      = target.map(_.id),
       status        = Some(ObsStatus.New),

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -307,13 +307,13 @@ object Init {
       p  <- repo.program.insert(
               ProgramModel.Create(
                 None,
-                Some("The real dark matter was the friends we made along the way")
+                NonEmptyString.from("The real dark matter was the friends we made along the way").toOption
               )
             )
       _  <- repo.program.insert(
               ProgramModel.Create(
                 None,
-                Some("An Empty Placeholder Program")
+                NonEmptyString.from("An Empty Placeholder Program").toOption
               )
             )
       cs <- targets.liftTo[F]


### PR DESCRIPTION
Adds a `NonEmptyStringType` GraphQL scalar and converts the various names to `NonEmptyString` and `Option[NonEmptyString]`.  This moves emptiness checking from the realm of user input checks to schema violations.