### PR TITLE
Adds a `totalCount` field to the paging connection

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ResultPage.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ResultPage.scala
@@ -7,18 +7,20 @@ import cats.Eq
 
 final case class ResultPage[A](
   nodes:       List[A],
-  hasNextPage: Boolean
+  hasNextPage: Boolean,
+  totalCount:  Int
 )
 
 object ResultPage {
 
   def empty[A]: ResultPage[A] =
-    ResultPage(Nil, hasNextPage = false)
+    ResultPage(Nil, hasNextPage = false, 0)
 
   def EqResultPage[A: Eq]: Eq[ResultPage[A]] =
     Eq.by { p => (
       p.nodes,
-      p.hasNextPage
+      p.hasNextPage,
+      p.totalCount
     )}
 
 }

--- a/modules/core/src/test/scala/lucuma/odb/api/repo/PagingQuerySpec.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/repo/PagingQuerySpec.scala
@@ -31,6 +31,32 @@ final class PagingQuerySpec extends ScalaCheckSuite with OdbRepoTest {
     }
   }
 
+  property("totalCount same on all result pages") {
+    forAll {  (t: Tables, pageSize: PosInt) =>
+
+      val sizes = runTest(t) { odb =>
+        val pages = allPages(pageSize, None, odb.program)
+        pages.map(_.map(_.totalCount).toSet)
+      }
+
+      assertEquals(sizes.size, 1)
+    }
+  }
+
+  property("totalCount includes all matching items") {
+    forAll {  (t: Tables, pageSize: PosInt) =>
+
+      val (a, b) = runTest(t) { odb =>
+        val pages = allPages(pageSize, None, odb.program)
+        (pages.map(_.map(_.totalCount).toSet.headOption.getOrElse(0)),
+         pages.map(_.map(_.nodes.size).sum)
+        ).tupled
+      }
+
+      assertEquals(a, b)
+    }
+  }
+
   property("filter") {
     forAll {  (t: Tables, pageSize: PosInt) =>
 


### PR DESCRIPTION
A `totalCount` field tells the caller, regardless of the page size, how many total items are forthcoming.  This is useful, for example, to determine whether a constraint set is shared by multiple observations.  You can select the observations associated with the constraint set and ask for its `totalCount`.

For example, to see the total target count for the `targets` query (along with the target names):

```
query Targets {
  targets(programId: "p-2", first: 100) {
    totalCount
    nodes {
      name
    }
  }
}
```

might return (say) 3 targets

```
{
  "data": {
    "targets": {
      "totalCount": 3,
      "nodes": [
        {
          "name": "NGC 5949"
        },
        {
          "name": "NGC 3269"
        },
        {
          "name": "NGC 3312"
        }
      ]
    }
  }
}
```

Asking for only 2 targets per page would return the two selected targets but the `totalCount` remains `3`:

```
query Targets {
  targets(programId: "p-2", first: 2) {
    totalCount
    nodes {
      name
    }
  }
}
```

```
{
  "data": {
    "targets": {
      "totalCount": 3,
      "nodes": [
        {
          "name": "NGC 5949"
        },
        {
          "name": "NGC 3269"
        }
      ]
    }
  }
}
```
