### PR TITLE
Small step refactor

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/Breakpoint.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/Breakpoint.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.core.util.Enumerated
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+import monocle.Iso
+
+
+sealed trait Breakpoint extends Product with Serializable {
+
+  def enabled: Boolean =
+    this match {
+      case Breakpoint.Enabled  => true
+      case Breakpoint.Disabled => false
+    }
+
+}
+
+object Breakpoint {
+
+  case object Enabled  extends Breakpoint
+  case object Disabled extends Breakpoint
+
+  val enabled: Breakpoint =
+    Enabled
+
+  val disabled: Breakpoint =
+    Disabled
+
+  val fromBoolean: Iso[Boolean, Breakpoint] =
+    Iso[Boolean, Breakpoint](b => if (b) Enabled else Disabled)(_.enabled)
+
+  implicit val EnumeratedBreakpoint: Enumerated[Breakpoint] =
+    Enumerated.of(enabled, disabled)
+
+  implicit val DecoderBreakpoint: Decoder[Breakpoint] =
+    deriveDecoder[Breakpoint]
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
@@ -596,22 +596,22 @@ object GmosModel {
     }
 
     object step {
-      val instrumentConfig: Optional[StepModel.CreateStep[CreateSouthDynamic], CreateSouthDynamic] =
-        StepModel.CreateStep.instrumentConfig[CreateSouthDynamic]
+      val instrumentConfig: Optional[StepConfig.CreateStepConfig[CreateSouthDynamic], CreateSouthDynamic] =
+        StepConfig.CreateStepConfig.instrumentConfig[CreateSouthDynamic]
 
-      val exposure: Optional[StepModel.CreateStep[CreateSouthDynamic], FiniteDurationModel.Input] =
+      val exposure: Optional[StepConfig.CreateStepConfig[CreateSouthDynamic], FiniteDurationModel.Input] =
         instrumentConfig ^|-> CreateSouthDynamic.exposure
 
-      val p: Optional[StepModel.CreateStep[CreateSouthDynamic], OffsetModel.ComponentInput] =
-        StepModel.CreateStep.p[CreateSouthDynamic]
+      val p: Optional[StepConfig.CreateStepConfig[CreateSouthDynamic], OffsetModel.ComponentInput] =
+        StepConfig.CreateStepConfig.p[CreateSouthDynamic]
 
-      val q: Optional[StepModel.CreateStep[CreateSouthDynamic], OffsetModel.ComponentInput] =
-        StepModel.CreateStep.q[CreateSouthDynamic]
+      val q: Optional[StepConfig.CreateStepConfig[CreateSouthDynamic], OffsetModel.ComponentInput] =
+        StepConfig.CreateStepConfig.q[CreateSouthDynamic]
 
-      val grating: Optional[StepModel.CreateStep[CreateSouthDynamic], CreateGrating[GmosSouthDisperser]] =
+      val grating: Optional[StepConfig.CreateStepConfig[CreateSouthDynamic], CreateGrating[GmosSouthDisperser]] =
         instrumentConfig ^|-? instrument.grating
 
-      val wavelength: Optional[StepModel.CreateStep[CreateSouthDynamic], WavelengthModel.Input] =
+      val wavelength: Optional[StepConfig.CreateStepConfig[CreateSouthDynamic], WavelengthModel.Input] =
         grating ^|-> CreateGrating.wavelength[GmosSouthDisperser]
 
     }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/PlannedTime.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/PlannedTime.scala
@@ -112,7 +112,7 @@ object PlannedTime {
 
   // Placeholder estimate.  In reality you cannot estimate a step independently
   // like this because you need to account for changes from the previous step.
-  def estimateStep[D](s: StepModel[D]): CategorizedTime = {
+  def estimateStep[D](s: StepConfig[D]): CategorizedTime = {
     def forExposure(exposure: FiniteDuration): CategorizedTime =
       CategorizedTime(
         configChange = NonNegativeFiniteDuration.unsafeFrom(7.seconds),
@@ -129,10 +129,10 @@ object PlannedTime {
       }
 
     s match {
-      case StepModel.Bias(a)          => forDynamicConfig(a)
-      case StepModel.Dark(a)          => forDynamicConfig(a)
-      case StepModel.Gcal(a, _)       => forDynamicConfig(a)
-      case StepModel.Science(a, _)    => forDynamicConfig(a)
+      case StepConfig.Bias(a)       => forDynamicConfig(a)
+      case StepConfig.Dark(a)       => forDynamicConfig(a)
+      case StepConfig.Gcal(a, _)    => forDynamicConfig(a)
+      case StepConfig.Science(a, _) => forDynamicConfig(a)
 
     }
   }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/PlannedTime.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/PlannedTime.scala
@@ -138,7 +138,7 @@ object PlannedTime {
   }
 
   def estimateAtom[D](a: SequenceModel.Atom[D]): CategorizedTime =
-    a.steps.map(s => estimateStep(s.step)).reduce
+    a.steps.map(s => estimateStep(s.config)).reduce
 
   def estimateSequence[D](s: SequenceModel.Sequence[D]): CategorizedTime =
     NonEmptyList(CategorizedTime.Zero, s.atoms.map(estimateAtom)).reduce

--- a/modules/core/src/main/scala/lucuma/odb/api/model/SequenceModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/SequenceModel.scala
@@ -16,75 +16,28 @@ import monocle.macros.Lenses
 
 object SequenceModel {
 
-  @Lenses final case class BreakpointStep[A](
-    breakpoint: Breakpoint,
-    step:       StepConfig[A]
-  )
-
-  object BreakpointStep {
-
-    implicit def EqBreakpointStep[A: Eq]: Eq[BreakpointStep[A]] =
-      Eq.by { a => (
-        a.breakpoint,
-        a.step
-      )}
-
-    @Lenses final case class Create[A](
-      breakpoint: Breakpoint,
-      step:       CreateStepConfig[A]
-    ) {
-
-      def create[B](implicit V: InputValidator[A, B]): ValidatedInput[BreakpointStep[B]] =
-        step.create[B].map(s => BreakpointStep(breakpoint, s))
-
-    }
-
-    object Create {
-
-      def stopBefore[A](s: CreateStepConfig[A]): Create[A] =
-        Create(Breakpoint.enabled, s)
-
-      def continueTo[A](s: CreateStepConfig[A]): Create[A] =
-        Create(Breakpoint.disabled, s)
-
-      implicit def EqCreate[A: Eq]: Eq[Create[A]] =
-        Eq.by { a => (
-          a.breakpoint,
-          a.step
-        )}
-
-      implicit def DecoderCreate[A: Decoder]: Decoder[Create[A]] =
-        deriveDecoder[Create[A]]
-
-      implicit def ValidatorCreate[A, B](implicit V: InputValidator[A, B]): InputValidator[Create[A], BreakpointStep[B]] =
-        (cbs: Create[A]) => cbs.create[B]
-    }
-
-  }
-
-
   @Lenses final case class Atom[A](
-    steps: NonEmptyList[BreakpointStep[A]]
+    steps: NonEmptyList[StepModel[A]]
   )
 
 
   object Atom {
 
-    def one[A](head: BreakpointStep[A]): Atom[A] =
+    def one[A](head: StepModel[A]): Atom[A] =
       Atom(NonEmptyList.one(head))
 
-    def ofSteps[A](head: BreakpointStep[A], tail: BreakpointStep[A]*): Atom[A] =
+    def ofSteps[A](head: StepModel[A], tail: StepModel[A]*): Atom[A] =
       Atom(NonEmptyList.of(head, tail: _*))
 
-    def fromNel[A]: Iso[NonEmptyList[BreakpointStep[A]], Atom[A]] =
-      Iso[NonEmptyList[BreakpointStep[A]], Atom[A]](nel => Atom(nel))(_.steps)
+    def fromNel[A]: Iso[NonEmptyList[StepModel[A]], Atom[A]] =
+      Iso[NonEmptyList[StepModel[A]], Atom[A]](nel => Atom(nel))(_.steps)
 
     implicit def EqSequenceAtom[A: Eq]: Eq[Atom[A]] =
       Eq.by(_.steps)
 
 
     @Lenses final case class Create[A](
-      steps: List[BreakpointStep.Create[A]]
+      steps: List[StepModel.Create[A]]
     ) {
 
       def create[B](implicit V: InputValidator[A, B]): ValidatedInput[Atom[B]] =
@@ -102,14 +55,14 @@ object SequenceModel {
 
     object Create {
 
-      def singleton[A](step: BreakpointStep.Create[A]): Create[A] =
+      def singleton[A](step: StepModel.Create[A]): Create[A] =
         Create(List(step))
 
       def stopBefore[A](step: CreateStepConfig[A]): Create[A] =
-        singleton(BreakpointStep.Create.stopBefore(step))
+        singleton(StepModel.Create.stopBefore(step))
 
       def continueTo[A](step: CreateStepConfig[A]): Create[A] =
-        singleton(BreakpointStep.Create.continueTo(step))
+        singleton(StepModel.Create.continueTo(step))
 
       implicit def DecoderCreate[A: Decoder]: Decoder[Create[A]] =
         deriveDecoder[Create[A]]

--- a/modules/core/src/main/scala/lucuma/odb/api/model/SequenceModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/SequenceModel.scala
@@ -3,7 +3,6 @@
 
 package lucuma.odb.api.model
 
-import lucuma.core.util.Enumerated
 import lucuma.odb.api.model.StepConfig.CreateStepConfig
 import lucuma.odb.api.model.syntax.inputvalidator._
 import cats.Eq
@@ -16,38 +15,6 @@ import monocle.{Iso, Lens}
 import monocle.macros.Lenses
 
 object SequenceModel {
-
-  sealed trait Breakpoint extends Product with Serializable {
-
-    def enabled: Boolean =
-      this match {
-        case Breakpoint.Enabled  => true
-        case Breakpoint.Disabled => false
-      }
-
-  }
-
-  object Breakpoint {
-
-    case object Enabled  extends Breakpoint
-    case object Disabled extends Breakpoint
-
-    val enabled: Breakpoint =
-      Enabled
-
-    val disabled: Breakpoint =
-      Disabled
-
-    val fromBoolean: Iso[Boolean, Breakpoint] =
-      Iso[Boolean, Breakpoint](b => if (b) Enabled else Disabled)(_.enabled)
-
-    implicit val EnumeratedBreakpoint: Enumerated[Breakpoint] =
-      Enumerated.of(enabled, disabled)
-
-    implicit val DecoderBreakpoint: Decoder[Breakpoint] =
-      deriveDecoder[Breakpoint]
-  }
-
 
   @Lenses final case class BreakpointStep[A](
     breakpoint: Breakpoint,

--- a/modules/core/src/main/scala/lucuma/odb/api/model/SequenceModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/SequenceModel.scala
@@ -4,7 +4,7 @@
 package lucuma.odb.api.model
 
 import lucuma.core.util.Enumerated
-import lucuma.odb.api.model.StepModel.CreateStep
+import lucuma.odb.api.model.StepConfig.CreateStepConfig
 import lucuma.odb.api.model.syntax.inputvalidator._
 import cats.Eq
 import cats.data.NonEmptyList
@@ -51,7 +51,7 @@ object SequenceModel {
 
   @Lenses final case class BreakpointStep[A](
     breakpoint: Breakpoint,
-    step:       StepModel[A]
+    step:       StepConfig[A]
   )
 
   object BreakpointStep {
@@ -64,7 +64,7 @@ object SequenceModel {
 
     @Lenses final case class Create[A](
       breakpoint: Breakpoint,
-      step:       CreateStep[A]
+      step:       CreateStepConfig[A]
     ) {
 
       def create[B](implicit V: InputValidator[A, B]): ValidatedInput[BreakpointStep[B]] =
@@ -74,10 +74,10 @@ object SequenceModel {
 
     object Create {
 
-      def stopBefore[A](s: CreateStep[A]): Create[A] =
+      def stopBefore[A](s: CreateStepConfig[A]): Create[A] =
         Create(Breakpoint.enabled, s)
 
-      def continueTo[A](s: CreateStep[A]): Create[A] =
+      def continueTo[A](s: CreateStepConfig[A]): Create[A] =
         Create(Breakpoint.disabled, s)
 
       implicit def EqCreate[A: Eq]: Eq[Create[A]] =
@@ -138,10 +138,10 @@ object SequenceModel {
       def singleton[A](step: BreakpointStep.Create[A]): Create[A] =
         Create(List(step))
 
-      def stopBefore[A](step: CreateStep[A]): Create[A] =
+      def stopBefore[A](step: CreateStepConfig[A]): Create[A] =
         singleton(BreakpointStep.Create.stopBefore(step))
 
-      def continueTo[A](step: CreateStep[A]): Create[A] =
+      def continueTo[A](step: CreateStepConfig[A]): Create[A] =
         singleton(BreakpointStep.Create.continueTo(step))
 
       implicit def DecoderCreate[A: Decoder]: Decoder[Create[A]] =

--- a/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.odb.api.model.StepConfig.CreateStepConfig
+
+import cats.Eq
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import monocle.macros.Lenses
+
+
+@Lenses final case class StepModel[A](
+  breakpoint: Breakpoint,
+  config:     StepConfig[A]
+)
+
+object StepModel {
+  implicit def EqStepModel[A: Eq]: Eq[StepModel[A]] =
+    Eq.by { a => (
+      a.breakpoint,
+      a.config
+    )}
+
+  @Lenses final case class Create[A](
+    breakpoint: Breakpoint,
+    step:       CreateStepConfig[A]
+  ) {
+
+    def create[B](implicit V: InputValidator[A, B]): ValidatedInput[StepModel[B]] =
+      step.create[B].map(s => StepModel(breakpoint, s))
+
+  }
+
+  object Create {
+
+    def stopBefore[A](s: CreateStepConfig[A]): Create[A] =
+      Create(Breakpoint.enabled, s)
+
+    def continueTo[A](s: CreateStepConfig[A]): Create[A] =
+      Create(Breakpoint.disabled, s)
+
+    implicit def EqCreate[A: Eq]: Eq[Create[A]] =
+      Eq.by { a => (
+        a.breakpoint,
+        a.step
+      )}
+
+    implicit def DecoderCreate[A: Decoder]: Decoder[Create[A]] =
+      deriveDecoder[Create[A]]
+
+    implicit def ValidatorCreate[A, B](implicit V: InputValidator[A, B]): InputValidator[Create[A], StepModel[B]] =
+      (cbs: Create[A]) => cbs.create[B]
+  }
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
@@ -13,7 +13,7 @@ import io.circe.generic.semiauto.deriveDecoder
 import monocle.{Lens, Optional}
 import monocle.macros.Lenses
 
-// For now, just bias, dark, and science.  Pending smart-gcal and gcal.
+// For now, just bias, dark, gcal and science.  Pending smart-gcal.
 
 sealed abstract class StepModel[A] extends Product with Serializable {
   def instrumentConfig: A
@@ -308,23 +308,4 @@ object StepModel {
       offset[A] ^|-> OffsetModel.Input.q
   }
 
-  /*
-  val x =
-    """
-      |"gmos": {
-      |  "static": ...
-      |  "acquisition": [
-      |
-      |  ],
-      |  "sequence": [
-      |    {
-      |      "bias": {
-      |        "filter" : ...
-      |      }
-      |    }
-      |  ]
-      |
-      |}
-      |""".stripMargin
-   */
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SequenceSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SequenceSchema.scala
@@ -3,7 +3,7 @@
 
 package lucuma.odb.api.schema
 
-import lucuma.odb.api.model.{Breakpoint, PlannedTime, SequenceModel}
+import lucuma.odb.api.model.{PlannedTime, SequenceModel}
 import lucuma.odb.api.model.SequenceModel._
 import lucuma.odb.api.repo.OdbRepo
 import cats.effect.Effect
@@ -13,46 +13,7 @@ object SequenceSchema {
 
   import FiniteDurationSchema.DurationType
   import PlannedTimeSchema._
-  import StepSchema.StepType
-  import syntax.`enum`._
-
-  implicit val EnumTypeBreakpoint: EnumType[Breakpoint] =
-    EnumType.fromEnumerated[Breakpoint](
-      "Breakpoint",
-      "Stopping point in a series of steps"
-    )
-
-  def BreakpointStepType[F[_]: Effect, D](
-    typePrefix:  String,
-    dynamicType: OutputType[D]
-  ): ObjectType[OdbRepo[F], SequenceModel.BreakpointStep[D]] =
-    ObjectType(
-      name        = s"${typePrefix}BreakpointStep",
-      description = s"$typePrefix step with potential breakpoint",
-      fieldsFn    = () => fields(
-
-        Field(
-          name        = "breakpoint",
-          fieldType   = EnumTypeBreakpoint,
-          description = Some("Whether to pause before the execution of this step"),
-          resolve     = _.value.breakpoint
-        ),
-
-        Field(
-          name        = "step",
-          fieldType   = StepType[F, D](typePrefix, dynamicType),
-          description = Some("The sequence step itself"),
-          resolve     = _.value.step
-        ),
-
-        Field(
-          name        = "time",
-          fieldType   = CategorizedTimeType[F],
-          description = Some("Time estimate for this step's execution"),
-          resolve     = c => PlannedTime.estimateStep(c.value.step)
-        )
-      )
-    )
+  import StepSchema.InstrumentStepType
 
   def AtomType[F[_]: Effect, D](
     typePrefix:  String,
@@ -65,7 +26,7 @@ object SequenceSchema {
 
         Field(
           name        = "steps",
-          fieldType   = ListType(BreakpointStepType[F, D](typePrefix, dynamicType)),
+          fieldType   = ListType(InstrumentStepType[F, D](typePrefix, dynamicType)),
           description = Some("Individual steps that comprise the atom"),
           resolve     = _.value.steps.toList
         ),

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SequenceSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SequenceSchema.scala
@@ -3,7 +3,7 @@
 
 package lucuma.odb.api.schema
 
-import lucuma.odb.api.model.{PlannedTime, SequenceModel}
+import lucuma.odb.api.model.{Breakpoint, PlannedTime, SequenceModel}
 import lucuma.odb.api.model.SequenceModel._
 import lucuma.odb.api.repo.OdbRepo
 import cats.effect.Effect
@@ -16,8 +16,8 @@ object SequenceSchema {
   import StepSchema.StepType
   import syntax.`enum`._
 
-  implicit val EnumTypeBreakpoint: EnumType[SequenceModel.Breakpoint] =
-    EnumType.fromEnumerated[SequenceModel.Breakpoint](
+  implicit val EnumTypeBreakpoint: EnumType[Breakpoint] =
+    EnumType.fromEnumerated[Breakpoint](
       "Breakpoint",
       "Stopping point in a series of steps"
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/StepSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/StepSchema.scala
@@ -4,7 +4,7 @@
 package lucuma.odb.api.schema
 
 import lucuma.core.`enum`._
-import lucuma.odb.api.model.StepModel
+import lucuma.odb.api.model.StepConfig
 import lucuma.odb.api.repo.OdbRepo
 import cats.effect.Effect
 import sangria.schema._
@@ -54,11 +54,11 @@ object StepSchema {
   def StepType[F[_]: Effect, A](
     typePrefix: String,
     outputType: OutputType[A]
-  ): ObjectType[OdbRepo[F], StepModel[A]] =
-    ObjectType[OdbRepo[F], StepModel[A]](
+  ): ObjectType[OdbRepo[F], StepConfig[A]] =
+    ObjectType[OdbRepo[F], StepConfig[A]](
       name         = s"${typePrefix}Step",
       description  = "Step (bias, dark, science, etc.)",
-      fields[OdbRepo[F], StepModel[A]](
+      fields[OdbRepo[F], StepConfig[A]](
 
         Field(
           name        = "stepType",
@@ -84,11 +84,11 @@ object StepSchema {
       )
     )
 
-  def StepConfigType[F[_]: Effect]: InterfaceType[OdbRepo[F], StepModel[_]] =
-    InterfaceType[OdbRepo[F], StepModel[_]](
+  def StepConfigType[F[_]: Effect]: InterfaceType[OdbRepo[F], StepConfig[_]] =
+    InterfaceType[OdbRepo[F], StepConfig[_]](
       name         = s"StepConfig",
       description  = "Step (bias, dark, science, etc.)",
-      fields[OdbRepo[F], StepModel[_]](
+      fields[OdbRepo[F], StepConfig[_]](
 
         Field(
           name        = "stepType",
@@ -99,85 +99,85 @@ object StepSchema {
 
       )
     ).withPossibleTypes(() => List(
-      PossibleObject[OdbRepo[F], StepModel[_]](BiasStepType[F]),
-      PossibleObject[OdbRepo[F], StepModel[_]](DarkStepType[F]),
-      PossibleObject[OdbRepo[F], StepModel[_]](GcalStepType[F]),
-      PossibleObject[OdbRepo[F], StepModel[_]](ScienceStepType[F])
+      PossibleObject[OdbRepo[F], StepConfig[_]](BiasStepType[F]),
+      PossibleObject[OdbRepo[F], StepConfig[_]](DarkStepType[F]),
+      PossibleObject[OdbRepo[F], StepConfig[_]](GcalStepType[F]),
+      PossibleObject[OdbRepo[F], StepConfig[_]](ScienceStepType[F])
     ))
 
-  def BiasStepType[F[_]: Effect]: ObjectType[OdbRepo[F], StepModel.Bias[_]] =
-    ObjectType[OdbRepo[F], StepModel.Bias[_]](
+  def BiasStepType[F[_]: Effect]: ObjectType[OdbRepo[F], StepConfig.Bias[_]] =
+    ObjectType[OdbRepo[F], StepConfig.Bias[_]](
       name        = "Bias",
       description = "Bias calibration step",
-      interfaces  = List(PossibleInterface.apply[OdbRepo[F], StepModel.Bias[_]](StepConfigType[F])),
+      interfaces  = List(PossibleInterface.apply[OdbRepo[F], StepConfig.Bias[_]](StepConfigType[F])),
       fields      = Nil
     )
 
-  def DarkStepType[F[_]: Effect]: ObjectType[OdbRepo[F], StepModel.Dark[_]] =
-    ObjectType[OdbRepo[F], StepModel.Dark[_]](
+  def DarkStepType[F[_]: Effect]: ObjectType[OdbRepo[F], StepConfig.Dark[_]] =
+    ObjectType[OdbRepo[F], StepConfig.Dark[_]](
       name        = "Dark",
       description = "Dark calibration step",
-      interfaces  = List(PossibleInterface.apply[OdbRepo[F], StepModel.Dark[_]](StepConfigType[F])),
+      interfaces  = List(PossibleInterface.apply[OdbRepo[F], StepConfig.Dark[_]](StepConfigType[F])),
       fields      = Nil
     )
 
-  def GcalStepType[F[_]: Effect]: ObjectType[OdbRepo[F], StepModel.Gcal[_]] =
-    ObjectType[OdbRepo[F], StepModel.Gcal[_]](
+  def GcalStepType[F[_]: Effect]: ObjectType[OdbRepo[F], StepConfig.Gcal[_]] =
+    ObjectType[OdbRepo[F], StepConfig.Gcal[_]](
       name        = "Gcal",
       description = "GCAL calibration step (flat / arc)",
-      interfaces  = List(PossibleInterface.apply[OdbRepo[F], StepModel.Gcal[_]](StepConfigType[F])),
+      interfaces  = List(PossibleInterface.apply[OdbRepo[F], StepConfig.Gcal[_]](StepConfigType[F])),
       fields      = List(
 
         Field(
           name        = "continuum",
           fieldType   = OptionType(EnumTypeGcalContinuum),
           description = Some("GCAL continuum, present if no arcs are used"),
-          resolve     = (ctx: Context[OdbRepo[F], StepModel.Gcal[_]]) => ctx.value.gcalConfig.lamp.swap.toOption
+          resolve     = (ctx: Context[OdbRepo[F], StepConfig.Gcal[_]]) => ctx.value.gcalConfig.lamp.swap.toOption
         ),
 
         Field(
           name        = "arcs",
           fieldType   = ListType(EnumTypeGcalArc),
           description = Some("GCAL arcs, one or more present if no continuum is used"),
-          resolve     = (ctx: Context[OdbRepo[F], StepModel.Gcal[_]]) => ctx.value.gcalConfig.lamp.toOption.toList.flatMap(_.toList)
+          resolve     = (ctx: Context[OdbRepo[F], StepConfig.Gcal[_]]) => ctx.value.gcalConfig.lamp.toOption.toList.flatMap(_.toList)
         ),
 
         Field(
           name        = "filter",
           fieldType   = EnumTypeGcalFilter,
           description = Some("GCAL filter"),
-          resolve     = (ctx: Context[OdbRepo[F], StepModel.Gcal[_]]) => ctx.value.gcalConfig.filter
+          resolve     = (ctx: Context[OdbRepo[F], StepConfig.Gcal[_]]) => ctx.value.gcalConfig.filter
         ),
 
         Field(
           name        = "diffuser",
           fieldType   = EnumTypeGcalDiffuser,
           description = Some("GCAL diffuser"),
-          resolve     = (ctx: Context[OdbRepo[F], StepModel.Gcal[_]]) => ctx.value.gcalConfig.diffuser
+          resolve     = (ctx: Context[OdbRepo[F], StepConfig.Gcal[_]]) => ctx.value.gcalConfig.diffuser
         ),
 
         Field(
           name        = "shutter",
           fieldType   = EnumTypeGcalShutter,
           description = Some("GCAL shutter"),
-          resolve     = (ctx: Context[OdbRepo[F], StepModel.Gcal[_]]) => ctx.value.gcalConfig.shutter
+          resolve     = (ctx: Context[OdbRepo[F], StepConfig.Gcal[_]]) => ctx.value.gcalConfig.shutter
         )
 
       )
     )
 
-  def ScienceStepType[F[_]: Effect]: ObjectType[OdbRepo[F], StepModel.Science[_]] =
-    ObjectType[OdbRepo[F], StepModel.Science[_]] (
+  def ScienceStepType[F[_]: Effect]: ObjectType[OdbRepo[F], StepConfig.Science[_]] =
+    ObjectType[OdbRepo[F], StepConfig.Science[_]] (
       name        = "Science",
       description = "Science step",
-      interfaces  = List(PossibleInterface.apply[OdbRepo[F], StepModel.Science[_]](StepConfigType[F])),
+      interfaces  = List(PossibleInterface.apply[OdbRepo[F], StepConfig.Science[_]](StepConfigType[F])),
       fields      = List(
 
         Field(
           name        = "offset",
           fieldType   = OffsetType[F],
           description = Some("Offset"),
-          resolve     = (ctx: Context[OdbRepo[F], StepModel.Science[_]]) => ctx.value.offset
+          resolve     = (ctx: Context[OdbRepo[F], StepConfig.Science[_]]) => ctx.value.offset
         )
       )
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/SequenceModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/SequenceModelSuite.scala
@@ -14,9 +14,6 @@ final class SequenceModelSuite extends DisciplineSuite {
 
   import ArbSequenceModel._
 
-  checkAll("BreakpointStep",       EqTests[BreakpointStep[Int]].eqv)
-  checkAll("CreateBreakpointStep", EqTests[BreakpointStep.Create[Int]].eqv)
-
   checkAll("Atom",                 EqTests[Atom[Int]].eqv)
   checkAll("CreateAtom",           EqTests[Atom.Create[Int]].eqv)
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/StepModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/StepModelSuite.scala
@@ -15,10 +15,13 @@ final class StepModelSuite extends DisciplineSuite {
   import ArbStepModel._
   import ArbOffsetModel._
 
-  checkAll("StepModel.StepModel",  EqTests[StepConfig[Int]].eqv)
-  checkAll("StepModel.CreateStep", EqTests[StepConfig.CreateStepConfig[Int]].eqv)
+  checkAll("StepModel",                  EqTests[StepModel[Int]].eqv)
+  checkAll("StepModel",                  EqTests[StepModel.Create[Int]].eqv)
 
-  checkAll("StepModel.CreateStep.instrumentConfig", OptionalTests(StepConfig.CreateStepConfig.instrumentConfig[Int]))
-  checkAll("StepModel.CreateStep.gcalConfig",    OptionalTests(StepConfig.CreateStepConfig.gcalConfig[Int]))
-  checkAll("StepModel.CreateStep.offset",        OptionalTests(StepConfig.CreateStepConfig.offset[Int]))
+  checkAll("StepConfig",                  EqTests[StepConfig[Int]].eqv)
+  checkAll("StepConfig.CreateStepConfig", EqTests[StepConfig.CreateStepConfig[Int]].eqv)
+
+  checkAll("StepConfig.CreateStep.instrumentConfig", OptionalTests(StepConfig.CreateStepConfig.instrumentConfig[Int]))
+  checkAll("StepConfig.CreateStep.gcalConfig",       OptionalTests(StepConfig.CreateStepConfig.gcalConfig[Int]))
+  checkAll("StepConfig.CreateStep.offset",           OptionalTests(StepConfig.CreateStepConfig.offset[Int]))
 }

--- a/modules/core/src/test/scala/lucuma/odb/api/model/StepModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/StepModelSuite.scala
@@ -15,10 +15,10 @@ final class StepModelSuite extends DisciplineSuite {
   import ArbStepModel._
   import ArbOffsetModel._
 
-  checkAll("StepModel.StepModel",  EqTests[StepModel[Int]].eqv)
-  checkAll("StepModel.CreateStep", EqTests[StepModel.CreateStep[Int]].eqv)
+  checkAll("StepModel.StepModel",  EqTests[StepConfig[Int]].eqv)
+  checkAll("StepModel.CreateStep", EqTests[StepConfig.CreateStepConfig[Int]].eqv)
 
-  checkAll("StepModel.CreateStep.instrumentConfig", OptionalTests(StepModel.CreateStep.instrumentConfig[Int]))
-  checkAll("StepModel.CreateStep.gcalConfig",    OptionalTests(StepModel.CreateStep.gcalConfig[Int]))
-  checkAll("StepModel.CreateStep.offset",        OptionalTests(StepModel.CreateStep.offset[Int]))
+  checkAll("StepModel.CreateStep.instrumentConfig", OptionalTests(StepConfig.CreateStepConfig.instrumentConfig[Int]))
+  checkAll("StepModel.CreateStep.gcalConfig",    OptionalTests(StepConfig.CreateStepConfig.gcalConfig[Int]))
+  checkAll("StepModel.CreateStep.offset",        OptionalTests(StepConfig.CreateStepConfig.offset[Int]))
 }

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSequenceModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSequenceModel.scala
@@ -21,12 +21,12 @@ trait ArbSequenceModel extends Helper {
     Arbitrary {
       for {
         b <- arbitrary[Breakpoint]
-        s <- arbitrary[StepModel[A]]
+        s <- arbitrary[StepConfig[A]]
       } yield BreakpointStep(b, s)
     }
 
   implicit def cogBreakpointStep[A: Cogen]: Cogen[BreakpointStep[A]] =
-    Cogen[(Breakpoint, StepModel[A])].contramap { in => (
+    Cogen[(Breakpoint, StepConfig[A])].contramap { in => (
       in.breakpoint,
       in.step
     )}
@@ -35,12 +35,12 @@ trait ArbSequenceModel extends Helper {
     Arbitrary {
       for {
         b <- arbitrary[Breakpoint]
-        s <- arbitrary[StepModel.CreateStep[A]]
+        s <- arbitrary[StepConfig.CreateStepConfig[A]]
       } yield BreakpointStep.Create(b, s)
     }
 
   implicit def cogBreakpointStepCreate[A: Cogen]: Cogen[BreakpointStep.Create[A]] =
-    Cogen[(Breakpoint, StepModel.CreateStep[A])].contramap { in => (
+    Cogen[(Breakpoint, StepConfig.CreateStepConfig[A])].contramap { in => (
       in.breakpoint,
       in.step
     )}

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSequenceModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSequenceModel.scala
@@ -7,68 +7,38 @@ package arb
 import lucuma.odb.api.model.SequenceModel._
 
 import cats.data.NonEmptyList
-import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 
 trait ArbSequenceModel extends Helper {
 
-  import ArbEnumerated._
   import ArbGmosModel._
   import ArbStepModel._
-
-  implicit def arbBreakpointStep[A: Arbitrary]: Arbitrary[BreakpointStep[A]] =
-    Arbitrary {
-      for {
-        b <- arbitrary[Breakpoint]
-        s <- arbitrary[StepConfig[A]]
-      } yield BreakpointStep(b, s)
-    }
-
-  implicit def cogBreakpointStep[A: Cogen]: Cogen[BreakpointStep[A]] =
-    Cogen[(Breakpoint, StepConfig[A])].contramap { in => (
-      in.breakpoint,
-      in.step
-    )}
-
-  implicit def arbBreakpointStepCreate[A: Arbitrary]: Arbitrary[BreakpointStep.Create[A]] =
-    Arbitrary {
-      for {
-        b <- arbitrary[Breakpoint]
-        s <- arbitrary[StepConfig.CreateStepConfig[A]]
-      } yield BreakpointStep.Create(b, s)
-    }
-
-  implicit def cogBreakpointStepCreate[A: Cogen]: Cogen[BreakpointStep.Create[A]] =
-    Cogen[(Breakpoint, StepConfig.CreateStepConfig[A])].contramap { in => (
-      in.breakpoint,
-      in.step
-    )}
 
   implicit def arbAtom[A: Arbitrary]: Arbitrary[Atom[A]] =
     Arbitrary {
       for {
-        s0 <- arbitrary[BreakpointStep[A]]
+        s0 <- arbitrary[StepModel[A]]
         s  <- tinyPositiveSize
-        ss <- Gen.listOfN(s, arbitrary[BreakpointStep[A]])
+        ss <- Gen.listOfN(s, arbitrary[StepModel[A]])
       } yield Atom(NonEmptyList(s0, ss))
     }
 
   implicit def cogAtom[A: Cogen]: Cogen[Atom[A]] =
-    Cogen[List[BreakpointStep[A]]].contramap(_.steps.toList)
+    Cogen[List[StepModel[A]]].contramap(_.steps.toList)
 
 
   implicit def arbCreateAtom[A: Arbitrary]: Arbitrary[Atom.Create[A]] =
     Arbitrary {
       for {
-        s0 <- arbitrary[BreakpointStep.Create[A]]
+        s0 <- arbitrary[StepModel.Create[A]]
         s  <- tinyPositiveSize
-        ss <- Gen.listOfN(s, arbitrary[BreakpointStep.Create[A]])
+        ss <- Gen.listOfN(s, arbitrary[StepModel.Create[A]])
       } yield Atom.Create[A](s0 :: ss)
     }
 
   implicit def cogAtomCreate[A: Cogen]: Cogen[Atom.Create[A]] =
-    Cogen[List[BreakpointStep.Create[A]]].contramap(_.steps)
+    Cogen[List[StepModel.Create[A]]].contramap(_.steps)
 
 
   implicit def arbSequence[D: Arbitrary]: Arbitrary[Sequence[D]] =

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbStepModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbStepModel.scala
@@ -6,12 +6,13 @@ package arb
 
 import lucuma.core.math.Offset
 import lucuma.core.math.arb.ArbOffset
-
+import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 
 trait ArbStepModel {
 
+  import ArbEnumerated._
   import ArbGcalModel._
   import ArbOffset._
   import ArbOffsetModel._
@@ -60,7 +61,7 @@ trait ArbStepModel {
       in.offset
     )}
 
-  implicit def arbStep[A: Arbitrary]: Arbitrary[StepConfig[A]] =
+  implicit def arbStepConfig[A: Arbitrary]: Arbitrary[StepConfig[A]] =
     Arbitrary {
       Gen.oneOf(
         arbitrary[StepConfig.Bias[A]],
@@ -70,7 +71,7 @@ trait ArbStepModel {
       )
     }
 
-  implicit def cogStep[A: Cogen]: Cogen[StepConfig[A]] =
+  implicit def cogStepConfig[A: Cogen]: Cogen[StepConfig[A]] =
     Cogen[(
       Option[StepConfig.Bias[A]],
       Option[StepConfig.Dark[A]],
@@ -123,7 +124,7 @@ trait ArbStepModel {
       in.offset
     )}
 
-  implicit def arbCreateStep[A: Arbitrary]: Arbitrary[StepConfig.CreateStepConfig[A]] =
+  implicit def arbCreateStepConfig[A: Arbitrary]: Arbitrary[StepConfig.CreateStepConfig[A]] =
     Arbitrary {
       Gen.oneOf(
         arbitrary[StepConfig.CreateBias[A]].map(   b => StepConfig.CreateStepConfig(Some(b), None, None, None)),
@@ -136,7 +137,7 @@ trait ArbStepModel {
       )
     }
 
-  implicit def cogCreateStep[A: Cogen]: Cogen[StepConfig.CreateStepConfig[A]] =
+  implicit def cogCreateStepConfig[A: Cogen]: Cogen[StepConfig.CreateStepConfig[A]] =
     Cogen[(
       Option[StepConfig.CreateBias[A]],
       Option[StepConfig.CreateDark[A]],
@@ -148,6 +149,35 @@ trait ArbStepModel {
       in.gcal,
       in.science
     )}
+
+    implicit def arbStepModel[A: Arbitrary]: Arbitrary[StepModel[A]] =
+    Arbitrary {
+      for {
+        b <- arbitrary[Breakpoint]
+        s <- arbitrary[StepConfig[A]]
+      } yield StepModel(b, s)
+    }
+
+  implicit def cogStepModel[A: Cogen]: Cogen[StepModel[A]] =
+    Cogen[(Breakpoint, StepConfig[A])].contramap { in => (
+      in.breakpoint,
+      in.config
+    )}
+
+  implicit def arbStepModelCreate[A: Arbitrary]: Arbitrary[StepModel.Create[A]] =
+    Arbitrary {
+      for {
+        b <- arbitrary[Breakpoint]
+        s <- arbitrary[StepConfig.CreateStepConfig[A]]
+      } yield StepModel.Create(b, s)
+    }
+
+  implicit def cogStepModelCreate[A: Cogen]: Cogen[StepModel.Create[A]] =
+    Cogen[(Breakpoint, StepConfig.CreateStepConfig[A])].contramap { in => (
+      in.breakpoint,
+      in.step
+    )}
+
 
 }
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbStepModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbStepModel.scala
@@ -16,132 +16,132 @@ trait ArbStepModel {
   import ArbOffset._
   import ArbOffsetModel._
 
-  implicit def arbBias[A: Arbitrary]: Arbitrary[StepModel.Bias[A]] =
+  implicit def arbBias[A: Arbitrary]: Arbitrary[StepConfig.Bias[A]] =
     Arbitrary {
-      arbitrary[A].map(StepModel.Bias(_))
+      arbitrary[A].map(StepConfig.Bias(_))
     }
 
-  implicit def cogBias[A: Cogen]: Cogen[StepModel.Bias[A]] =
+  implicit def cogBias[A: Cogen]: Cogen[StepConfig.Bias[A]] =
     Cogen[A].contramap(_.instrumentConfig)
 
-  implicit def arbDark[A: Arbitrary]: Arbitrary[StepModel.Dark[A]] =
+  implicit def arbDark[A: Arbitrary]: Arbitrary[StepConfig.Dark[A]] =
     Arbitrary {
-      arbitrary[A].map(StepModel.Dark(_))
+      arbitrary[A].map(StepConfig.Dark(_))
     }
 
-  implicit def cogDark[A: Cogen]: Cogen[StepModel.Dark[A]] =
+  implicit def cogDark[A: Cogen]: Cogen[StepConfig.Dark[A]] =
     Cogen[A].contramap(_.instrumentConfig)
 
-  implicit def arbGcal[A: Arbitrary]: Arbitrary[StepModel.Gcal[A]] =
+  implicit def arbGcal[A: Arbitrary]: Arbitrary[StepConfig.Gcal[A]] =
     Arbitrary {
       for {
         a <- arbitrary[A]
         g <- arbitrary[GcalModel]
-      } yield StepModel.Gcal(a, g)
+      } yield StepConfig.Gcal(a, g)
     }
 
-  implicit def cogGcal[A: Cogen]: Cogen[StepModel.Gcal[A]] =
+  implicit def cogGcal[A: Cogen]: Cogen[StepConfig.Gcal[A]] =
     Cogen[(A, GcalModel)].contramap { in => (
       in.instrumentConfig,
       in.gcalConfig
     )}
 
-  implicit def arbScience[A: Arbitrary]: Arbitrary[StepModel.Science[A]] =
+  implicit def arbScience[A: Arbitrary]: Arbitrary[StepConfig.Science[A]] =
     Arbitrary {
       for {
         a <- arbitrary[A]
         o <- arbitrary[Offset]
-      } yield StepModel.Science(a, o)
+      } yield StepConfig.Science(a, o)
     }
 
-  implicit def cogScience[A: Cogen]: Cogen[StepModel.Science[A]] =
+  implicit def cogScience[A: Cogen]: Cogen[StepConfig.Science[A]] =
     Cogen[(A, Offset)].contramap { in => (
       in.instrumentConfig,
       in.offset
     )}
 
-  implicit def arbStep[A: Arbitrary]: Arbitrary[StepModel[A]] =
+  implicit def arbStep[A: Arbitrary]: Arbitrary[StepConfig[A]] =
     Arbitrary {
       Gen.oneOf(
-        arbitrary[StepModel.Bias[A]],
-        arbitrary[StepModel.Dark[A]],
-        arbitrary[StepModel.Gcal[A]],
-        arbitrary[StepModel.Science[A]]
+        arbitrary[StepConfig.Bias[A]],
+        arbitrary[StepConfig.Dark[A]],
+        arbitrary[StepConfig.Gcal[A]],
+        arbitrary[StepConfig.Science[A]]
       )
     }
 
-  implicit def cogStep[A: Cogen]: Cogen[StepModel[A]] =
+  implicit def cogStep[A: Cogen]: Cogen[StepConfig[A]] =
     Cogen[(
-      Option[StepModel.Bias[A]],
-      Option[StepModel.Dark[A]],
-      Option[StepModel.Gcal[A]],
-      Option[StepModel.Science[A]]
+      Option[StepConfig.Bias[A]],
+      Option[StepConfig.Dark[A]],
+      Option[StepConfig.Gcal[A]],
+      Option[StepConfig.Science[A]]
     )].contramap { in => (in.bias, in.dark, in.gcal, in.science) }
 
 
-  implicit def arbCreateBias[A: Arbitrary]: Arbitrary[StepModel.CreateBias[A]] =
+  implicit def arbCreateBias[A: Arbitrary]: Arbitrary[StepConfig.CreateBias[A]] =
     Arbitrary {
-      arbitrary[A].map(StepModel.CreateBias(_))
+      arbitrary[A].map(StepConfig.CreateBias(_))
     }
 
-  implicit def cogCreateBias[A: Cogen]: Cogen[StepModel.CreateBias[A]] =
+  implicit def cogCreateBias[A: Cogen]: Cogen[StepConfig.CreateBias[A]] =
     Cogen[A].contramap(_.config)
 
-  implicit def arbCreateDark[A: Arbitrary]: Arbitrary[StepModel.CreateDark[A]] =
+  implicit def arbCreateDark[A: Arbitrary]: Arbitrary[StepConfig.CreateDark[A]] =
     Arbitrary {
-      arbitrary[A].map(StepModel.CreateDark(_))
+      arbitrary[A].map(StepConfig.CreateDark(_))
     }
 
-  implicit def cogCreateDark[A: Cogen]: Cogen[StepModel.CreateDark[A]] =
+  implicit def cogCreateDark[A: Cogen]: Cogen[StepConfig.CreateDark[A]] =
     Cogen[A].contramap(_.config)
 
-  implicit def arbCreateGcal[A: Arbitrary]: Arbitrary[StepModel.CreateGcal[A]] =
+  implicit def arbCreateGcal[A: Arbitrary]: Arbitrary[StepConfig.CreateGcal[A]] =
     Arbitrary {
       for {
         a <- arbitrary[A]
         g <- arbitrary[GcalModel.Create]
-      } yield StepModel.CreateGcal(a, g)
+      } yield StepConfig.CreateGcal(a, g)
     }
 
-  implicit def cogCreateGcal[A: Cogen]: Cogen[StepModel.CreateGcal[A]] =
+  implicit def cogCreateGcal[A: Cogen]: Cogen[StepConfig.CreateGcal[A]] =
     Cogen[(A, GcalModel.Create)].contramap { in => (
       in.config,
       in.gcalConfig
     )}
 
-  implicit def arbCreateScience[A: Arbitrary]: Arbitrary[StepModel.CreateScience[A]] =
+  implicit def arbCreateScience[A: Arbitrary]: Arbitrary[StepConfig.CreateScience[A]] =
     Arbitrary {
       for {
         a <- arbitrary[A]
         o <- arbitrary[OffsetModel.Input]
-      } yield StepModel.CreateScience(a, o)
+      } yield StepConfig.CreateScience(a, o)
     }
 
-  implicit def cogCreateScience[A: Cogen]: Cogen[StepModel.CreateScience[A]] =
+  implicit def cogCreateScience[A: Cogen]: Cogen[StepConfig.CreateScience[A]] =
     Cogen[(A, OffsetModel.Input)].contramap { in => (
       in.config,
       in.offset
     )}
 
-  implicit def arbCreateStep[A: Arbitrary]: Arbitrary[StepModel.CreateStep[A]] =
+  implicit def arbCreateStep[A: Arbitrary]: Arbitrary[StepConfig.CreateStepConfig[A]] =
     Arbitrary {
       Gen.oneOf(
-        arbitrary[StepModel.CreateBias[A]].map(   b => StepModel.CreateStep(Some(b), None, None, None)),
-        arbitrary[StepModel.CreateDark[A]].map(   d => StepModel.CreateStep(None, Some(d), None, None)),
-        arbitrary[StepModel.CreateGcal[A]].map(   g => StepModel.CreateStep(None, None, Some(g), None)),
-        arbitrary[StepModel.CreateScience[A]].map(s => StepModel.CreateStep(None, None, None, Some(s))),
-        arbitrary[(StepModel.CreateGcal[A], StepModel.CreateScience[A])].map { case (g, s) =>
-          StepModel.CreateStep(None, None, Some(g), Some(s))  // invalid but possible input
+        arbitrary[StepConfig.CreateBias[A]].map(   b => StepConfig.CreateStepConfig(Some(b), None, None, None)),
+        arbitrary[StepConfig.CreateDark[A]].map(   d => StepConfig.CreateStepConfig(None, Some(d), None, None)),
+        arbitrary[StepConfig.CreateGcal[A]].map(   g => StepConfig.CreateStepConfig(None, None, Some(g), None)),
+        arbitrary[StepConfig.CreateScience[A]].map(s => StepConfig.CreateStepConfig(None, None, None, Some(s))),
+        arbitrary[(StepConfig.CreateGcal[A], StepConfig.CreateScience[A])].map { case (g, s) =>
+          StepConfig.CreateStepConfig(None, None, Some(g), Some(s))  // invalid but possible input
         }
       )
     }
 
-  implicit def cogCreateStep[A: Cogen]: Cogen[StepModel.CreateStep[A]] =
+  implicit def cogCreateStep[A: Cogen]: Cogen[StepConfig.CreateStepConfig[A]] =
     Cogen[(
-      Option[StepModel.CreateBias[A]],
-      Option[StepModel.CreateDark[A]],
-      Option[StepModel.CreateGcal[A]],
-      Option[StepModel.CreateScience[A]]
+      Option[StepConfig.CreateBias[A]],
+      Option[StepConfig.CreateDark[A]],
+      Option[StepConfig.CreateGcal[A]],
+      Option[StepConfig.CreateScience[A]]
     )].contramap { in => (
       in.bias,
       in.dark,

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -274,7 +274,7 @@ object Init {
         sci0_525,  flat_525,
         flat_525,  sci0_525,
         sci15_525, flat_525
-      ).map(BreakpointStep.Create.continueTo)
+      ).map(StepModel.Create.continueTo)
        .grouped(2) // pairs flat and science steps
        .toList
        .map(Atom.Create(_))

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -159,7 +159,7 @@ object Init {
     targetsJson.traverse(decode[TargetModel.CreateSidereal])
 
   import GmosModel.{CreateCcdReadout, CreateSouthDynamic}
-  import StepModel.CreateStep
+  import StepConfig.CreateStepConfig
 
   import CreateSouthDynamic.{exposure, filter, fpu, grating, readout, roi, step}
   import CreateCcdReadout.{ampRead, xBin, yBin}
@@ -184,10 +184,10 @@ object Init {
       None
     )
 
-  val ac1: CreateStep[CreateSouthDynamic] =
-    CreateStep.science(gmosAc, OffsetModel.Input.Zero)
+  val ac1: CreateStepConfig[CreateSouthDynamic] =
+    CreateStepConfig.science(gmosAc, OffsetModel.Input.Zero)
 
-  val ac2: CreateStep[CreateSouthDynamic] =
+  val ac2: CreateStepConfig[CreateSouthDynamic] =
     edit(ac1) {
       for {
         _ <- step.p                                         := ComponentInput(10.arcsec)
@@ -199,7 +199,7 @@ object Init {
       } yield ()
     }
 
-  val ac3: CreateStep[CreateSouthDynamic] =
+  val ac3: CreateStepConfig[CreateSouthDynamic] =
     step.exposure.assign_(FiniteDurationModel.Input(30.seconds)).runS(ac2).value
 
   val acquisitionSequence: Sequence.Create[CreateSouthDynamic] =
@@ -242,23 +242,23 @@ object Init {
   val threeSeconds: FiniteDurationModel.Input =
     FiniteDurationModel.Input.fromSeconds(3.0)
 
-  val flat_520: CreateStep[CreateSouthDynamic] =
-    CreateStep.gcal(edit(gmos520)(exposure := threeSeconds), gcal)
+  val flat_520: CreateStepConfig[CreateSouthDynamic] =
+    CreateStepConfig.gcal(edit(gmos520)(exposure := threeSeconds), gcal)
 
-  val flat_525: CreateStep[CreateSouthDynamic] =
-    CreateStep.gcal(edit(gmos525)(exposure := threeSeconds), gcal)
+  val flat_525: CreateStepConfig[CreateSouthDynamic] =
+    CreateStepConfig.gcal(edit(gmos525)(exposure := threeSeconds), gcal)
 
-  val sci0_520: CreateStep[CreateSouthDynamic] =
-    CreateStep.science(gmos520, OffsetModel.Input.Zero)
+  val sci0_520: CreateStepConfig[CreateSouthDynamic] =
+    CreateStepConfig.science(gmos520, OffsetModel.Input.Zero)
 
-  val sci15_520: CreateStep[CreateSouthDynamic] =
-    CreateStep.science(gmos520, Q15)
+  val sci15_520: CreateStepConfig[CreateSouthDynamic] =
+    CreateStepConfig.science(gmos520, Q15)
 
-  val sci0_525: CreateStep[CreateSouthDynamic] =
-    CreateStep.science(gmos525, OffsetModel.Input.Zero)
+  val sci0_525: CreateStepConfig[CreateSouthDynamic] =
+    CreateStepConfig.science(gmos525, OffsetModel.Input.Zero)
 
-  val sci15_525: CreateStep[CreateSouthDynamic] =
-    CreateStep.science(gmos525, Q15)
+  val sci15_525: CreateStepConfig[CreateSouthDynamic] =
+    CreateStepConfig.science(gmos525, Q15)
 
   val scienceSequence: Sequence.Create[CreateSouthDynamic] =
     Sequence.Create(


### PR DESCRIPTION
A bit of a deck-chair shuffling of the step model on the road to adding ids.  It removes a layer of hierarchy and offers a `Step` interface that contains everything except the instrument-specific bits, making it possible to use most of it w/o knowing the instrument.