### PR TITLE
Atom and step ids (Part 1)

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/Database.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/Database.scala
@@ -25,4 +25,6 @@ trait Database[T] {
 
   def error[A](m: => String): State[T, ValidatedInput[A]] =
     State.pure[T, ValidatedInput[A]](InputError.fromMessage(m).invalidNec[A])
+
+//  def programAsterism(pas: List[(Program.Id, Asterism.Id)]): State[T, ]
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/Database.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/Database.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.core.model.{Asterism, ConstraintSet, Observation, Program, Target}
+import cats.data.State
+import cats.syntax.all._
+
+trait Database[T] {
+
+  val atom:          Store[T, Atom.Id, AtomModel[_]]
+
+  val asterism:      Store[T, Asterism.Id, AsterismModel]
+
+  val constraintSet: Store[T, ConstraintSet.Id, ConstraintSetModel]
+
+  val observation:   Store[T, Observation.Id, ObservationModel]
+
+  val program:       Store[T, Program.Id, ProgramModel]
+
+  val step:          Store[T, Step.Id, StepModel[_]]
+
+  val target:        Store[T, Target.Id, TargetModel]
+
+  def error[A](m: => String): State[T, ValidatedInput[A]] =
+    State.pure[T, ValidatedInput[A]](InputError.fromMessage(m).invalidNec[A])
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/Database.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/Database.scala
@@ -26,5 +26,4 @@ trait Database[T] {
   def error[A](m: => String): State[T, ValidatedInput[A]] =
     State.pure[T, ValidatedInput[A]](InputError.fromMessage(m).invalidNec[A])
 
-//  def programAsterism(pas: List[(Program.Id, Asterism.Id)]): State[T, ]
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
@@ -32,40 +32,12 @@ object StepModel {
     config:     CreateStepConfig[A]
   ) {
 
-    // Presumably IdSupply turns into something more capable --
-    //
-    // * id lookup
-    // * id creation when necessary
-    // * registering newly created stuff in the item map
-
     def create[T, B](db: Database[T])(implicit V: InputValidator[A, B]): State[T, ValidatedInput[StepModel[B]]] =
       for {
         i <- db.step.getUnusedId(id)
         o  = (i, config.create[B]).mapN { (i, c) => StepModel(i, breakpoint, c) }
         _ <- db.step.saveValid(o)(_.id)
       } yield o
-
-    // ^^^ this is still somehow not quite right.  what if there were other
-    //     ids to lookup?  In the case of ObservationModel you have to make sure
-    //     that target / asterism, constraint set, etc. really exist.
-
-    // So the second argument, instead of just being a Validated[Id => StepModel[D]]
-    // should maybe be a full fledged State[T, Validated[Id => StepModel[D]]
-    // though the "simpler" form above could exist as a convenience.
-    //
-    // So for an observation maybe:
-    //
-    // store.storeObservation(
-    //   id,
-    //   for {
-    //     a <- store.definedAsterismId(aid)  // State[T, ValidatedInput[Asterism.Id]] though aid may be None ...
-    //     ....
-    //   } yield (a, blah, baz).mapN { (x, y, z) => ObservationModel(...) }
-    // }
-
-    // Think this "Store[T] thing should be moved to TableState and we should
-    // delete the IdSupply in Ids.
-
 
   }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
@@ -4,14 +4,16 @@
 package lucuma.odb.api.model
 
 import lucuma.odb.api.model.StepConfig.CreateStepConfig
-
 import cats.Eq
+import cats.data.State
+import cats.syntax.all._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 import monocle.macros.Lenses
 
 
 @Lenses final case class StepModel[A](
+  id:         Step.Id,
   breakpoint: Breakpoint,
   config:     StepConfig[A]
 )
@@ -19,39 +21,72 @@ import monocle.macros.Lenses
 object StepModel {
   implicit def EqStepModel[A: Eq]: Eq[StepModel[A]] =
     Eq.by { a => (
+      a.id,
       a.breakpoint,
       a.config
     )}
 
   @Lenses final case class Create[A](
+    id:         Option[Step.Id],
     breakpoint: Breakpoint,
-    step:       CreateStepConfig[A]
+    config:     CreateStepConfig[A]
   ) {
 
-    def create[B](implicit V: InputValidator[A, B]): ValidatedInput[StepModel[B]] =
-      step.create[B].map(s => StepModel(breakpoint, s))
+    // Presumably IdSupply turns into something more capable --
+    //
+    // * id lookup
+    // * id creation when necessary
+    // * registering newly created stuff in the item map
+
+    def create[T, B](db: Database[T])(implicit V: InputValidator[A, B]): State[T, ValidatedInput[StepModel[B]]] =
+      for {
+        i <- db.step.getUnusedId(id)
+        o  = (i, config.create[B]).mapN { (i, c) => StepModel(i, breakpoint, c) }
+        _ <- db.step.saveValid(o)(_.id)
+      } yield o
+
+    // ^^^ this is still somehow not quite right.  what if there were other
+    //     ids to lookup?  In the case of ObservationModel you have to make sure
+    //     that target / asterism, constraint set, etc. really exist.
+
+    // So the second argument, instead of just being a Validated[Id => StepModel[D]]
+    // should maybe be a full fledged State[T, Validated[Id => StepModel[D]]
+    // though the "simpler" form above could exist as a convenience.
+    //
+    // So for an observation maybe:
+    //
+    // store.storeObservation(
+    //   id,
+    //   for {
+    //     a <- store.definedAsterismId(aid)  // State[T, ValidatedInput[Asterism.Id]] though aid may be None ...
+    //     ....
+    //   } yield (a, blah, baz).mapN { (x, y, z) => ObservationModel(...) }
+    // }
+
+    // Think this "Store[T] thing should be moved to TableState and we should
+    // delete the IdSupply in Ids.
+
 
   }
 
   object Create {
 
     def stopBefore[A](s: CreateStepConfig[A]): Create[A] =
-      Create(Breakpoint.enabled, s)
+      Create(None, Breakpoint.enabled, s)
 
     def continueTo[A](s: CreateStepConfig[A]): Create[A] =
-      Create(Breakpoint.disabled, s)
+      Create(None, Breakpoint.disabled, s)
 
     implicit def EqCreate[A: Eq]: Eq[Create[A]] =
       Eq.by { a => (
+        a.id,
         a.breakpoint,
-        a.step
+        a.config
       )}
 
     implicit def DecoderCreate[A: Decoder]: Decoder[Create[A]] =
       deriveDecoder[Create[A]]
 
-    implicit def ValidatorCreate[A, B](implicit V: InputValidator[A, B]): InputValidator[Create[A], StepModel[B]] =
-      (cbs: Create[A]) => cbs.create[B]
   }
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/Store.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/Store.scala
@@ -1,0 +1,77 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.core.util.Gid
+import cats.data.State
+import cats.kernel.BoundedEnumerable
+import cats.syntax.all._
+import monocle.Lens
+import monocle.state.all._
+
+import scala.collection.immutable.SortedMap
+
+final class Store[T, I: Gid, M](
+  name:      String,
+  idLens:    Lens[T, I],
+  modelLens: Lens[T, SortedMap[I, M]]
+) {
+
+  def isDefinedAt(id: I): State[T, Boolean] =
+    modelLens.st.map(_.isDefinedAt(id))
+
+  def isEmptyAt(id: I): State[T, Boolean] =
+    isDefinedAt(id).map(r => !r)
+
+  val cycleNextUnused: State[T, I] = {
+    val unused: State[T, Boolean] =
+      for {
+        i <- idLens.extract
+        b <- isEmptyAt(i)
+      } yield b
+
+    for {
+      _ <- idLens.mod(BoundedEnumerable[I].cycleNext).untilM_(unused)
+      i <- idLens.extract
+    } yield i
+  }
+
+  private def alreadyDefined[A](i: I): State[T, ValidatedInput[A]] =
+    State.pure[T, ValidatedInput[A]](
+      InputError
+        .fromMessage(s"$name `${Gid[I].show(i)}` is already defined")
+        .invalidNec[A]
+    )
+
+  def getUnusedId(suggestion: Option[I]): State[T, ValidatedInput[I]] =
+    suggestion.fold(cycleNextUnused.map(_.validNec[InputError])) { id =>
+      isEmptyAt(id).ifM(
+        State.pure[T, ValidatedInput[I]](id.validNec[InputError]),
+        alreadyDefined[I](id)
+      )
+    }
+
+  def lookup(id: I): State[T, ValidatedInput[M]] =
+    modelLens
+      .st
+      .map(_.get(id).toValidNec(InputError.missingReference(name, Gid[I].show(id))))
+
+  def orError(id: I): State[T, M] =
+    lookup(id).map(_.valueOr(nec => throw InputError.Exception(nec)))
+
+  def optionalLookup(id: Option[I]): State[T, ValidatedInput[Option[M]]] =
+    id.traverse(lookup).map(_.sequence)
+
+  def save(i: I, m: M): State[T, ValidatedInput[Unit]] =
+    isDefinedAt(i).ifM(
+      alreadyDefined[Unit](i),
+      modelLens.mod_(_ + (i -> m)).map(_.validNec[InputError])
+    )
+
+  def saveValid(vim: ValidatedInput[M])(id: M => I): State[T, ValidatedInput[Unit]] =
+    vim.fold(
+      nec => State.pure[T, ValidatedInput[Unit]](nec.invalid[Unit]),
+      m   => save(id(m), m)
+    )
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ids.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ids.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.core.model.WithId
+
+import eu.timepit.refined.auto._
+
+// To be moved to lucuma.core.model.ids, presumably
+
+object Atom extends WithId {
+  protected val idTag = 'm'
+}
+
+object Step extends WithId {
+  protected val idTag = 's'
+}
+
+

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
@@ -137,7 +137,7 @@ object AsterismRepo {
         shareLeft[Program.Id, ProgramModel](
           "asterism",
           input,
-          TableState.program,
+          TableState.program.lookup,
           Tables.programAsterism,
           ProgramModel.ProgramEvent.updated
         )(update)
@@ -154,7 +154,7 @@ object AsterismRepo {
         update: (ManyToMany[Target.Id, Asterism.Id], IterableOnce[(Target.Id, Asterism.Id)]) => ManyToMany[Target.Id, Asterism.Id]
       ): F[AsterismModel] =
         shareLeft[Target.Id, TargetModel](
-          "asterism", input, TableState.target, Tables.targetAsterism, TargetModel.TargetEvent.updated
+          "asterism", input, TableState.target.lookup, Tables.targetAsterism, TargetModel.TargetEvent.updated
         )(update)
 
       override def shareWithTargets(input: Sharing[Asterism.Id, Target.Id]): F[AsterismModel] =

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
@@ -3,12 +3,12 @@
 
 package lucuma.odb.api.repo
 
-import lucuma.odb.api.model.{AsterismModel, ProgramModel, Sharing, TargetModel}
+import lucuma.odb.api.model.{AsterismModel, Event, InputError, ProgramModel, Sharing, TargetModel}
 import lucuma.odb.api.model.AsterismModel.{AsterismEvent, Create}
 import lucuma.odb.api.model.syntax.toplevel._
 import lucuma.core.model.{Asterism, Observation, Program, Target}
 import cats._
-import cats.data.State
+import cats.data.EitherT
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import monocle.state.all._
@@ -109,25 +109,28 @@ object AsterismRepo {
           .filter(a => includeDeleted || a.isPresent)
         }
 
-      private def addAsterism[T <: AsterismModel](
-        asterismId: Option[Asterism.Id],
-        programs:   Set[Program.Id],
-        factory:    Asterism.Id => T
-      ): State[Tables, T] =
+      override def insert(input: Create): F[AsterismModel] = {
+        val create = EitherT(
+          tablesRef.modify { tables =>
+
+            val (tablesʹ, a) = (for {
+              a <- input.create(TableState)
+              _ <- a.traverse(am => Tables.programAsterism.mod_(_ ++ input.programIds.tupleRight(am.id)))
+            } yield a).run(tables).value
+
+            a.fold(
+              err => (tables,  InputError.Exception(err).asLeft),
+              am  => (tablesʹ, am.asRight)
+            )
+          }
+        ).rethrowT
+
         for {
-          a   <- createAndInsert(asterismId, factory)
-          _   <- Tables.programAsterism.mod_(_ ++ programs.toList.tupleRight(a.id))
+          a <- create
+          _ <- eventService.publish(AsterismEvent(_, Event.EditType.Created, a))
         } yield a
 
-      override def insert(input: Create): F[AsterismModel] =
-        constructAndPublish { t =>
-          val existing = tryNotFindAsterism(t, input.asterismId)
-          val programs = input.programIds.traverse(tryFindProgram(t, _))
-          val asterism = input.withId
-          (existing, programs, asterism).mapN((_, _, f) =>
-            addAsterism(input.asterismId, input.programIds.toSet, f)
-          )
-        }
+      }
 
       def programSharing(
         input: Sharing[Asterism.Id, Program.Id]

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ConstraintSetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ConstraintSetRepo.scala
@@ -4,10 +4,11 @@
 package lucuma.odb.api.repo
 
 import cats._
+import cats.data.EitherT
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import lucuma.core.model.{ConstraintSet, Observation, Program}
-import lucuma.odb.api.model.ConstraintSetModel
+import lucuma.odb.api.model.{ConstraintSetModel, Event, InputError}
 import lucuma.odb.api.model.ConstraintSetModel.ConstraintSetEvent
 import lucuma.odb.api.model.syntax.toplevel._
 
@@ -47,7 +48,7 @@ object ConstraintSetRepo {
         oid:            Observation.Id,
         includeDeleted: Boolean
       ): F[Option[ConstraintSetModel]] =
-        tablesRef.get.map{ t => 
+        tablesRef.get.map{ t =>
           for {
             o <- t.observations.get(oid)
             csid <- o.constraintSetId
@@ -65,11 +66,22 @@ object ConstraintSetRepo {
 
         selectPageFiltered(count, afterGid, includeDeleted) { _.programId === pid }
 
-      override def insert(newCs: ConstraintSetModel.Create): F[ConstraintSetModel] =
-        constructAndPublish { t =>
-          (tryNotFindConstraintSet(t, newCs.constraintSetId) *>
-            tryFindProgram(t, newCs.programId) *>
-            newCs.withId).map(createAndInsert(newCs.constraintSetId, _))
-        }
+      override def insert(newCs: ConstraintSetModel.Create): F[ConstraintSetModel] = {
+        val create = EitherT(
+          tablesRef.modify { tables =>
+            val (tablesʹ, c) = newCs.create(TableState).run(tables).value
+
+            c.fold(
+              err => (tables,  InputError.Exception(err).asLeft),
+              cm  => (tablesʹ, cm.asRight)
+            )
+          }
+        ).rethrowT
+
+        for {
+          c <- create
+          _ <- eventService.publish(ConstraintSetEvent(_, Event.EditType.Created, c))
+        } yield c
+      }
     }
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ConstraintSetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ConstraintSetRepo.scala
@@ -66,10 +66,10 @@ object ConstraintSetRepo {
 
         selectPageFiltered(count, afterGid, includeDeleted) { _.programId === pid }
 
-      override def insert(newCs: ConstraintSetModel.Create): F[ConstraintSetModel] = {
+      override def insert(input: ConstraintSetModel.Create): F[ConstraintSetModel] = {
         val create = EitherT(
           tablesRef.modify { tables =>
-            val (tablesʹ, c) = newCs.create(TableState).run(tables).value
+            val (tablesʹ, c) = input.create(TableState).run(tables).value
 
             c.fold(
               err => (tables,  InputError.Exception(err).asLeft),

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/Ids.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/Ids.scala
@@ -3,10 +3,10 @@
 
 package lucuma.odb.api.repo
 
+import lucuma.core.model.{Asterism, ConstraintSet, Observation, Program, Target}
+import lucuma.odb.api.model.{Atom, Step}
 import cats.kernel.BoundedEnumerable
-import lucuma.core.model.{ Asterism, Observation, Program, Target }
 import monocle.Lens
-import lucuma.core.model.ConstraintSet
 
 /**
  * Tracking "last" used ids of top-level types.
@@ -14,9 +14,11 @@ import lucuma.core.model.ConstraintSet
 final case class Ids(
   event:         Long,
   asterism:      Asterism.Id,
+  atom:          Atom.Id,
   constraintSet: ConstraintSet.Id,
   observation:   Observation.Id,
   program:       Program.Id,
+  step:          Step.Id,
   target:        Target.Id
 )
 
@@ -26,9 +28,11 @@ object Ids extends IdsOptics {
     Ids(
       event         = 0L,
       asterism      = BoundedEnumerable[Asterism.Id].minBound,
+      atom          = BoundedEnumerable[Atom.Id].minBound,
       constraintSet = BoundedEnumerable[ConstraintSet.Id].minBound,
       observation   = BoundedEnumerable[Observation.Id].minBound,
       program       = BoundedEnumerable[Program.Id].minBound,
+      step          = BoundedEnumerable[Step.Id].minBound,
       target        = BoundedEnumerable[Target.Id].minBound
     )
 
@@ -42,6 +46,9 @@ sealed trait IdsOptics { self: Ids.type =>
   val lastAsterism: Lens[Ids, Asterism.Id] =
     Lens[Ids, Asterism.Id](_.asterism)(b => a => a.copy(asterism = b))
 
+  val lastAtom: Lens[Ids, Atom.Id] =
+    Lens[Ids, Atom.Id](_.atom)(b => a => a.copy(atom = b))
+
   val lastConstraintSet: Lens[Ids, ConstraintSet.Id] =
     Lens[Ids, ConstraintSet.Id](_.constraintSet)(b => a => a.copy(constraintSet = b))
 
@@ -50,6 +57,9 @@ sealed trait IdsOptics { self: Ids.type =>
 
   val lastProgram: Lens[Ids, Program.Id] =
     Lens[Ids, Program.Id](_.program)(b => a => a.copy(program = b))
+
+  val lastStep: Lens[Ids, Step.Id] =
+    Lens[Ids, Step.Id](_.step)(b => a => a.copy(step = b))
 
   val lastTarget: Lens[Ids, Target.Id] =
     Lens[Ids, Target.Id](_.target)(b => a => a.copy(target = b))

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TableState.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TableState.scala
@@ -3,21 +3,38 @@
 
 package lucuma.odb.api.repo
 
-import lucuma.core.util.Gid
-import lucuma.odb.api.model.{AsterismModel, ConstraintSetModel, InputError, ObservationModel, ProgramModel, TargetModel, ValidatedInput}
+import lucuma.odb.api.model.{AsterismModel, Atom, AtomModel, ConstraintSetModel, Database, ObservationModel, ProgramModel, Step, StepModel, Store, TargetModel}
 import lucuma.core.model.{Asterism, ConstraintSet, Observation, Program, Target}
-
 import cats.data.State
-import cats.kernel.BoundedEnumerable
-import cats.syntax.option._
-import monocle.Lens
 import monocle.state.all._
 
-trait TableState {
+trait TableState extends Database[Tables] {
 
   val nextEventId: State[Tables, Long] =
     Tables.lastEventId.mod(_ + 1L)
 
+  override val atom: Store[Tables, Atom.Id, AtomModel[_]] =
+    new Store("atom", Tables.lastAtomId, Tables.atoms)
+
+  override val asterism: Store[Tables, Asterism.Id, AsterismModel] =
+    new Store("asterism", Tables.lastAsterismId, Tables.asterisms)
+
+  override val constraintSet: Store[Tables, ConstraintSet.Id, ConstraintSetModel] =
+    new Store("constraintSet", Tables.lastConstraintSetId, Tables.constraintSets)
+
+  override val observation: Store[Tables, Observation.Id, ObservationModel] =
+    new Store("observation", Tables.lastObservationId, Tables.observations)
+
+  override val program: Store[Tables, Program.Id, ProgramModel] =
+    new Store("program", Tables.lastProgramId, Tables.programs)
+
+  override val step: Store[Tables, Step.Id, StepModel[_]] =
+    new Store("step", Tables.lastStepId, Tables.steps)
+
+  override val target: Store[Tables, Target.Id, TargetModel] =
+    new Store("target", Tables.lastTargetId, Tables.targets)
+
+  /*
   val nextAsterismId: State[Tables, Asterism.Id] =
     Tables.lastAsterismId.mod(BoundedEnumerable[Asterism.Id].cycleNext)
 
@@ -69,7 +86,7 @@ trait TableState {
 
   def requireTarget(tid: Target.Id): State[Tables, TargetModel] =
     require(target(tid))
-
+ */
 }
 
 object TableState extends TableState

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TableState.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TableState.scala
@@ -34,59 +34,6 @@ trait TableState extends Database[Tables] {
   override val target: Store[Tables, Target.Id, TargetModel] =
     new Store("target", Tables.lastTargetId, Tables.targets)
 
-  /*
-  val nextAsterismId: State[Tables, Asterism.Id] =
-    Tables.lastAsterismId.mod(BoundedEnumerable[Asterism.Id].cycleNext)
-
-  val nextConstraintSetId: State[Tables, ConstraintSet.Id] =
-    Tables.lastConstraintSetId.mod(BoundedEnumerable[ConstraintSet.Id].cycleNext)
-
-  val nextObservationId: State[Tables, Observation.Id] =
-    Tables.lastObservationId.mod(BoundedEnumerable[Observation.Id].cycleNext)
-
-  val nextProgramId: State[Tables, Program.Id] =
-    Tables.lastProgramId.mod(BoundedEnumerable[Program.Id].cycleNext)
-
-  val nextTargetId: State[Tables, Target.Id] =
-    Tables.lastTargetId.mod(BoundedEnumerable[Target.Id].cycleNext)
-
-  private def tryFind[I: Gid, T](name: String, id: I, lens: I => Lens[Tables, Option[T]]): State[Tables, ValidatedInput[T]] =
-    lens(id).st.map(_.toValidNec(InputError.missingReference(name, Gid[I].show(id))))
-
-  def asterism(aid: Asterism.Id): State[Tables, ValidatedInput[AsterismModel]] =
-    tryFind("asterism", aid, Tables.asterism)
-
-    def constraintSet(csid: ConstraintSet.Id): State[Tables, ValidatedInput[ConstraintSetModel]] =
-    tryFind("constraintSet", csid, Tables.constraintSet)
-
-  def observation(oid: Observation.Id): State[Tables, ValidatedInput[ObservationModel]] =
-    tryFind("observation", oid, Tables.observation)
-
-  def program(pid: Program.Id): State[Tables, ValidatedInput[ProgramModel]] =
-    tryFind("program", pid, Tables.program)
-
-  def target(tid: Target.Id): State[Tables, ValidatedInput[TargetModel]] =
-    tryFind("target", tid, Tables.target)
-
-
-  private def require[A](s: State[Tables, ValidatedInput[A]]): State[Tables, A] =
-    s.map(_.valueOr(nec => throw InputError.Exception(nec)))
-
-  def requireAsterism(aid: Asterism.Id): State[Tables, AsterismModel] =
-    require(asterism(aid))
-
-  def requireConstraintSet(csid: ConstraintSet.Id): State[Tables, ConstraintSetModel] =
-    require(constraintSet(csid))
-
-  def requireObservation(oid: Observation.Id): State[Tables, ObservationModel] =
-    require(observation(oid))
-
-  def requireProgram(pid: Program.Id): State[Tables, ProgramModel] =
-    require(program(pid))
-
-  def requireTarget(tid: Target.Id): State[Tables, TargetModel] =
-    require(target(tid))
- */
 }
 
 object TableState extends TableState

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/Tables.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/Tables.scala
@@ -3,13 +3,7 @@
 
 package lucuma.odb.api.repo
 
-import lucuma.odb.api.model.{
-  AsterismModel,
-  ConstraintSetModel,
-  ObservationModel,
-  ProgramModel,
-  TargetModel
-}
+import lucuma.odb.api.model.{AsterismModel, Atom, AtomModel, ConstraintSetModel, ObservationModel, ProgramModel, Step, StepModel, TargetModel}
 import lucuma.core.model.{Asterism, ConstraintSet, Observation, Program, Target}
 import cats.instances.order._
 import monocle.Lens
@@ -22,10 +16,12 @@ import scala.collection.immutable.{SortedMap, TreeMap}
  */
 final case class Tables(
   ids:                      Ids,
+  atoms:                    SortedMap[Atom.Id, AtomModel[_]],
   asterisms:                SortedMap[Asterism.Id, AsterismModel],
   constraintSets:           SortedMap[ConstraintSet.Id, ConstraintSetModel],
   observations:             SortedMap[Observation.Id, ObservationModel],
   programs:                 SortedMap[Program.Id, ProgramModel],
+  steps:                    SortedMap[Step.Id, StepModel[_]],
   targets:                  SortedMap[Target.Id, TargetModel],
 
   programAsterism:          ManyToMany[Program.Id, Asterism.Id],
@@ -39,10 +35,12 @@ object Tables extends TableOptics {
     Tables(
       ids                      = Ids.zero,
 
+      atoms                    = TreeMap.empty[Atom.Id, AtomModel[_]],
       asterisms                = TreeMap.empty[Asterism.Id, AsterismModel],
       constraintSets           = TreeMap.empty[ConstraintSet.Id, ConstraintSetModel],
       observations             = TreeMap.empty[Observation.Id, ObservationModel],
       programs                 = TreeMap.empty[Program.Id, ProgramModel],
+      steps                    = TreeMap.empty[Step.Id, StepModel[_]],
       targets                  = TreeMap.empty[Target.Id, TargetModel],
 
       programAsterism          = ManyToMany.empty,
@@ -60,6 +58,9 @@ sealed trait TableOptics { self: Tables.type =>
   val lastEventId: Lens[Tables, Long] =
     ids ^|-> Ids.lastEvent
 
+  val lastAtomId: Lens[Tables, Atom.Id] =
+    ids ^|-> Ids.lastAtom
+
   val lastAsterismId: Lens[Tables, Asterism.Id] =
     ids ^|-> Ids.lastAsterism
 
@@ -72,9 +73,17 @@ sealed trait TableOptics { self: Tables.type =>
   val lastProgramId: Lens[Tables, Program.Id] =
     ids ^|-> Ids.lastProgram
 
+  val lastStepId: Lens[Tables, Step.Id] =
+    ids ^|-> Ids.lastStep
+
   val lastTargetId: Lens[Tables, Target.Id] =
     ids ^|-> Ids.lastTarget
 
+  val atoms: Lens[Tables, SortedMap[Atom.Id, AtomModel[_]]] =
+    Lens[Tables, SortedMap[Atom.Id, AtomModel[_]]](_.atoms)(b => a => a.copy(atoms = b))
+
+  def atom(aid: Atom.Id): Lens[Tables, Option[AtomModel[_]]] =
+    atoms ^|-> At.at(aid)
 
   val asterisms: Lens[Tables, SortedMap[Asterism.Id, AsterismModel]] =
     Lens[Tables, SortedMap[Asterism.Id, AsterismModel]](_.asterisms)(b => a => a.copy(asterisms = b))
@@ -96,13 +105,17 @@ sealed trait TableOptics { self: Tables.type =>
   def observation(oid: Observation.Id): Lens[Tables, Option[ObservationModel]] =
     observations ^|-> At.at(oid)
 
-
   val programs: Lens[Tables, SortedMap[Program.Id, ProgramModel]] =
     Lens[Tables, SortedMap[Program.Id, ProgramModel]](_.programs)(b => a => a.copy(programs = b))
 
   def program(pid: Program.Id): Lens[Tables, Option[ProgramModel]] =
     programs ^|-> At.at(pid)
 
+  val steps: Lens[Tables, SortedMap[Step.Id, StepModel[_]]] =
+    Lens[Tables, SortedMap[Step.Id, StepModel[_]]](_.steps)(b => a => a.copy(steps = b))
+
+  def step(sid: Step.Id): Lens[Tables, Option[StepModel[_]]] =
+    steps ^|-> At.at(sid)
 
   val targets: Lens[Tables, SortedMap[Target.Id, TargetModel]] =
     Lens[Tables, SortedMap[Target.Id, TargetModel]](_.targets)(b => a => a.copy(targets = b))

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
@@ -110,7 +110,7 @@ object TargetRepo {
         update: (ManyToMany[Target.Id, Asterism.Id], IterableOnce[(Target.Id, Asterism.Id)]) => ManyToMany[Target.Id, Asterism.Id]
       ): F[TargetModel] =
         shareRight[Asterism.Id, AsterismModel](
-          "target", input, TableState.asterism, Tables.targetAsterism, AsterismModel.AsterismEvent.updated
+          "target", input, TableState.asterism.lookup, Tables.targetAsterism, AsterismModel.AsterismEvent.updated
         )(update)
 
       override def shareWithAsterisms(input: Sharing[Target.Id, Asterism.Id]): F[TargetModel] =
@@ -125,7 +125,7 @@ object TargetRepo {
         update: (ManyToMany[Program.Id, Target.Id], IterableOnce[(Program.Id, Target.Id)]) => ManyToMany[Program.Id, Target.Id]
       ): F[TargetModel] =
         shareLeft[Program.Id, ProgramModel](
-          "target", input, TableState.program, Tables.programTarget, ProgramModel.ProgramEvent.updated
+          "target", input, TableState.program.lookup, Tables.programTarget, ProgramModel.ProgramEvent.updated
         )(update)
 
       override def shareWithPrograms(input: Sharing[Target.Id, Program.Id]): F[TargetModel] =

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
@@ -3,12 +3,11 @@
 
 package lucuma.odb.api.repo
 
-import lucuma.odb.api.model.{AsterismModel, ProgramModel, Sharing, TargetModel, ValidatedInput}
+import lucuma.odb.api.model.{AsterismModel, Event, InputError, ProgramModel, Sharing, TargetModel, ValidatedInput}
 import lucuma.odb.api.model.TargetModel.{CreateNonsidereal, CreateSidereal, TargetEvent}
-import lucuma.odb.api.model.Existence._
 import lucuma.core.model.{Asterism, Program, Target}
 import cats._
-import cats.data.State
+import cats.data.{EitherT, State}
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import monocle.state.all._
@@ -85,24 +84,36 @@ object TargetRepo {
           tables.targetAsterism.selectLeft(aid)
         }
 
-      def addAndShare(id: Option[Target.Id], g: Target, pids: Set[Program.Id]): State[Tables, TargetModel] =
-        for {
-          t <- createAndInsert(id, tid => TargetModel(tid, Present, g))
-          _ <- Tables.programTarget.mod_(_ ++ pids.toList.tupleRight(t.id))
-        } yield t
+      private def insertTarget(
+        pids: Option[List[Program.Id]],
+        tm:   State[Tables, ValidatedInput[TargetModel]]
+      ): F[TargetModel] = {
+        val create = EitherT(
+          tablesRef.modify { tables =>
+            val (tablesʹ, t) = (for {
+              t <- tm
+              _ <- t.traverse(tm => Tables.programTarget.mod_(_ ++ pids.toList.flatten.tupleRight(tm.id)))
+            } yield t).run(tables).value
 
-      private def insertTarget(id: Option[Target.Id], pids: List[Program.Id], vt: ValidatedInput[Target]): F[TargetModel] =
-        constructAndPublish { t =>
-          (vt, tryNotFindTarget(t, id), pids.traverse(tryFindProgram(t, _))).mapN((g, _, _) =>
-            addAndShare(id, g, pids.toSet)
-          )
-        }
+            t.fold(
+              err => (tables,  InputError.Exception(err).asLeft),
+              tm  => (tablesʹ, tm.asRight)
+            )
+          }
+        ).rethrowT
+
+        for {
+          t <- create
+          _ <- eventService.publish(TargetEvent(_, Event.EditType.Created, t))
+        } yield t
+      }
+
 
       override def insertNonsidereal(input: CreateNonsidereal): F[TargetModel] =
-        insertTarget(input.targetId, input.programIds.toList.flatten, input.toGemTarget)
+        insertTarget(input.programIds, input.create(TableState))
 
       override def insertSidereal(input: CreateSidereal): F[TargetModel] =
-        insertTarget(input.targetId, input.programIds.toList.flatten, input.toGemTarget)
+        insertTarget(input.programIds, input.create(TableState))
 
       private def asterismSharing(
         input: Sharing[Target.Id, Asterism.Id]

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TopLevelRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TopLevelRepo.scala
@@ -192,13 +192,6 @@ abstract class TopLevelRepoBase[F[_]: Monad, I: Gid, T: TopLevelModel[I, *]: Eq]
     } yield u
   }
 
-  def createAndInsert[U <: T](id: Option[I], f: I => U): State[Tables, U] =
-    for {
-      i <- id.fold(idLens.mod(BoundedEnumerable[I].cycleNext))(State.pure[Tables, I])
-      t  = f(i)
-      _ <- mapLens.mod(_ + (i -> t))
-    } yield t
-
   override def edit(
     id:     I,
     editor: ValidatedInput[State[T, Unit]],

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SequenceSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SequenceSchema.scala
@@ -3,7 +3,7 @@
 
 package lucuma.odb.api.schema
 
-import lucuma.odb.api.model.{AtomModel, PlannedTime, SequenceModel}
+import lucuma.odb.api.model.{Atom, AtomModel, PlannedTime, SequenceModel}
 import lucuma.odb.api.repo.OdbRepo
 import cats.effect.Effect
 import sangria.schema._
@@ -13,6 +13,9 @@ object SequenceSchema {
   import PlannedTimeSchema._
   import StepSchema.InstrumentStepType
 
+  implicit val AtomIdType: ScalarType[Atom.Id] =
+    ObjectIdSchema.idType[Atom.Id](name = "AtomId")
+
   def AtomType[F[_]: Effect, D](
     typePrefix:  String,
     dynamicType: OutputType[D]
@@ -21,6 +24,13 @@ object SequenceSchema {
       name        = s"${typePrefix}Atom",
       description = s"$typePrefix atom, a collection of steps that should be executed in their entirety",
       fieldsFn    = () => fields(
+
+        Field(
+          name        = "id",
+          fieldType   = AtomIdType,
+          description = Some("Atom id"),
+          resolve     = _.value.id
+        ),
 
         Field(
           name        = "steps",

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/StepSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/StepSchema.scala
@@ -4,7 +4,7 @@
 package lucuma.odb.api.schema
 
 import lucuma.core.`enum`._
-import lucuma.odb.api.model.{Breakpoint, PlannedTime, StepConfig, StepModel}
+import lucuma.odb.api.model.{Breakpoint, PlannedTime, Step, StepConfig, StepModel}
 import lucuma.odb.api.repo.OdbRepo
 import cats.effect.Effect
 import lucuma.odb.api.schema.PlannedTimeSchema.CategorizedTimeType
@@ -15,6 +15,9 @@ object StepSchema {
 
   import OffsetSchema._
   import syntax.`enum`._
+
+  implicit val StepIdType: ScalarType[Step.Id] =
+    ObjectIdSchema.idType[Step.Id](name = "StepId")
 
   implicit val EnumTypeBreakpoint: EnumType[Breakpoint] =
     EnumType.fromEnumerated[Breakpoint](
@@ -63,6 +66,13 @@ object StepSchema {
       name        = "Step",
       description = "Sequence step",
       fieldsFn    = () => fields[OdbRepo[F], StepModel[_]](
+
+        Field(
+          name        = "id",
+          fieldType   = StepIdType,
+          description = Some("Step id"),
+          resolve     = _.value.id
+        ),
 
         Field(
           name        = "breakpoint",

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbAtomModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbAtomModel.scala
@@ -4,6 +4,8 @@
 package lucuma.odb.api.model
 package arb
 
+import lucuma.core.util.arb.ArbGid
+
 import cats.data.NonEmptyList
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
@@ -11,32 +13,41 @@ import org.scalacheck.Arbitrary.arbitrary
 
 trait ArbAtomModel extends Helper {
 
+  import ArbGid._
   import ArbStepModel._
 
   implicit def arbAtom[A: Arbitrary]: Arbitrary[AtomModel[A]] =
     Arbitrary {
       for {
+        id <- arbitrary[Atom.Id]
         s0 <- arbitrary[StepModel[A]]
         s  <- tinyPositiveSize
         ss <- Gen.listOfN(s, arbitrary[StepModel[A]])
-      } yield AtomModel(NonEmptyList(s0, ss))
+      } yield AtomModel(id, NonEmptyList(s0, ss))
     }
 
   implicit def cogAtom[A: Cogen]: Cogen[AtomModel[A]] =
-    Cogen[List[StepModel[A]]].contramap(_.steps.toList)
+    Cogen[(Atom.Id, List[StepModel[A]])].contramap { in => (
+      in.id,
+      in.steps.toList
+    )}
 
 
   implicit def arbCreateAtom[A: Arbitrary]: Arbitrary[AtomModel.Create[A]] =
     Arbitrary {
       for {
+        id <- arbitrary[Option[Atom.Id]]
         s0 <- arbitrary[StepModel.Create[A]]
         s  <- tinyPositiveSize
         ss <- Gen.listOfN(s, arbitrary[StepModel.Create[A]])
-      } yield AtomModel.Create[A](s0 :: ss)
+      } yield AtomModel.Create[A](id, s0 :: ss)
     }
 
   implicit def cogAtomCreate[A: Cogen]: Cogen[AtomModel.Create[A]] =
-    Cogen[List[StepModel.Create[A]]].contramap(_.steps)
+    Cogen[(Option[Atom.Id], List[StepModel.Create[A]])].contramap { in => (
+      in.id,
+      in.steps
+    )}
 
 }
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbStepModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbStepModel.scala
@@ -6,7 +6,7 @@ package arb
 
 import lucuma.core.math.Offset
 import lucuma.core.math.arb.ArbOffset
-import lucuma.core.util.arb.ArbEnumerated
+import lucuma.core.util.arb.{ArbEnumerated, ArbGid}
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 
@@ -14,6 +14,7 @@ trait ArbStepModel {
 
   import ArbEnumerated._
   import ArbGcalModel._
+  import ArbGid._
   import ArbOffset._
   import ArbOffsetModel._
 
@@ -153,13 +154,15 @@ trait ArbStepModel {
     implicit def arbStepModel[A: Arbitrary]: Arbitrary[StepModel[A]] =
     Arbitrary {
       for {
+        i <- arbitrary[Step.Id]
         b <- arbitrary[Breakpoint]
         s <- arbitrary[StepConfig[A]]
-      } yield StepModel(b, s)
+      } yield StepModel(i, b, s)
     }
 
   implicit def cogStepModel[A: Cogen]: Cogen[StepModel[A]] =
-    Cogen[(Breakpoint, StepConfig[A])].contramap { in => (
+    Cogen[(Step.Id, Breakpoint, StepConfig[A])].contramap { in => (
+      in.id,
       in.breakpoint,
       in.config
     )}
@@ -167,15 +170,17 @@ trait ArbStepModel {
   implicit def arbStepModelCreate[A: Arbitrary]: Arbitrary[StepModel.Create[A]] =
     Arbitrary {
       for {
+        i <- arbitrary[Option[Step.Id]]
         b <- arbitrary[Breakpoint]
         s <- arbitrary[StepConfig.CreateStepConfig[A]]
-      } yield StepModel.Create(b, s)
+      } yield StepModel.Create(i, b, s)
     }
 
   implicit def cogStepModelCreate[A: Cogen]: Cogen[StepModel.Create[A]] =
-    Cogen[(Breakpoint, StepConfig.CreateStepConfig[A])].contramap { in => (
+    Cogen[(Option[Step.Id], Breakpoint, StepConfig.CreateStepConfig[A])].contramap { in => (
+      in.id,
       in.breakpoint,
-      in.step
+      in.config
     )}
 
 

--- a/modules/core/src/test/scala/lucuma/odb/api/repo/arb/ArbTables.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/repo/arb/ArbTables.scala
@@ -5,20 +5,12 @@ package lucuma.odb.api.repo
 package arb
 
 import lucuma.core.model.{Asterism, ConstraintSet, Observation, Program, Target}
-import lucuma.odb.api.model.{
-  AsterismModel,
-  ConstraintSetModel,
-  ObservationModel,
-  ProgramModel,
-  TargetModel
-}
+import lucuma.odb.api.model.{AsterismModel, Atom, AtomModel, ConstraintSetModel, ObservationModel, ProgramModel, Step, StepModel, TargetModel}
 import lucuma.odb.api.model.arb._
 import lucuma.core.util.Gid
-
 import cats.Order
 import cats.kernel.instances.order._
 import cats.syntax.all._
-
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 
@@ -117,15 +109,17 @@ trait ArbTables extends SplitSetHelper {
         ids = Ids(
           0L,
           lastGid[Asterism.Id](as),
+          lastGid[Atom.Id](SortedMap.empty[Atom.Id, AtomModel[_]]),
           lastGid[ConstraintSet.Id](cs),
           lastGid[Observation.Id](os),
           lastGid[Program.Id](ps),
+          lastGid[Step.Id](SortedMap.empty[Step.Id, StepModel[_]]),
           lastGid[Target.Id](ts)
         )
         pa <- manyToMany(ps.keys, as.keys)
         pt <- manyToMany(ps.keys, ts.keys)
         ta <- manyToMany(ts.keys, as.keys)
-      } yield Tables(ids, as, cs, os, ps, ts, pa, pt, ta)
+      } yield Tables(ids, SortedMap.empty, as, cs, os, ps, SortedMap.empty, ts, pa, pt, ta)
     }
 }
 

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -276,7 +276,7 @@ object Init {
       ).map(StepModel.Create.continueTo)
        .grouped(2) // pairs flat and science steps
        .toList
-       .map(AtomModel.Create(_))
+       .map(AtomModel.Create(None, _))
     )
 
   def obs(


### PR DESCRIPTION
This PR grew from an attempt to add atom and step ids and lead to a refactoring of the various top-level item `create` methods.  In particular they needed access to some of the lookup/store features that were previously done exclusively in the various repos.  This meant abstracting these features into a `Database` trait that is provided upon creation.