### PR TITLE
Add Datasets and Execution Events (Part 1)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ val catsEffectVersion           = "2.5.1"
 val catsMtlVersion              = "1.2.1"
 val catsTestkitScalaTestVersion = "2.1.4"
 val catsVersion                 = "2.6.1"
+val catsTimeVersion             = "0.3.4"
 val circeOpticsVersion          = "0.13.0"
 val circeVersion                = "0.13.0"
 val cirisVersion                = "1.2.1"
@@ -79,6 +80,7 @@ lazy val core = project
       "org.typelevel"              %% "cats-core"                 % catsVersion,
       "org.typelevel"              %% "cats-effect"               % catsEffectVersion,
       "org.typelevel"              %% "cats-mtl"                  % catsMtlVersion,
+      "io.chrisdavenport"          %% "cats-time"                 % catsTimeVersion,
       "io.circe"                   %% "circe-core"                % circeVersion,
       "io.circe"                   %% "circe-literal"             % circeVersion,
       "io.circe"                   %% "circe-optics"              % circeOpticsVersion,
@@ -92,6 +94,7 @@ lazy val core = project
       "eu.timepit"                 %% "singleton-ops"             % singletonOpsVersion,
       "eu.timepit"                 %% "refined"                   % refinedVersion,
       "eu.timepit"                 %% "refined-cats"              % refinedVersion,
+
 
       "edu.gemini"                 %% "lucuma-core-testkit"       % lucumaCoreVersion      % Test,
       "org.scalameta"              %% "munit"                     % munitVersion           % Test,

--- a/modules/core/src/main/scala/lucuma/odb/api/model/DatabaseState.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/DatabaseState.scala
@@ -7,19 +7,23 @@ import lucuma.core.model.{Asterism, Atom, ConstraintSet, Observation, Program, S
 
 trait DatabaseState[T] extends DatabaseReader[T] {
 
-  def atom:          RepoState[T, Atom.Id, AtomModel[Step.Id]]
+  def atom:           RepoState[T, Atom.Id, AtomModel[Step.Id]]
 
-  def asterism:      RepoState[T, Asterism.Id, AsterismModel]
+  def asterism:       RepoState[T, Asterism.Id, AsterismModel]
 
-  def constraintSet: RepoState[T, ConstraintSet.Id, ConstraintSetModel]
+  def constraintSet:  RepoState[T, ConstraintSet.Id, ConstraintSetModel]
 
-  def observation:   RepoState[T, Observation.Id, ObservationModel]
+  def dataset:        RepoState[T, Dataset.Id, DatasetModel]
 
-  def program:       RepoState[T, Program.Id, ProgramModel]
+  def executionEvent: RepoState[T, ExecutionEvent.Id, ExecutionEventModel]
 
-  def step:          RepoState[T, Step.Id, StepModel[_]]
+  def observation:    RepoState[T, Observation.Id, ObservationModel]
 
-  def target:        RepoState[T, Target.Id, TargetModel]
+  def program:        RepoState[T, Program.Id, ProgramModel]
+
+  def step:           RepoState[T, Step.Id, StepModel[_]]
+
+  def target:         RepoState[T, Target.Id, TargetModel]
 
   def programAsterism: SharingState[T, Program.Id, Asterism.Id]
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/DatasetFilename.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/DatasetFilename.scala
@@ -1,0 +1,67 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.core.`enum`.Site
+import lucuma.odb.api.model.time.FourDigitYearLocalDate
+import lucuma.core.optics.Format
+import atto._
+import Atto._
+import cats.Order
+import io.chrisdavenport.cats.time.instances.localdate._
+import eu.timepit.refined.types.all.PosInt
+import io.circe.Decoder
+import monocle.macros.Lenses
+
+/**
+ * Describes the components of a valid dataset filename.
+ */
+@Lenses final case class DatasetFilename(
+  site:      Site,
+  localDate: FourDigitYearLocalDate,
+  index:     PosInt
+) {
+
+  /**
+   * Formats the dataset filename.  For example, N20210521S0123.fits.
+   */
+  def format: String =
+    f"${site.tag.last}${localDate.value.getYear}%04d${localDate.value.getMonth.getValue}%02d${localDate.value.getDayOfMonth}%02dS${index.value}%04d.fits"
+
+}
+
+object DatasetFilename {
+
+  private def fixed(n: Int): Parser[Int] =
+    count(n, digit).map(_.mkString).flatMap { s =>
+      try ok(s.toInt) catch { case e: NumberFormatException => err(e.toString) }
+    }
+
+  val parser: Parser[DatasetFilename] =
+    for {
+      s  <- oneOf("NS").map(c => Site.unsafeFromTag(s"G$c"))
+      y  <- fixed(4)
+      m  <- fixed(2)
+      d  <- fixed(2)
+      ld <- FourDigitYearLocalDate.fromYMD(y, m, d).fold(err[FourDigitYearLocalDate](s"invalid date $y-$m-$d"))(ok)
+      _  <- char('S')
+      n  <- int.filter(_ > 0)
+      _  <- string(".fits")
+    } yield new DatasetFilename(s, ld, PosInt.unsafeFrom(n))
+
+  val fromString: Format[String, DatasetFilename] =
+    Format(s => parser.parse(s).option, _.format)
+
+  implicit val OrderDatasetFilename: Order[DatasetFilename] =
+    Order.by { a => (
+      a.site,
+      a.localDate.value,
+      a.index.value
+    )}
+
+  implicit val DecoderDatasetFilename: Decoder[DatasetFilename] =
+    Decoder[String].emap(s => fromString.getOption(s).toRight(s"Could not parse '$s' as a dataset filename"))
+
+}
+

--- a/modules/core/src/main/scala/lucuma/odb/api/model/DatasetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/DatasetModel.scala
@@ -1,0 +1,77 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.core.model.{Observation, Step, WithId}
+import cats.Monad
+import cats.kernel.Eq
+
+import cats.mtl.Stateful
+import cats.syntax.all._
+import eu.timepit.refined.auto._
+import monocle.macros.Lenses
+import io.chrisdavenport.cats.time.instances.instant._
+import io.circe.Decoder
+import io.circe.generic.semiauto._
+
+import java.time.Instant
+
+// TODO: Move to lucuma-core
+object Dataset extends WithId('d')
+
+
+@Lenses final case class DatasetModel(
+  id:            Dataset.Id,
+  observationId: Observation.Id,
+  stepId:        Step.Id,
+  timestamp:     Instant,
+  filename:      DatasetFilename
+)
+
+object DatasetModel {
+
+  implicit val EqDatasetModel: Eq[DatasetModel] =
+    Eq.by { a => (
+      a.id,
+      a.timestamp,
+      a.filename,
+      a.observationId,
+      a.stepId
+    )}
+
+
+  final case class Create(
+    datasetId:     Option[Dataset.Id],
+    observationId: Observation.Id,
+    stepId:        Step.Id,
+    timestamp:     Instant,
+    filename:      DatasetFilename
+  ) {
+
+    def create[F[_]: Monad, T](db: DatabaseState[T])(implicit S: Stateful[F, T]): F[ValidatedInput[DatasetModel]] =
+      for {
+        i <- db.dataset.getUnusedId(datasetId)
+        o <- db.observation.lookupValidated(observationId)
+        s <- db.step.lookupValidated(stepId)
+        d  = (i, o, s).mapN((iʹ, _, _) => DatasetModel.apply(iʹ, observationId, stepId, timestamp, filename))
+        _ <- db.dataset.saveIfValid(d)(_.id)
+      } yield d
+
+  }
+
+  object Create {
+
+    implicit val DecoderCreate: Decoder[Create] =
+      deriveDecoder[Create]
+
+    implicit val EqCreate: Eq[Create] =
+      Eq.by { a => (
+        a.datasetId,
+        a.stepId,
+        a.timestamp,
+        a.filename
+      )}
+
+  }
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ExecutedStep.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ExecutedStep.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.core.model.{Atom, Step}
+
+import cats.{Eq, Functor}
+import cats.mtl.Stateful
+
+final case class ExecutedStep(
+  stepId:       Step.Id,
+  atomId:       Atom.Id,
+  sequenceType: SequenceModel.SequenceType
+) {
+
+  def dereference[F[_]: Functor, T, D](
+    db: DatabaseReader[T]
+  )(
+    f: StepConfig[_] => Option[D]
+  )(
+    implicit S: Stateful[F, T]
+  ): F[Option[StepModel[D]]] =
+
+    StepModel.dereference[F, T, D](db, stepId)(f)
+
+}
+
+object ExecutedStep {
+
+  implicit val EqExecutedStep: Eq[ExecutedStep] =
+    Eq.by { a => (
+      a.stepId,
+      a.atomId,
+      a.sequenceType
+    )}
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ExecutionEventModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ExecutionEventModel.scala
@@ -1,0 +1,389 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import cats.mtl.Stateful
+import lucuma.core.model.{Observation, Step, WithId}
+import lucuma.core.util.Enumerated
+import cats.{Monad, Order}
+import cats.syntax.all._
+import eu.timepit.refined.types.numeric._
+import io.chrisdavenport.cats.time.instances.instant._
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import io.circe.refined._
+import eu.timepit.refined.auto._
+
+import java.time.Instant
+
+// TODO: Move to lucuma-core
+object ExecutionEvent extends WithId('e')
+
+/**
+ * Shared interface for all execution events: sequence, step and dataset.
+ */
+sealed trait ExecutionEventModel {
+
+  def id:            ExecutionEvent.Id
+
+  def observationId: Observation.Id
+
+  def generated:     Instant
+
+  def received:      Instant
+
+}
+
+object ExecutionEventModel {
+
+  // Sequence-level Events ----------------------------------------------------
+
+  sealed abstract class SequenceCommandType(
+    val tag:       String,
+    val shortName: String
+  ) extends Product with Serializable
+
+
+  object SequenceCommandType {
+
+    case object Abort    extends SequenceCommandType("ABORT", "Abort")
+    case object Continue extends SequenceCommandType("CONTINUE", "Continue")
+    case object Pause    extends SequenceCommandType("PAUSE", "Pause")
+    case object Slew     extends SequenceCommandType("SLEW", "Slew")
+    case object Start    extends SequenceCommandType("START", "Start")
+    case object Stop     extends SequenceCommandType("STOP", "Stop")
+
+    val all: List[SequenceCommandType] =
+      List(
+        Abort,
+        Continue,
+        Pause,
+        Slew,
+        Start,
+        Stop
+      )
+
+    def fromTag(s: String): Option[SequenceCommandType] =
+      all.find(_.tag === s)
+
+    def unsafeFromTag(s: String): SequenceCommandType =
+      fromTag(s).getOrElse(throw new NoSuchElementException(s"SequenceCommandType: Invalid tag: '$s'"))
+
+    implicit val EnumeratedSequenceCommandType: Enumerated[SequenceCommandType] =
+      new Enumerated[SequenceCommandType] {
+        def all: List[SequenceCommandType] = SequenceCommandType.all
+        def tag(a: SequenceCommandType): String = a.tag
+        override def unsafeFromTag(s: String): SequenceCommandType =
+          SequenceCommandType.unsafeFromTag(s)
+      }
+
+  }
+
+  final case class SequenceEvent(
+    id:            ExecutionEvent.Id,
+    observationId: Observation.Id,
+    generated:     Instant,
+    received:      Instant,
+    command:       SequenceCommandType
+  ) extends ExecutionEventModel
+
+  object SequenceEvent {
+
+    implicit val OrderSequenceEvent: Order[SequenceEvent] = {
+      Order.by { a => (
+        a.id,
+        a.observationId,
+        a.command,
+        a.generated,
+        a.received
+      )}
+    }
+
+    final case class Create(
+      eventId:       Option[ExecutionEvent.Id],
+      observationId: Observation.Id,
+      generated:     Instant,
+      command:       SequenceCommandType
+    ) {
+
+      def create[F[_]: Monad, T](
+        db:       DatabaseState[T],
+        received: Instant
+      )(implicit S: Stateful[F, T]): F[ValidatedInput[SequenceEvent]] =
+        for {
+          i <- db.executionEvent.getUnusedId(eventId)
+          o <- db.observation.lookupValidated[F](observationId)
+          e  = (i, o).mapN((iʹ, _) => SequenceEvent(iʹ, observationId, received, generated, command))
+          _ <- db.executionEvent.saveIfValid(e)(_.id)
+        } yield e
+
+    }
+
+    object Create {
+
+      implicit val DecoderCreate: Decoder[Create] =
+        deriveDecoder[Create]
+
+      implicit val OrderCreate: Order[Create] =
+        Order.by { a => (
+          a.eventId,
+          a.observationId,
+          a.command,
+          a.generated
+        )}
+
+    }
+
+  }
+
+
+  // Step-level Events --------------------------------------------------------
+
+  sealed abstract class StepStageType(
+    val tag:       String,
+    val shortName: String
+  ) extends Product with Serializable
+
+  object StepStageType {
+    case object EndConfigure   extends StepStageType("END_CONFIGURE", "EndConfigure")
+    case object EndObserve     extends StepStageType("END_OBSERVE", "EndObserve")
+    case object EndStep        extends StepStageType("END_STEP", "EndStep")
+    case object StartConfigure extends StepStageType("START_CONFIGURE", "StartConfigure")
+    case object StartObserve   extends StepStageType("START_OBSERVE", "StartObserve")
+    case object StartStep      extends StepStageType("START_STEP", "StartStep")
+
+    val all: List[StepStageType] =
+      List(
+        EndConfigure,
+        EndObserve,
+        EndStep,
+        StartConfigure,
+        StartObserve,
+        StartStep
+      )
+
+    def fromTag(s: String): Option[StepStageType] =
+      all.find(_.tag === s)
+
+    def unsafeFromTag(s: String): StepStageType =
+      fromTag(s).getOrElse(throw new NoSuchElementException(s"StepStageType: Invalid tag: '$s'"))
+
+    implicit val EnumeratedStepStageType: Enumerated[StepStageType] =
+      new Enumerated[StepStageType] {
+        override def all: List[StepStageType] = StepStageType.all
+        override def tag(a: StepStageType): String = a.tag
+        override def unsafeFromTag(s: String): StepStageType = StepStageType.unsafeFromTag(s)
+      }
+
+  }
+
+  final case class StepEvent(
+    id:            ExecutionEvent.Id,
+    observationId: Observation.Id,
+    generated:     Instant,
+    received:      Instant,
+
+    stepId:        Step.Id,
+    sequenceType:  SequenceModel.SequenceType,
+
+    stage:         StepStageType
+
+  ) extends ExecutionEventModel
+
+  object StepEvent {
+
+    implicit val OrderStepEvent: Order[StepEvent] =
+      Order.by { a => (
+        a.id,
+        a.observationId,
+        a.stepId,
+        a.sequenceType,
+
+        a.stage,
+
+        a.received,
+        a.generated
+      )}
+
+
+    final case class Create(
+      eventId:       Option[ExecutionEvent.Id],
+      observationId: Observation.Id,
+      generated:     Instant,
+
+      stepId:        Step.Id,
+      sequenceType:  SequenceModel.SequenceType,
+      stage:         StepStageType
+    ) {
+
+      def create[F[_]: Monad, T](
+        db:           DatabaseState[T],
+        received:     Instant
+      )(implicit S: Stateful[F, T]): F[ValidatedInput[StepEvent]] =
+
+        for {
+          i <- db.executionEvent.getUnusedId(eventId)
+          o <- db.observation.lookupValidated(observationId)
+          s <- db.step.lookupValidated(stepId)
+          e  = (i, o, s).mapN { (iʹ, _, _) =>
+
+            StepEvent(
+              iʹ,
+              observationId,
+              received,
+              generated,
+              stepId,
+              sequenceType,
+              stage
+            )
+          }
+          _ <- db.executionEvent.saveIfValid(e)(_.id)
+        } yield e
+
+    }
+
+    object Create {
+
+      implicit val DecoderCreate: Decoder[Create] =
+        deriveDecoder[Create]
+
+      implicit val OrderCreate: Order[Create] =
+        Order.by { a => (
+          a.eventId,
+          a.observationId,
+          a.stepId,
+          a.sequenceType,
+          a.stage,
+          a.generated
+        )}
+
+    }
+
+  }
+
+  // Dataset-level Events -----------------------------------------------------
+
+  sealed abstract class DatasetStageType(
+    val tag:       String,
+    val shortName: String
+  ) extends Product with Serializable
+
+  object DatasetStageType {
+    case object EndObserve    extends DatasetStageType("END_OBSERVE", "EndObserve")
+    case object EndReadout    extends DatasetStageType("END_READOUT", "EndReadout")
+    case object EndWrite      extends DatasetStageType("END_WRITE", "EndWrite")
+    case object StartObserve  extends DatasetStageType("START_OBSERVE", "StartObserve")
+    case object StartReadout  extends DatasetStageType("START_READOUT", "StartReadout")
+    case object StartWrite    extends DatasetStageType("START_WRITE", "StartWrite")
+
+    val all: List[DatasetStageType] =
+      List(
+        EndObserve,
+        EndReadout,
+        EndWrite,
+        StartObserve,
+        StartReadout,
+        StartWrite
+      )
+
+    def fromTag(s: String): Option[DatasetStageType] =
+      all.find(_.tag === s)
+
+    def unsafeFromTag(s: String): DatasetStageType =
+      fromTag(s).getOrElse(throw new NoSuchElementException(s"DatasetStageType: Invalid tag: '$s'"))
+
+    implicit val EnumeratedDatasetStageType: Enumerated[DatasetStageType] =
+      new Enumerated[DatasetStageType] {
+        override def all: List[DatasetStageType] = DatasetStageType.all
+        override def tag(a: DatasetStageType): String = a.tag
+        override def unsafeFromTag(s: String): DatasetStageType = DatasetStageType.unsafeFromTag(s)
+      }
+
+  }
+
+  final case class DatasetEvent(
+    id:            ExecutionEvent.Id,
+    observationId: Observation.Id,
+    generated:     Instant,
+    received:      Instant,
+
+    stepId:        Step.Id,
+    datasetIndex:  PosInt,
+    filename:      Option[DatasetFilename],
+    stageType:     DatasetStageType
+  ) extends ExecutionEventModel
+
+  object DatasetEvent {
+
+    implicit val OrderDatasetEvent: Order[DatasetEvent] =
+      Order.by { a => (
+        a.id,
+        a.observationId,
+        a.stepId,
+        a.datasetIndex.value,
+        a.filename,
+        a.stageType,
+        a.generated,
+        a.received
+      )}
+
+    final case class Create(
+      eventId:       Option[ExecutionEvent.Id],
+      observationId: Observation.Id,
+      generated:     Instant,
+
+      stepId:        Step.Id,
+      datasetIndex:  PosInt,
+      filename:      Option[DatasetFilename],
+      stageType:     DatasetStageType
+    ) {
+
+      def create[F[_]: Monad, T](
+        db:           DatabaseState[T],
+        received:     Instant
+      )(implicit S: Stateful[F, T]): F[ValidatedInput[DatasetEvent]] =
+
+        for {
+          i <- db.executionEvent.getUnusedId(eventId)
+          o <- db.observation.lookupValidated(observationId)
+          s <- db.step.lookupValidated(stepId)
+          e  = (i, o, s).mapN { (iʹ, _, _) =>
+
+            DatasetEvent(
+              iʹ,
+              observationId,
+              generated,
+              received,
+              stepId,
+              datasetIndex,
+              filename,
+              stageType
+            )
+
+          }
+          _ <- db.executionEvent.saveIfValid(e)(_.id)
+        } yield e
+
+    }
+
+    object Create {
+
+      implicit val DecoderCreate: Decoder[Create] =
+        deriveDecoder[Create]
+
+      implicit val OrderCreate: Order[Create] =
+        Order.by { a => (
+          a.eventId,
+          a.observationId,
+          a.generated,
+          a.stepId,
+          a.datasetIndex.value,
+          a.filename,
+          a.stageType
+        )}
+    }
+
+  }
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -29,7 +29,8 @@ final case class ObservationModel(
   pointing:             Option[Either[Asterism.Id, Target.Id]],
   constraintSetId:      Option[ConstraintSet.Id],
   plannedTimeSummary:   PlannedTimeSummaryModel,
-  config:               Option[InstrumentConfigModel.Reference]
+  config:               Option[InstrumentConfigModel.Reference],
+  executedSteps:        List[ExecutedStep]
 ) {
 
   def asterismId: Option[Asterism.Id] =
@@ -55,7 +56,8 @@ object ObservationModel extends ObservationOptics {
       o.pointing,
       o.constraintSetId,
       o.plannedTimeSummary,
-      o.config
+      o.config,
+      o.executedSteps
     )}
 
 
@@ -97,7 +99,8 @@ object ObservationModel extends ObservationOptics {
             pointingʹ,
             constraintSetId,
             s,
-            gʹ.map(_.toReference)
+            gʹ.map(_.toReference),
+            List.empty
           )
         }
 
@@ -285,5 +288,8 @@ trait ObservationOptics { self: ObservationModel.type =>
 
   val config: Lens[ObservationModel, Option[InstrumentConfigModel.Reference]] =
     Lens[ObservationModel, Option[InstrumentConfigModel.Reference]](_.config)(a => _.copy(config = a))
+
+  val executedSteps: Lens[ObservationModel, List[ExecutedStep]] =
+    Lens[ObservationModel, List[ExecutedStep]](_.executedSteps)(a => _.copy(executedSteps = a))
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/PlannedTime.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/PlannedTime.scala
@@ -4,7 +4,7 @@
 package lucuma.odb.api.model
 
 import lucuma.core.util.Enumerated
-import lucuma.odb.api.model.duration._
+import lucuma.odb.api.model.time._
 import cats.{Eq, Semigroup}
 import cats.data.NonEmptyList
 import cats.syntax.all._

--- a/modules/core/src/main/scala/lucuma/odb/api/model/SequenceModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/SequenceModel.scala
@@ -4,12 +4,12 @@
 package lucuma.odb.api.model
 
 import lucuma.core.model.Atom
-
 import cats.{Applicative, Eq, Eval, Monad, Traverse}
 import cats.mtl.Stateful
 import cats.syntax.all._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
+import lucuma.core.util.Enumerated
 import monocle.macros.Lenses
 
 /**
@@ -66,5 +66,37 @@ object SequenceModel {
       deriveDecoder[Create[D]]
 
   }
+
+  sealed abstract class SequenceType(
+    val tag:       String,
+    val shortName: String
+  ) extends Product with Serializable
+
+  object SequenceType {
+    case object Acquisition extends SequenceType("ACQUISITION", "Acquisition")
+    case object Science     extends SequenceType("SCIENCE", "Science")
+
+    val all: List[SequenceType] =
+      List(
+        Acquisition,
+        Science
+      )
+
+    def fromTag(s: String): Option[SequenceType] =
+      all.find(_.tag === s)
+
+    def unsafeFromTag(s: String): SequenceType =
+      fromTag(s).getOrElse(throw new NoSuchElementException(s"SequenceType: Invalid tag: '$s'"))
+
+    implicit val EnumeratedSequenceType: Enumerated[SequenceType] =
+      new Enumerated[SequenceType] {
+        override def all: List[SequenceType] = SequenceType.all
+        override def tag(a: SequenceType): String = a.tag
+        override def unsafeFromTag(s: String): SequenceType = SequenceType.unsafeFromTag(s)
+      }
+
+  }
+
+
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
@@ -5,7 +5,6 @@ package lucuma.odb.api.model
 
 import lucuma.core.model.Step
 import lucuma.odb.api.model.StepConfig.CreateStepConfig
-
 import cats.{Applicative, Eq, Eval, Functor, Monad, Traverse}
 import cats.mtl.Stateful
 import cats.syntax.all._

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/DatasetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/DatasetRepo.scala
@@ -1,0 +1,87 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.repo
+
+import lucuma.core.model.Observation
+import lucuma.odb.api.model.{Dataset, DatasetModel, InputError}
+
+import cats.data.{EitherT, State}
+import cats.effect.Sync
+import cats.effect.concurrent.Ref
+import cats.syntax.all._
+
+
+sealed trait DatasetRepo[F[_]] {
+
+  def selectDataset(
+    did: Dataset.Id
+  ): F[Option[DatasetModel]]
+
+  def unsafeSelectDataset(
+    did: Dataset.Id
+  ): F[DatasetModel]
+
+  def selectDatasetsForObservation(
+    oid:      Observation.Id,
+    count:    Int,
+    afterGid: Option[Dataset.Id] = None
+  ): F[ResultPage[DatasetModel]]
+
+  def insert(
+    dataset: DatasetModel.Create
+  ): F[DatasetModel]
+
+}
+
+object DatasetRepo {
+
+  def create[F[_]: Sync](
+    tablesRef: Ref[F, Tables]
+  ): DatasetRepo[F] =
+    new DatasetRepo[F] {
+
+      override def selectDataset(
+        did: Dataset.Id
+      ): F[Option[DatasetModel]] =
+        tablesRef.get.map(Tables.dataset(did).get)
+
+      override def unsafeSelectDataset(
+        did: Dataset.Id
+      ): F[DatasetModel] =
+        selectDataset(did).map(_.getOrElse(sys.error(s"Dataset id '$did' missing")))
+
+      override def selectDatasetsForObservation(
+        oid:      Observation.Id,
+        count:    Int,
+        afterGid: Option[Dataset.Id]
+      ): F[ResultPage[DatasetModel]] =
+        tablesRef.get.map { tables =>
+
+          ResultPage.select[Dataset.Id, DatasetModel](
+            count,
+            afterGid,
+            tables.datasets.keySet,
+            tables.datasets.apply,
+            _.observationId === oid
+          )
+
+        }
+
+      override def insert(
+        newDataset: DatasetModel.Create
+      ): F[DatasetModel] =
+        EitherT(
+          tablesRef.modify { tables =>
+            val (tablesʹ, d) = newDataset.create[State[Tables, *], Tables](TableState).run(tables).value
+            d.fold(
+              err  => (tables, InputError.Exception(err).asLeft),
+              dset => (tablesʹ, dset.asRight)
+            )
+          }
+        ).rethrowT
+    }
+
+}
+
+

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ExecutionEventRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ExecutionEventRepo.scala
@@ -1,0 +1,115 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.repo
+
+import lucuma.odb.api.model.{DatabaseState, ExecutionEvent, ExecutionEventModel, InputError, ValidatedInput}
+import lucuma.odb.api.model.ExecutionEventModel.{DatasetEvent, SequenceEvent, StepEvent}
+import lucuma.core.model.Observation
+
+import cats.data.{EitherT, State}
+import cats.syntax.all._
+import cats.effect.Sync
+import cats.effect.concurrent.Ref
+
+import java.time.Instant
+
+
+sealed trait ExecutionEventRepo[F[_]] {
+
+  def selectEvent(
+    eid: ExecutionEvent.Id
+  ): F[Option[ExecutionEventModel]]
+
+  def selectEventsForObservation(
+    oid:      Observation.Id,
+    count:    Int,
+    afterGid: Option[ExecutionEvent.Id] = None
+  ): F[ResultPage[ExecutionEventModel]]
+
+  def insertSequenceEvent(
+    event: SequenceEvent.Create
+  ): F[SequenceEvent]
+
+  def insertStepEvent(
+    event: StepEvent.Create
+  ): F[StepEvent]
+
+  def insertDatasetEvent(
+    event: DatasetEvent.Create
+  ): F[DatasetEvent]
+
+}
+
+object ExecutionEventRepo {
+
+  def create[F[_]: Sync](
+    tablesRef: Ref[F, Tables]
+  ): ExecutionEventRepo[F] =
+    new ExecutionEventRepo[F] {
+
+      override def selectEvent(
+        eid: ExecutionEvent.Id
+      ): F[Option[ExecutionEventModel]] =
+        tablesRef.get.map(Tables.executionEvent(eid).get)
+
+      override def selectEventsForObservation(
+        oid:      Observation.Id,
+        count:    Int,
+        afterGid: Option[ExecutionEvent.Id]
+      ): F[ResultPage[ExecutionEventModel]] =
+        tablesRef.get.map { tables =>
+
+          ResultPage.select[ExecutionEvent.Id, ExecutionEventModel](
+            count,
+            afterGid,
+            tables.executionEvents.keySet,
+            tables.executionEvents.apply,
+            _.observationId === oid
+          )
+
+        }
+
+      private def received: F[Instant] =
+        Sync[F].delay(Instant.now)
+
+      private def runState[T](
+        s: State[Tables, ValidatedInput[T]]
+      ): F[T] =
+        EitherT(
+          tablesRef.modify { tables =>
+            val (tablesʹ, e) = s.run(tables).value
+            e.fold(
+              err => (tables, InputError.Exception(err).asLeft),
+              evt => (tablesʹ, evt.asRight)
+            )
+          }
+        ).rethrowT
+
+      private def insertEvent[A](
+        f: (DatabaseState[Tables], Instant) => State[Tables, ValidatedInput[A]]
+      ): F[A] =
+        for {
+          w <- received
+          e <- runState(f(TableState, w))
+        } yield e
+
+      override def insertSequenceEvent(
+        event: SequenceEvent.Create
+      ): F[SequenceEvent] =
+        insertEvent(event.create[State[Tables, *], Tables])
+
+      override def insertStepEvent(
+        event: StepEvent.Create
+      ): F[StepEvent] =
+        insertEvent(event.create[State[Tables, *], Tables])
+
+      override def insertDatasetEvent(
+        event: DatasetEvent.Create
+      ): F[DatasetEvent] =
+        insertEvent(event.create[State[Tables, *], Tables])
+
+    }
+
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/Ids.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/Ids.scala
@@ -5,6 +5,7 @@ package lucuma.odb.api.repo
 
 import lucuma.core.model.{Atom, Step}
 import lucuma.core.model.{Asterism, ConstraintSet, Observation, Program, Target}
+import lucuma.odb.api.model.{Dataset, ExecutionEvent}
 import cats.kernel.BoundedEnumerable
 import monocle.Lens
 
@@ -12,28 +13,32 @@ import monocle.Lens
  * Tracking "last" used ids of top-level types.
  */
 final case class Ids(
-  event:         Long,
-  asterism:      Asterism.Id,
-  atom:          Atom.Id,
-  constraintSet: ConstraintSet.Id,
-  observation:   Observation.Id,
-  program:       Program.Id,
-  step:          Step.Id,
-  target:        Target.Id
+  event:          Long,
+  asterism:       Asterism.Id,
+  atom:           Atom.Id,
+  constraintSet:  ConstraintSet.Id,
+  dataset:        Dataset.Id,
+  executionEvent: ExecutionEvent.Id,
+  observation:    Observation.Id,
+  program:        Program.Id,
+  step:           Step.Id,
+  target:         Target.Id
 )
 
 object Ids extends IdsOptics {
 
   val zero: Ids =
     Ids(
-      event         = 0L,
-      asterism      = BoundedEnumerable[Asterism.Id].minBound,
-      atom          = BoundedEnumerable[Atom.Id].minBound,
-      constraintSet = BoundedEnumerable[ConstraintSet.Id].minBound,
-      observation   = BoundedEnumerable[Observation.Id].minBound,
-      program       = BoundedEnumerable[Program.Id].minBound,
-      step          = BoundedEnumerable[Step.Id].minBound,
-      target        = BoundedEnumerable[Target.Id].minBound
+      event          = 0L,
+      asterism       = BoundedEnumerable[Asterism.Id].minBound,
+      atom           = BoundedEnumerable[Atom.Id].minBound,
+      constraintSet  = BoundedEnumerable[ConstraintSet.Id].minBound,
+      dataset        = BoundedEnumerable[Dataset.Id].minBound,
+      executionEvent = BoundedEnumerable[ExecutionEvent.Id].minBound,
+      observation    = BoundedEnumerable[Observation.Id].minBound,
+      program        = BoundedEnumerable[Program.Id].minBound,
+      step           = BoundedEnumerable[Step.Id].minBound,
+      target         = BoundedEnumerable[Target.Id].minBound
     )
 
 }
@@ -51,6 +56,12 @@ sealed trait IdsOptics { self: Ids.type =>
 
   val lastConstraintSet: Lens[Ids, ConstraintSet.Id] =
     Lens[Ids, ConstraintSet.Id](_.constraintSet)(b => a => a.copy(constraintSet = b))
+
+  val lastDataset: Lens[Ids, Dataset.Id] =
+    Lens[Ids, Dataset.Id](_.dataset)(b => a => a.copy(dataset = b))
+
+  val lastExecutionEvent: Lens[Ids, ExecutionEvent.Id] =
+    Lens[Ids, ExecutionEvent.Id](_.executionEvent)(b => a => a.copy(executionEvent = b))
 
   val lastObservation: Lens[Ids, Observation.Id] =
     Lens[Ids, Observation.Id](_.observation)(b => a => a.copy(observation = b))

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/OdbRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/OdbRepo.scala
@@ -22,9 +22,15 @@ trait OdbRepo[F[_]] {
 
   def constraintSet: ConstraintSetRepo[F]
 
+  def dataset: DatasetRepo[F]
+
+  def executionEvent: ExecutionEventRepo[F]
+
   def observation: ObservationRepo[F]
 
   def program: ProgramRepo[F]
+
+  def step: StepRepo[F]
 
   def target: TargetRepo[F]
 
@@ -59,11 +65,20 @@ object OdbRepo {
       override def constraintSet: ConstraintSetRepo[F] =
         ConstraintSetRepo.create(r, s)
 
+      override def dataset: DatasetRepo[F] =
+        DatasetRepo.create(r)
+
+      override def executionEvent: ExecutionEventRepo[F] =
+        ExecutionEventRepo.create(r)
+
       override def observation: ObservationRepo[F] =
         ObservationRepo.create(r, s)
 
       override def program: ProgramRepo[F] =
         ProgramRepo.create(r, s)
+
+      override def step: StepRepo[F] =
+        StepRepo.create[F](r)
 
       override def target: TargetRepo[F] =
         TargetRepo.create(r, s)

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ResultPage.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ResultPage.scala
@@ -3,7 +3,10 @@
 
 package lucuma.odb.api.repo
 
-import cats.Eq
+import cats.{Eq, Order}
+import cats.syntax.all._
+
+import scala.collection.immutable.SortedSet
 
 final case class ResultPage[A](
   nodes:       List[A],
@@ -15,6 +18,34 @@ object ResultPage {
 
   def empty[A]: ResultPage[A] =
     ResultPage(Nil, hasNextPage = false, 0)
+
+  def fromIterator[A](
+    count:      Int,
+    it:         Iterator[A],
+    totalCount: Int
+  ): ResultPage[A] = {
+    val res = scala.collection.mutable.Buffer.empty[A]
+    while (it.hasNext && (res.size < count)) res += it.next()
+    ResultPage(res.toList, it.hasNext, totalCount)
+  }
+
+  def select[A: Order, B](
+    count:   Int,
+    after:   Option[A],
+    keys:    SortedSet[A],
+    lookup:  A => B,
+    include: B => Boolean
+  ): ResultPage[B] =
+
+    ResultPage.fromIterator(
+      count,
+      after
+        .fold(keys.iterator)(a => keys.iteratorFrom(a).dropWhile(_ === a))
+        .map(lookup)
+        .filter(include),
+      keys.count(k => include(lookup(k)))
+    )
+
 
   def EqResultPage[A: Eq]: Eq[ResultPage[A]] =
     Eq.by { p => (

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TableState.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TableState.scala
@@ -4,8 +4,7 @@
 package lucuma.odb.api.repo
 
 import lucuma.core.model.{Asterism, Atom, ConstraintSet, Observation, Program, Step, Target}
-import lucuma.odb.api.model.{AsterismModel, AtomModel, ConstraintSetModel, DatabaseState, ObservationModel, ProgramModel, RepoState, SharingState, StepModel, TargetModel}
-
+import lucuma.odb.api.model.{AsterismModel, AtomModel, ConstraintSetModel, DatabaseState, Dataset, DatasetModel, ExecutionEvent, ExecutionEventModel, ObservationModel, ProgramModel, RepoState, SharingState, StepModel, TargetModel}
 import cats.data.State
 import cats.mtl.Stateful
 import monocle.Lens
@@ -24,6 +23,12 @@ trait TableState extends DatabaseState[Tables] {
 
   override val constraintSet: RepoState[Tables, ConstraintSet.Id, ConstraintSetModel] =
     RepoState.fromLenses(Tables.lastConstraintSetId, Tables.constraintSets)
+
+  override val dataset: RepoState[Tables, Dataset.Id, DatasetModel] =
+    RepoState.fromLenses(Tables.lastDatasetId, Tables.datasets)
+
+  override val executionEvent: RepoState[Tables, ExecutionEvent.Id, ExecutionEventModel] =
+    RepoState.fromLenses(Tables.lastExecutionEventId, Tables.executionEvents)
 
   override val observation: RepoState[Tables, Observation.Id, ObservationModel] =
     RepoState.fromLenses(Tables.lastObservationId, Tables.observations)

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/Tables.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/Tables.scala
@@ -4,8 +4,7 @@
 package lucuma.odb.api.repo
 
 import lucuma.core.model.{Asterism, Atom, ConstraintSet, Observation, Program, Step, Target}
-import lucuma.odb.api.model.{AsterismModel, AtomModel, ConstraintSetModel, ObservationModel, ProgramModel, StepModel, TargetModel}
-
+import lucuma.odb.api.model.{AsterismModel, AtomModel, ConstraintSetModel, Dataset, DatasetModel, ExecutionEvent, ExecutionEventModel, ObservationModel, ProgramModel, StepModel, TargetModel}
 import cats.instances.order._
 import monocle.Lens
 import monocle.function.At
@@ -16,37 +15,41 @@ import scala.collection.immutable.{SortedMap, TreeMap}
  * Simplistic immutable database "tables" of top-level types keyed by Id.
  */
 final case class Tables(
-  ids:                      Ids,
-  atoms:                    SortedMap[Atom.Id, AtomModel[Step.Id]],
-  asterisms:                SortedMap[Asterism.Id, AsterismModel],
-  constraintSets:           SortedMap[ConstraintSet.Id, ConstraintSetModel],
-  observations:             SortedMap[Observation.Id, ObservationModel],
-  programs:                 SortedMap[Program.Id, ProgramModel],
-  steps:                    SortedMap[Step.Id, StepModel[_]],
-  targets:                  SortedMap[Target.Id, TargetModel],
+  ids:             Ids,
+  atoms:           SortedMap[Atom.Id, AtomModel[Step.Id]],
+  asterisms:       SortedMap[Asterism.Id, AsterismModel],
+  constraintSets:  SortedMap[ConstraintSet.Id, ConstraintSetModel],
+  datasets:        SortedMap[Dataset.Id, DatasetModel],
+  executionEvents: SortedMap[ExecutionEvent.Id, ExecutionEventModel],
+  observations:    SortedMap[Observation.Id, ObservationModel],
+  programs:        SortedMap[Program.Id, ProgramModel],
+  steps:           SortedMap[Step.Id, StepModel[_]],
+  targets:         SortedMap[Target.Id, TargetModel],
 
-  programAsterism:          ManyToMany[Program.Id, Asterism.Id],
-  programTarget:            ManyToMany[Program.Id, Target.Id],
-  targetAsterism:           ManyToMany[Target.Id, Asterism.Id],
+  programAsterism: ManyToMany[Program.Id, Asterism.Id],
+  programTarget:   ManyToMany[Program.Id, Target.Id],
+  targetAsterism:  ManyToMany[Target.Id, Asterism.Id],
 )
 
 object Tables extends TableOptics {
 
   val empty: Tables =
     Tables(
-      ids                      = Ids.zero,
+      ids             = Ids.zero,
 
-      atoms                    = TreeMap.empty[Atom.Id, AtomModel[Step.Id]],
-      asterisms                = TreeMap.empty[Asterism.Id, AsterismModel],
-      constraintSets           = TreeMap.empty[ConstraintSet.Id, ConstraintSetModel],
-      observations             = TreeMap.empty[Observation.Id, ObservationModel],
-      programs                 = TreeMap.empty[Program.Id, ProgramModel],
-      steps                    = TreeMap.empty[Step.Id, StepModel[_]],
-      targets                  = TreeMap.empty[Target.Id, TargetModel],
+      atoms           = TreeMap.empty[Atom.Id, AtomModel[Step.Id]],
+      asterisms       = TreeMap.empty[Asterism.Id, AsterismModel],
+      constraintSets  = TreeMap.empty[ConstraintSet.Id, ConstraintSetModel],
+      datasets        = TreeMap.empty[Dataset.Id, DatasetModel],
+      executionEvents = TreeMap.empty[ExecutionEvent.Id, ExecutionEventModel],
+      observations    = TreeMap.empty[Observation.Id, ObservationModel],
+      programs        = TreeMap.empty[Program.Id, ProgramModel],
+      steps           = TreeMap.empty[Step.Id, StepModel[_]],
+      targets         = TreeMap.empty[Target.Id, TargetModel],
 
-      programAsterism          = ManyToMany.empty,
-      programTarget            = ManyToMany.empty,
-      targetAsterism           = ManyToMany.empty,
+      programAsterism = ManyToMany.empty,
+      programTarget   = ManyToMany.empty,
+      targetAsterism  = ManyToMany.empty,
     )
 
 }
@@ -67,6 +70,12 @@ sealed trait TableOptics { self: Tables.type =>
 
   val lastConstraintSetId: Lens[Tables, ConstraintSet.Id] =
     ids ^|-> Ids.lastConstraintSet
+
+  val lastDatasetId: Lens[Tables, Dataset.Id] =
+    ids ^|-> Ids.lastDataset
+
+  val lastExecutionEventId: Lens[Tables, ExecutionEvent.Id] =
+    ids ^|-> Ids.lastExecutionEvent
 
   val lastObservationId: Lens[Tables, Observation.Id] =
     ids ^|-> Ids.lastObservation
@@ -99,6 +108,18 @@ sealed trait TableOptics { self: Tables.type =>
 
   def constraintSet(csid: ConstraintSet.Id): Lens[Tables, Option[ConstraintSetModel]] =
     constraintSets ^|-> At.at(csid)
+
+  val datasets: Lens[Tables, SortedMap[Dataset.Id, DatasetModel]] =
+    Lens[Tables, SortedMap[Dataset.Id, DatasetModel]](_.datasets)(b => a => a.copy(datasets = b))
+
+  def dataset(did: Dataset.Id): Lens[Tables, Option[DatasetModel]] =
+    datasets ^|-> At.at(did)
+
+  val executionEvents: Lens[Tables, SortedMap[ExecutionEvent.Id, ExecutionEventModel]] =
+    Lens[Tables, SortedMap[ExecutionEvent.Id, ExecutionEventModel]](_.executionEvents)(b => a => a.copy(executionEvents = b))
+
+  def executionEvent(eid: ExecutionEvent.Id): Lens[Tables, Option[ExecutionEventModel]] =
+    executionEvents ^|-> At.at(eid)
 
   val observations: Lens[Tables, SortedMap[Observation.Id, ObservationModel]] =
     Lens[Tables, SortedMap[Observation.Id, ObservationModel]](_.observations)(b => a => a.copy(observations = b))

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TopLevelRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TopLevelRepo.scala
@@ -18,7 +18,6 @@ import monocle.function.At
 import monocle.state.all._
 
 import scala.collection.immutable.SortedMap
-import scala.collection.mutable
 
 
 trait TopLevelRepo[F[_], I, T] {
@@ -120,23 +119,19 @@ abstract class TopLevelRepoBase[F[_]: Monad, I: Gid, T: TopLevelModel[I, *]: Eq]
     includeDeleted: Boolean
   )(
     predicate: T => Boolean
-  ): F[ResultPage[T]] = {
-
-    val isSelected: T => Boolean =
-      t => (includeDeleted || t.isPresent) && predicate(t)
+  ): F[ResultPage[T]] =
 
     tablesRef.get.map { tables =>
       val all = mapLens.get(tables)
 
-      page(
+      ResultPage.select(
         count,
-        afterGid
-          .fold(all.valuesIterator)(gid => all.valuesIteratorFrom(gid).dropWhile(t => TopLevelModel[I, T].id(t) === gid))
-          .filter(isSelected),
-        all.count { case (_, t) => isSelected(t) }
+        afterGid,
+        all.keySet,
+        all.apply,
+        t => (includeDeleted || t.isPresent) && predicate(t)
       )
     }
-  }
 
   def selectPageFromIds(
     count:          Int,
@@ -144,35 +139,17 @@ abstract class TopLevelRepoBase[F[_]: Monad, I: Gid, T: TopLevelModel[I, *]: Eq]
     includeDeleted: Boolean
   )(
     ids: Tables => scala.collection.immutable.SortedSet[I]
-  ): F[ResultPage[T]] = {
-
-    val isSelected: T => Boolean =
-      t => includeDeleted || t.isPresent
+  ): F[ResultPage[T]] =
 
     tablesRef.get.map { tables =>
-      val all    = ids(tables)
-      val lookup = mapLens.get(tables)
-
-      page(
+      ResultPage.select(
         count,
-        afterGid
-          .fold(all.iterator)(gid => all.iteratorFrom(gid).dropWhile(_ === gid))
-          .map(lookup)
-          .filter(isSelected),
-        all.count(k => isSelected(lookup(k)))
+        afterGid,
+        ids(tables),
+        mapLens.get(tables).apply,
+        t => includeDeleted || t.isPresent
       )
     }
-  }
-
-  private def page(
-    count:      Int,
-    it:         Iterator[T],
-    totalCount: Int
-  ): ResultPage[T] = {
-    val res = mutable.Buffer.empty[T]
-    while (it.hasNext && (res.size < count)) res += it.next()
-    ResultPage(res.toList, it.hasNext, totalCount)
-  }
 
   def constructAndPublish[U <: T](
     cons: Tables => ValidatedInput[State[Tables, U]]

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/DatasetSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/DatasetSchema.scala
@@ -1,0 +1,103 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.schema
+
+import lucuma.odb.api.model.{Dataset, DatasetFilename, DatasetModel}
+import lucuma.odb.api.model.format.ScalarFormat
+import lucuma.odb.api.repo.OdbRepo
+import lucuma.odb.api.schema.syntax.scalar._
+
+import cats.effect.Effect
+
+import sangria.schema._
+
+
+object DatasetSchema {
+
+  import context._
+  import TimeSchema._
+
+  implicit val DatasetIdType: ScalarType[Dataset.Id] =
+    ObjectIdSchema.idType[Dataset.Id](name = "DatasetId")
+
+  val DatasetIdArgument: Argument[Dataset.Id] =
+    Argument(
+      name         = "datasetId",
+      argumentType = DatasetIdType,
+      description  = "Dataset ID"
+    )
+
+  val OptionalDatasetIdArgument: Argument[Option[Dataset.Id]] =
+    Argument(
+      name         = "datasetId",
+      argumentType = OptionInputType(DatasetIdType),
+      description  = "Dataset ID"
+    )
+
+  val DatasetFilenameScalar: ScalarType[DatasetFilename] =
+    ScalarType.fromScalarFormat(
+      name         = "DatasetFilename",
+      description  = "Dataset filename in standard format",
+      scalarFormat = ScalarFormat(DatasetFilename.fromString, "N20210519S0001.fits")
+    )
+
+  def DatasetType[F[_]](implicit F: Effect[F]): ObjectType[OdbRepo[F], DatasetModel] =
+    ObjectType(
+      name     = "Dataset",
+      fieldsFn = () => fields(
+
+        Field(
+          name        = "id",
+          fieldType   = DatasetIdType,
+          description = Some("Dataset ID"),
+          resolve     = _.value.id
+        ),
+
+        Field(
+          name        = "observation",
+          fieldType   = ObservationSchema.ObservationType[F],
+          description = Some("Observation associated with this dataset"),
+          resolve     = c => c.observation(_.unsafeSelect(c.value.observationId, includeDeleted = true))
+        ),
+
+        Field(
+          name        = "step",
+          fieldType   = StepSchema.StepInterfaceType[F],
+          description = Some("Step that produced the dataset"),
+          resolve     = c => c.step(_.unsafeSelectStep(c.value.stepId))
+        ),
+
+        Field(
+          name        = "timestamp",
+          fieldType   = InstantScalar,
+          description = Some("Dataset timestamp"),
+          resolve     = _.value.timestamp
+        ),
+
+        Field(
+          name        = "filename",
+          fieldType   = DatasetFilenameScalar,
+          description = Some("Dataset filename"),
+          resolve     = _.value.filename
+        )
+
+      )
+    )
+
+  def DatasetEdgeType[F[_]: Effect]: ObjectType[OdbRepo[F], Paging.Edge[DatasetModel]] =
+    Paging.EdgeType(
+      "DatasetEdge",
+      "A Dataset and its cursor",
+      DatasetType[F]
+    )
+
+  def DatasetConnectionType[F[_]: Effect]: ObjectType[OdbRepo[F], Paging.Connection[DatasetModel]] =
+    Paging.ConnectionType(
+      "DatasetConnection",
+      "Datasets in the current page",
+      DatasetType[F],
+      DatasetEdgeType[F]
+    )
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventSchema.scala
@@ -1,0 +1,190 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.schema
+
+import lucuma.odb.api.model.{ExecutionEvent, ExecutionEventModel}
+import lucuma.odb.api.repo.OdbRepo
+
+import cats.effect.Effect
+
+import sangria.schema._
+
+
+object ExecutionEventSchema {
+
+  import context._
+
+  import TimeSchema._
+  import ExecutionEventModel._
+  import syntax.`enum`._
+
+  implicit val ExecutionEventIdType: ScalarType[ExecutionEvent.Id] =
+    ObjectIdSchema.idType[ExecutionEvent.Id](name = "ExecutionEventId")
+
+  val ExecutionEventArgument: Argument[ExecutionEvent.Id] =
+    Argument(
+      name         = "executionEventId",
+      argumentType = ExecutionEventIdType,
+      description  = "Execution Event ID"
+    )
+
+  val OptionalExecutionEventArgument: Argument[Option[ExecutionEvent.Id]] =
+    Argument(
+      name         = "executionEventId",
+      argumentType = OptionInputType(ExecutionEventIdType),
+      description  = "Execution Event ID"
+    )
+
+  implicit val EnumTypeSequenceCommand: EnumType[SequenceCommandType] =
+    EnumType.fromEnumerated(
+      "SequenceCommand",
+      "Sequence-level command"
+    )
+
+  implicit val EnumTypeStepStage: EnumType[StepStageType] =
+    EnumType.fromEnumerated(
+      "StepStage",
+      "Execution stage or phase of an individual step"
+    )
+
+  implicit val EnumTypeDatasetStage: EnumType[DatasetStageType] =
+    EnumType.fromEnumerated(
+      "DatasetStage",
+      "Execution stage or phase of an individual dataset"
+    )
+
+  def ExecutionEventType[F[_]: Effect]: InterfaceType[OdbRepo[F], ExecutionEventModel] =
+    InterfaceType[OdbRepo[F], ExecutionEventModel](
+      name         = "ExecutionEvent",
+      description  = "Execution event (sequence, step, or dataset events)",
+      fields[OdbRepo[F], ExecutionEventModel](
+
+        Field(
+          name        = "id",
+          fieldType   = ExecutionEventIdType,
+          description = Some("Event id"),
+          resolve     = _.value.id
+        ),
+
+        Field(
+          name        = "observation",
+          fieldType   = ObservationSchema.ObservationType[F],
+          description = Some("Observation whose execution produced this event"),
+          resolve     = c => c.observation(_.unsafeSelect(c.value.observationId, includeDeleted = true))
+        ),
+
+        Field(
+          name        = "generated",
+          fieldType   = InstantScalar,
+          description = Some("Time at which this event was generated, according to the caller (e.g., Observe)"),
+          resolve     = _.value.generated
+        ),
+
+        Field(
+          name        = "received",
+          fieldType   = InstantScalar,
+          description = Some("Time at which this event was received"),
+          resolve     = _.value.received
+        )
+
+      )
+    ).withPossibleTypes(() => List(
+      PossibleObject[OdbRepo[F], ExecutionEventModel](SequenceEventType[F]),
+      PossibleObject[OdbRepo[F], ExecutionEventModel](StepEventType[F]),
+      PossibleObject[OdbRepo[F], ExecutionEventModel](DatasetEventType[F])
+    ))
+
+  def SequenceEventType[F[_]: Effect]: ObjectType[OdbRepo[F], SequenceEvent] =
+    ObjectType[OdbRepo[F], SequenceEvent](
+      name        = "SequenceEvent",
+      description = "Sequence-level events",
+      interfaces  = List(PossibleInterface.apply[OdbRepo[F], SequenceEvent](ExecutionEventType[F])),
+      fields      = List[Field[OdbRepo[F], SequenceEvent]](
+
+        Field(
+          name        = "command",
+          fieldType   = EnumTypeSequenceCommand,
+          description = Some("Sequence command"),
+          resolve     = _.value.command
+        )
+
+      )
+    )
+
+  def StepEventType[F[_]: Effect]: ObjectType[OdbRepo[F], StepEvent] =
+    ObjectType[OdbRepo[F], StepEvent](
+      name        = "StepEvent",
+      description = "Step-level events",
+      interfaces  = List(PossibleInterface.apply[OdbRepo[F], StepEvent](ExecutionEventType[F])),
+      fields      = List[Field[OdbRepo[F], StepEvent]](
+
+        Field(
+          name        = "step",
+          fieldType   = StepSchema.StepInterfaceType[F],
+          description = Some("Step to which the event applies"),
+          resolve     = c => c.step(_.unsafeSelectStep(c.value.stepId))
+        ),
+
+        Field(
+          name        = "sequenceType",
+          fieldType   = SequenceSchema.EnumTypeSequenceType,
+          description = Some("Sequence type"),
+          resolve     = _.value.sequenceType
+        ),
+
+        Field(
+          name        = "stage",
+          fieldType   = EnumTypeStepStage,
+          description = Some("Step stage"),
+          resolve     = _.value.stage
+        )
+
+      )
+    )
+
+  def DatasetEventType[F[_]: Effect]: ObjectType[OdbRepo[F], DatasetEvent] =
+    ObjectType[OdbRepo[F], DatasetEvent](
+      name        = "DatasetEvent",
+      description = "Dataset-level events",
+      interfaces  = List(PossibleInterface.apply[OdbRepo[F], DatasetEvent](ExecutionEventType[F])),
+      fields      = List[Field[OdbRepo[F], DatasetEvent]](
+
+        Field(
+          name        = "step",
+          fieldType   = StepSchema.StepInterfaceType[F],
+          description = Some("Step from which the dataset comes"),
+          resolve     = c => c.step(_.unsafeSelectStep(c.value.stepId))
+        ),
+
+        Field(
+          name        = "filename",
+          fieldType   = OptionType(DatasetSchema.DatasetFilenameScalar),
+          description = Some("Dataset filename, when known"),
+          resolve     = _.value.filename
+        ),
+
+        Field(
+          name        = "stage",
+          fieldType   = EnumTypeDatasetStage,
+          description = Some("Dataset stage"),
+          resolve     = _.value.stageType
+        )
+      )
+    )
+
+  def ExecutionEventEdgeType[F[_]: Effect]: ObjectType[OdbRepo[F], Paging.Edge[ExecutionEventModel]] =
+    Paging.EdgeType(
+      "ExecutionEventEdge",
+      "An ExecutionEvent and its cursor",
+      ExecutionEventType[F]
+    )
+
+  def ExecutionEventConnectionType[F[_]: Effect]: ObjectType[OdbRepo[F], Paging.Connection[ExecutionEventModel]] =
+    Paging.ConnectionType(
+      "ExecutionEventConnection",
+      "ExecutionEvents in the current page",
+      ExecutionEventType[F],
+      ExecutionEventEdgeType[F]
+    )
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionRecordSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionRecordSchema.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.schema
+
+import lucuma.core.model.Observation
+import lucuma.odb.api.repo.OdbRepo
+import cats.effect.Effect
+import lucuma.odb.api.model.{Dataset, DatasetModel, ExecutionEvent, ExecutionEventModel}
+import sangria.schema._
+
+object ExecutionRecordSchema {
+
+  import context._
+  import DatasetSchema._
+  import ExecutionEventSchema._
+  import Paging._
+
+  def ExecutionRecordType[F[_]: Effect]: ObjectType[OdbRepo[F], Observation.Id] =
+    ObjectType(
+      name     = "ExecutionRecord",
+      fieldsFn = () => fields(
+
+        Field(
+          name        = "datasets",
+          fieldType   = DatasetConnectionType[F],
+          description = Some("Datasets associated with the observation"),
+          arguments   = List(
+            ArgumentPagingFirst,
+            ArgumentPagingCursor
+          ),
+          resolve     = c =>
+            unsafeSelectPageFuture[F, Dataset.Id, DatasetModel](c.pagingDatasetId, (d: DatasetModel) => d.id) { did =>
+              c.ctx.dataset.selectDatasetsForObservation(c.value, c.pagingFirst, did)
+            }
+        ),
+
+        Field(
+          name        = "events",
+          fieldType   = ExecutionEventConnectionType[F],
+          description = Some("Events associated with the observation"),
+          arguments   = List(
+            ArgumentPagingFirst,
+            ArgumentPagingCursor
+          ),
+          resolve     = c =>
+            unsafeSelectPageFuture[F, ExecutionEvent.Id, ExecutionEventModel](c.pagingExecutionEventId, (e: ExecutionEventModel) => e.id) { eid =>
+              // TODO: here we're going to want the events sorted by timestamp, not GID
+              c.ctx.executionEvent.selectEventsForObservation(c.value, c.pagingFirst, eid)
+            }
+        )
+
+      )
+    )
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/GeneralSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/GeneralSchema.scala
@@ -14,7 +14,7 @@ import sangria.validation.ValueCoercionViolation
 
 object GeneralSchema {
 
-  import FiniteDurationSchema._
+  import TimeSchema._
   import syntax.`enum`._
 
   implicit val EnumTypeExistence: EnumType[Existence] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/GmosSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/GmosSchema.scala
@@ -13,7 +13,7 @@ import scala.reflect.ClassTag
 
 object GmosSchema {
 
-  import FiniteDurationSchema._
+  import TimeSchema._
   import InstrumentSchema._
   import OffsetSchema._
   import WavelengthSchema._

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/InstrumentConfigSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/InstrumentConfigSchema.scala
@@ -7,7 +7,7 @@ import lucuma.core.`enum`.Instrument
 import lucuma.odb.api.model.{DereferencedSequence, InstrumentConfigModel, PlannedTime}
 import lucuma.odb.api.repo.OdbRepo
 import cats.effect.Effect
-import lucuma.odb.api.schema.FiniteDurationSchema.DurationType
+import lucuma.odb.api.schema.TimeSchema.DurationType
 import sangria.schema._
 
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
@@ -18,6 +18,7 @@ object ObservationSchema {
 
   import AsterismSchema.AsterismType
   import ConstraintSetSchema.ConstraintSetType
+  import ExecutionRecordSchema.ExecutionRecordType
   import GeneralSchema.{ArgumentIncludeDeleted, EnumTypeExistence, NonEmptyStringType, PlannedTimeSummaryType}
   import ProgramSchema.ProgramType
   import TargetSchema.TargetType
@@ -151,6 +152,13 @@ object ObservationSchema {
                 icm.dereference[State[Tables, *], Tables](TableState).runA(tables).value
               }
             }.toIO.unsafeToFuture()
+        ),
+
+        Field(
+          name        = "execution",
+          fieldType   = ExecutionRecordType[F],
+          description = Some("Execution sequence and runtime artifacts"),
+          resolve     = _.value.id
         )
 
       )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/PlannedTimeSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/PlannedTimeSchema.scala
@@ -5,7 +5,7 @@ package lucuma.odb.api.schema
 
 import lucuma.odb.api.model.PlannedTime
 import lucuma.odb.api.model.PlannedTime.{CategorizedTime, Category}
-import lucuma.odb.api.model.duration._
+import lucuma.odb.api.model.time._
 import lucuma.odb.api.repo.OdbRepo
 import cats.effect.Effect
 import sangria.schema._
@@ -13,7 +13,7 @@ import sangria.schema._
 
 object PlannedTimeSchema {
 
-  import FiniteDurationSchema.DurationType
+  import TimeSchema.DurationType
   import syntax.`enum`._
 
   implicit val EnumTypeCategory: EnumType[Category] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/RepoContext.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/RepoContext.scala
@@ -3,13 +3,13 @@
 
 package lucuma.odb.api.schema
 
-import lucuma.odb.api.repo.{AsterismRepo, ConstraintSetRepo, ObservationRepo, OdbRepo, ProgramRepo, TargetRepo}
+import lucuma.odb.api.repo.{AsterismRepo, ConstraintSetRepo, DatasetRepo, ExecutionEventRepo, ObservationRepo, OdbRepo, ProgramRepo, StepRepo, TargetRepo}
 import lucuma.core.model.{Asterism, ConstraintSet, Observation, Program, Target}
 import cats.effect.Effect
 import cats.effect.implicits._
 import cats.syntax.all._
 import lucuma.core.util.Gid
-import lucuma.odb.api.model.InputError
+import lucuma.odb.api.model.{Dataset, ExecutionEvent, InputError}
 import sangria.schema.Context
 
 import scala.concurrent.Future
@@ -27,6 +27,18 @@ final class RepoContextOps[F[_]: Effect](val self: Context[OdbRepo[F], _]) {
 
   def optionConstraintSetId: Option[ConstraintSet.Id] =
     self.arg(ConstraintSetSchema.OptionalConstraintSetIdArgument)
+
+  def datasetId: Dataset.Id =
+    self.arg(DatasetSchema.DatasetIdArgument)
+
+  def optionalDatasetId: Option[Dataset.Id] =
+    self.arg(DatasetSchema.OptionalDatasetIdArgument)
+
+  def executionEventId: ExecutionEvent.Id =
+    self.arg(ExecutionEventSchema.ExecutionEventArgument)
+
+  def optionalExecutionEventId: Option[ExecutionEvent.Id] =
+    self.arg(ExecutionEventSchema.OptionalExecutionEventArgument)
 
   def observationId: Observation.Id =
     self.arg(ObservationSchema.ObservationIdArgument)
@@ -73,6 +85,12 @@ final class RepoContextOps[F[_]: Effect](val self: Context[OdbRepo[F], _]) {
   def pagingConstraintSetId: Either[InputError, Option[ConstraintSet.Id]] =
     pagingGid[ConstraintSet.Id]("ConstraintSetId")
 
+  def pagingDatasetId: Either[InputError, Option[Dataset.Id]] =
+    pagingGid[Dataset.Id]("DatasetId")
+
+  def pagingExecutionEventId: Either[InputError, Option[ExecutionEvent.Id]] =
+    pagingGid[ExecutionEvent.Id]("ExecutionEventId")
+
   def pagingObservationId: Either[InputError, Option[Observation.Id]] =
     pagingGid[Observation.Id]("ObservationId")
 
@@ -88,11 +106,20 @@ final class RepoContextOps[F[_]: Effect](val self: Context[OdbRepo[F], _]) {
   def constraintSet[B](f: ConstraintSetRepo[F] => F[B]): Future[B] =
     f(self.ctx.constraintSet).toIO.unsafeToFuture()
 
+  def dataset[B](f: DatasetRepo[F] => F[B]): Future[B] =
+    f(self.ctx.dataset).toIO.unsafeToFuture()
+
+  def executionEvent[B](f: ExecutionEventRepo[F] => F[B]): Future[B] =
+    f(self.ctx.executionEvent).toIO.unsafeToFuture()
+
   def observation[B](f: ObservationRepo[F] => F[B]): Future[B] =
     f(self.ctx.observation).toIO.unsafeToFuture()
 
   def program[B](f: ProgramRepo[F] => F[B]): Future[B] =
     f(self.ctx.program).toIO.unsafeToFuture()
+
+  def step[B](f: StepRepo[F] => F[B]): Future[B] =
+    f(self.ctx.step).toIO.unsafeToFuture()
 
   def target[B](f: TargetRepo[F] => F[B]): Future[B] =
     f(self.ctx.target).toIO.unsafeToFuture()

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SequenceSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SequenceSchema.scala
@@ -4,18 +4,25 @@
 package lucuma.odb.api.schema
 
 import lucuma.core.model.Atom
-import lucuma.odb.api.model.{AtomModel, DereferencedSequence, PlannedTime, StepModel}
+import lucuma.odb.api.model.{AtomModel, DereferencedSequence, PlannedTime, SequenceModel, StepModel}
 import lucuma.odb.api.repo.OdbRepo
 import cats.effect.Effect
 import sangria.schema._
 
 object SequenceSchema {
 
+  import syntax.`enum`._
   import PlannedTimeSchema._
   import StepSchema.InstrumentStepType
 
   implicit val AtomIdType: ScalarType[Atom.Id] =
     ObjectIdSchema.idType[Atom.Id](name = "AtomId")
+
+  implicit val EnumTypeSequenceType: EnumType[SequenceModel.SequenceType] =
+    EnumType.fromEnumerated(
+      "SequenceType",
+      "Type of sequence, acquisition or science"
+    )
 
   def AtomType[F[_]: Effect, D](
     typePrefix:  String,

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/StepSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/StepSchema.scala
@@ -129,7 +129,7 @@ object StepSchema {
 
   def StepConfigType[F[_]: Effect]: InterfaceType[OdbRepo[F], StepConfig[_]] =
     InterfaceType[OdbRepo[F], StepConfig[_]](
-      name         = s"StepConfig",
+      name         = "StepConfig",
       description  = "Step (bias, dark, gcal, science, etc.)",
       fields[OdbRepo[F], StepConfig[_]](
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TimeSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TimeSchema.scala
@@ -3,13 +3,32 @@
 
 package lucuma.odb.api.schema
 
-import cats.effect.Effect
+import lucuma.core.optics.Format
+import lucuma.odb.api.model.format.ScalarFormat
+import lucuma.odb.api.schema.syntax.scalar._
 import lucuma.odb.api.repo.OdbRepo
-import sangria.schema.{BigDecimalType, Field, LongType, ObjectType, fields}
+import cats.effect.Effect
+import sangria.schema._
+
+import java.time.Instant
 
 import scala.concurrent.duration.FiniteDuration
+import scala.util.Try
 
-object FiniteDurationSchema {
+object TimeSchema {
+
+  val InstantFormat: Format[String, Instant] =
+    Format.apply[String, Instant](
+      s => Try(Instant.parse(s)).toOption,
+      _.toString
+    )
+
+  val InstantScalar: ScalarType[Instant] =
+    ScalarType.fromScalarFormat(
+      name         = "Instant",
+      description  = "Instant of time in ISO-8601 representation",
+      scalarFormat =  ScalarFormat(InstantFormat, "2011-12-03T10:15:30Z")
+    )
 
   def DurationType[F[_]: Effect]: ObjectType[OdbRepo[F], FiniteDuration] =
     ObjectType(

--- a/modules/core/src/test/scala/lucuma/odb/api/model/DatasetFilenameSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/DatasetFilenameSuite.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.odb.api.model.arb._
+
+import lucuma.core.optics.laws.discipline.FormatTests
+import cats.kernel.laws.discipline.OrderTests
+import munit.DisciplineSuite
+
+final class DatasetFilenameSuite extends DisciplineSuite {
+
+  import ArbDatasetFilename._
+
+  checkAll("DatasetFilename", OrderTests[DatasetFilename].order)
+
+  checkAll("DatasetFilename Format", FormatTests(DatasetFilename.fromString).formatWith(genDatasetFilenameString))
+
+}

--- a/modules/core/src/test/scala/lucuma/odb/api/model/DatasetModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/DatasetModelSuite.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import lucuma.odb.api.model.arb._
+import cats.kernel.laws.discipline.EqTests
+import munit.DisciplineSuite
+
+
+final class DatasetModelSuite extends DisciplineSuite {
+
+  import ArbDatasetModel._
+
+  checkAll("DatasetModel", EqTests[DatasetModel].eqv)
+  checkAll("DatasetModel.Create", EqTests[DatasetModel.Create].eqv)
+
+}

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbDatasetFilename.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbDatasetFilename.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+package arb
+
+import lucuma.core.`enum`.Site
+import lucuma.core.util.arb.ArbEnumerated
+import lucuma.odb.api.model.time.FourDigitYearLocalDate
+import eu.timepit.refined.scalacheck.all.greaterArbitrary
+import eu.timepit.refined.types.all.PosInt
+import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
+
+
+trait ArbDatasetFilename {
+
+  import ArbEnumerated._
+  import ArbFourDigitYearLocalDate._
+
+  implicit val arbDatasetFilename: Arbitrary[DatasetFilename] =
+    Arbitrary {
+      for {
+        s <- arbitrary[Site]
+        d <- arbitrary[FourDigitYearLocalDate]
+        i <- arbitrary[PosInt]
+      } yield DatasetFilename(s, d, i)
+    }
+
+  implicit val cogDatasetFilename: Cogen[DatasetFilename] =
+    Cogen[String].contramap(_.format)
+
+  val genDatasetFilenameString: Gen[String] =
+    Gen.oneOf(
+      arbitrary[DatasetFilename].map(_.format),
+      arbitrary[(DatasetFilename, Int)].map { case (f, n) => f.format.replace("1", (n % 10).abs.toString) },
+      arbitrary[DatasetFilename].map(_.format.replace("S0", "S"))
+    )
+
+}
+
+object ArbDatasetFilename extends ArbDatasetFilename

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbDatasetModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbDatasetModel.scala
@@ -1,0 +1,76 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+package arb
+
+import lucuma.core.arb.ArbTime
+import lucuma.core.model.{Observation, Step}
+import lucuma.core.util.arb.ArbGid
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
+
+import java.time.Instant
+
+trait ArbDatasetModel {
+
+  import ArbDatasetFilename._
+  import ArbGid._
+  import ArbTime._
+
+  implicit val arbDatasetModel: Arbitrary[DatasetModel] =
+    Arbitrary {
+      for {
+        d <- arbitrary[Dataset.Id]
+        o <- arbitrary[Observation.Id]
+        s <- arbitrary[Step.Id]
+        i <- arbitrary[Instant]
+        f <- arbitrary[DatasetFilename]
+      } yield DatasetModel(d, o, s, i, f)
+    }
+
+  implicit val cogDatasetModel: Cogen[DatasetModel] =
+    Cogen[(
+      Dataset.Id,
+      Observation.Id,
+      Step.Id,
+      Instant,
+      DatasetFilename
+    )].contramap { a => (
+      a.id,
+      a.observationId,
+      a.stepId,
+      a.timestamp,
+      a.filename
+    )}
+
+  implicit val arbDatasetModelCreate: Arbitrary[DatasetModel.Create] =
+    Arbitrary {
+      for {
+        d <- arbitrary[Option[Dataset.Id]]
+        o <- arbitrary[Observation.Id]
+        s <- arbitrary[Step.Id]
+        t <- arbitrary[Instant]
+        f <- arbitrary[DatasetFilename]
+      } yield DatasetModel.Create(d, o, s, t, f)
+    }
+
+  implicit val cogDatasetModelCreate: Cogen[DatasetModel.Create] =
+    Cogen[(
+      Option[Dataset.Id],
+      Observation.Id,
+      Step.Id,
+      Instant,
+      DatasetFilename
+    )].contramap { a => (
+      a.datasetId,
+      a.observationId,
+      a.stepId,
+      a.timestamp,
+      a.filename
+    )}
+
+}
+
+object ArbDatasetModel extends ArbDatasetModel

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
@@ -1,0 +1,83 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+package arb
+
+import ExecutionEventModel._
+import lucuma.core.arb.ArbTime
+import lucuma.core.model.{Observation, Step}
+import lucuma.core.util.arb.{ArbEnumerated, ArbGid}
+import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
+
+import java.time.Instant
+
+
+trait ArbExecutionEventModel {
+
+  import ArbEnumerated._
+  import ArbGid._
+  import ArbTime._
+
+  implicit val arbSequenceEvent: Arbitrary[SequenceEvent] =
+    Arbitrary {
+      for {
+        id  <- arbitrary[ExecutionEvent.Id]
+        oid <- arbitrary[Observation.Id]
+        gen <- arbitrary[Instant]
+        rec <- arbitrary[Instant]
+        cmd <- arbitrary[SequenceCommandType]
+      } yield SequenceEvent(id, oid, gen, rec, cmd)
+    }
+
+  implicit val cogSequenceEvent: Cogen[SequenceEvent] =
+    Cogen[(
+      ExecutionEvent.Id,
+      Observation.Id,
+      Instant,
+      Instant,
+      SequenceCommandType
+    )].contramap { a => (
+      a.id,
+      a.observationId,
+      a.generated,
+      a.received,
+      a.command
+    )}
+
+  implicit val arbStepEvent: Arbitrary[StepEvent] =
+    Arbitrary {
+      for {
+        id  <- arbitrary[ExecutionEvent.Id]
+        oid <- arbitrary[Observation.Id]
+        gen <- arbitrary[Instant]
+        rec <- arbitrary[Instant]
+        sid <- arbitrary[Step.Id]
+        tpe <- arbitrary[SequenceModel.SequenceType]
+        sge <- arbitrary[StepStageType]
+      } yield StepEvent(id, oid, gen, rec, sid, tpe, sge)
+    }
+
+  implicit val cogStepEvent: Cogen[StepEvent] =
+    Cogen[(
+      ExecutionEvent.Id,
+      Observation.Id,
+      Instant,
+      Instant,
+      Step.Id,
+      SequenceModel.SequenceType,
+      StepStageType
+    )].contramap { a => (
+      a.id,
+      a.observationId,
+      a.generated,
+      a.received,
+      a.stepId,
+      a.sequenceType,
+      a.stage
+    )}
+
+}
+
+object ArbExecutionEventModel extends ArbExecutionEventModel

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbFourDigitYearLocalDate.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbFourDigitYearLocalDate.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+package arb
+
+
+import lucuma.odb.api.model.time.FourDigitYearLocalDate
+import org.scalacheck._
+
+import java.time.LocalDate
+
+
+trait ArbFourDigitYearLocalDate {
+
+  implicit val arbFourDigitYearLocalDate: Arbitrary[FourDigitYearLocalDate] =
+    Arbitrary {
+      Gen.chooseNum(
+        FourDigitYearLocalDate.MinDate.value.toEpochDay,
+        FourDigitYearLocalDate.MaxDate.value.toEpochDay
+      ).map { epochDay =>
+        FourDigitYearLocalDate.unsafeFrom(LocalDate.ofEpochDay(epochDay))
+      }
+    }
+
+}
+
+object ArbFourDigitYearLocalDate extends ArbFourDigitYearLocalDate

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
@@ -28,7 +28,7 @@ trait ArbObservationModel {
         os <- arbitrary[ObsStatus]
         ts <- arbitrary[Option[Either[Asterism.Id, Target.Id]]]
         cs <- arbitrary[Option[ConstraintSet.Id]]
-      } yield ObservationModel(id, ex, pid, nm, os, ts, cs, PlannedTimeSummaryModel.Zero, None)
+      } yield ObservationModel(id, ex, pid, nm, os, ts, cs, PlannedTimeSummaryModel.Zero, None, Nil)
     }
 
   implicit val arbObservationModel: Arbitrary[ObservationModel] =

--- a/modules/core/src/test/scala/lucuma/odb/api/repo/arb/ArbTables.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/repo/arb/ArbTables.scala
@@ -5,10 +5,9 @@ package lucuma.odb.api.repo
 package arb
 
 import lucuma.core.model.{Asterism, Atom, ConstraintSet, Observation, Program, Step, Target}
-import lucuma.odb.api.model.{AsterismModel, AtomModel, ConstraintSetModel, ObservationModel, ProgramModel, StepModel, TargetModel}
+import lucuma.odb.api.model.{AsterismModel, AtomModel, ConstraintSetModel, Dataset, DatasetModel, ExecutionEvent, ExecutionEventModel, ObservationModel, ProgramModel, StepModel, TargetModel}
 import lucuma.odb.api.model.arb._
 import lucuma.core.util.Gid
-
 import cats.Order
 import cats.kernel.instances.order._
 import cats.syntax.all._
@@ -112,6 +111,8 @@ trait ArbTables extends SplitSetHelper {
           lastGid[Asterism.Id](as),
           lastGid[Atom.Id](SortedMap.empty[Atom.Id, AtomModel[_]]),
           lastGid[ConstraintSet.Id](cs),
+          lastGid[Dataset.Id](SortedMap.empty[Dataset.Id, DatasetModel]),
+          lastGid[ExecutionEvent.Id](SortedMap.empty[ExecutionEvent.Id, ExecutionEventModel]),
           lastGid[Observation.Id](os),
           lastGid[Program.Id](ps),
           lastGid[Step.Id](SortedMap.empty[Step.Id, StepModel[_]]),
@@ -120,7 +121,7 @@ trait ArbTables extends SplitSetHelper {
         pa <- manyToMany(ps.keys, as.keys)
         pt <- manyToMany(ps.keys, ts.keys)
         ta <- manyToMany(ts.keys, as.keys)
-      } yield Tables(ids, SortedMap.empty, as, cs, os, ps, SortedMap.empty, ts, pa, pt, ta)
+      } yield Tables(ids, SortedMap.empty, as, cs, SortedMap.empty, SortedMap.empty, os, ps, SortedMap.empty, ts, pa, pt, ta)
     }
 }
 


### PR DESCRIPTION
Adds datasets and execution events to the model and schema, accessible from an "execution record" tied to the observation. The next step will be mutations to add events but at the present only the API for querying them exists (along with storage in the faux database).