### PR TITLE
Basic case porting I

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ConfigurationAlternativesModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ConfigurationAlternativesModel.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import io.circe.refined._
+import eu.timepit.refined.types.numeric.PosInt
+
+object ConfigurationAlternativesModel {
+  final case class Search(
+    wavelength: Option[WavelengthModel.Input],
+    simultaneousCoverage: Option[WavelengthModel.Input],
+    resolution: Option[PosInt],
+    signalToNoise: Option[PosInt],
+    spatialProfile: Option[SpatialProfileModel.Input],
+    spectralDistribution: Option[SpectralDistributionModel.Input],
+    magnitude: Option[MagnitudeModel.Input],
+    redshift: Option[BigDecimal]
+)
+  object Search {
+
+    implicit val DecoderSerch: Decoder[Search] =
+      deriveDecoder[Search]
+
+  }
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/SpatialProfileModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/SpatialProfileModel.scala
@@ -1,0 +1,81 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import io.circe.Decoder
+import io.circe.generic.semiauto._
+import lucuma.core.util.Enumerated
+import lucuma.core.util.Display
+
+object SpatialProfileModel {
+  final case class Input(sourceType: SpatialProfileType, fwhm: Option[GaussianSourceAngleInput]) extends Product with Serializable
+
+  sealed abstract class Units(
+    val angleUnit: AngleModel.Units
+  ) extends Product with Serializable
+
+  object Units {
+
+    case object Microarcseconds extends Units(AngleModel.Units.Microarcseconds)
+    case object Milliarcseconds extends Units(AngleModel.Units.Milliarcseconds)
+    case object Arcseconds      extends Units(AngleModel.Units.Arcseconds)
+
+    val microarcseconds: Units = Microarcseconds
+    val milliarcseconds: Units = Milliarcseconds
+    val arcseconds: Units      = Arcseconds
+
+    implicit val EnumeratedUnits: Enumerated[Units] =
+      Enumerated.of(
+        Microarcseconds,
+        Milliarcseconds,
+        Arcseconds
+      )
+
+    implicit def DisplayUnits: Display[Units] =
+      Display.byShortName(_.angleUnit.abbreviation)
+
+  }
+
+  final case class GaussianSourceAngleInput(
+    microarcseconds: Option[Long],
+    milliarcseconds: Option[BigDecimal],
+    arcseconds:      Option[BigDecimal],
+    fromLong:        Option[NumericUnits.LongInput[Units]],
+    fromDecimal:     Option[NumericUnits.DecimalInput[Units]]
+  )
+
+  object GaussianSourceAngleInput {
+    implicit def DecoderGaussianSourceAngleInput: Decoder[GaussianSourceAngleInput] =
+      deriveDecoder[GaussianSourceAngleInput]
+
+  }
+
+  sealed trait SpatialProfileType extends Product with Serializable
+
+  final case object PointSource    extends SpatialProfileType
+  final case object UniformSource  extends SpatialProfileType
+  final case object GaussianSource extends SpatialProfileType
+
+  object SpatialProfileType {
+
+    implicit val EnumeratedProfileType: Enumerated[SpatialProfileType] =
+      Enumerated.of(
+        PointSource,
+        UniformSource,
+        GaussianSource
+      )
+
+    implicit val DecoderSpatialProfileType: Decoder[SpatialProfileType] =
+      deriveDecoder[SpatialProfileType]
+
+  }
+
+  object Input {
+
+    implicit val DecoderInput: Decoder[Input] =
+      deriveDecoder[Input]
+
+  }
+}
+

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ConfigurationAlternativesSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ConfigurationAlternativesSchema.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.schema
+
+import sangria.schema._
+import sangria.macros.derive._
+import sangria.marshalling.circe._
+import lucuma.odb.api.model.ConfigurationAlternativesModel
+
+object ConfigurationAlternativesSchema {
+  import WavelengthSchema._
+  import RefinedSchema._
+  import TargetMutation.InputObjectMagnitude
+  import SpatialProfileSchema._
+  import SpectralDistributionSchema._
+  import syntax.inputobjecttype._
+
+  val InputConfigurationAlternativesModelSearch: InputObjectType[ConfigurationAlternativesModel.Search] =
+    deriveInputObjectType[ConfigurationAlternativesModel.Search](
+      InputObjectTypeName("QueryConfigurationAlternativeSearchInput"),
+      InputObjectTypeDescription("Configuration alternatives query"),
+      DocumentInputField("wavelength", description  = "Observing wavelength."),
+      DocumentInputField("simultaneousCoverage", description  = "Minimum desired simultaneous wavelength coverage."),
+      DocumentInputField("resolution", description  = "Minimum desired resolution."),
+      DocumentInputField("signalToNoise", description  = "Minimum desired signal-to-noise ratio."),
+      DocumentInputField("spatialProfile", description  = "Spatial profile PointSource/UniformSource/GaussianSource."),
+      DocumentInputField("spectralDistribution", description  = "Spectral distribution variant BlacBode/PowerLaw/Stellar/NonStellar."),
+      DocumentInputField("magnitude", description  = "Target magnitude/system/band."),
+      DocumentInputField("redshift", description  = "Target redshift.")
+    )
+
+  val ArgumentConfigurationAlternativesModelSearch: Argument[ConfigurationAlternativesModel.Search] =
+    InputConfigurationAlternativesModelSearch.argument(
+      "input",
+      "Configuraton alternatives search parameters."
+    )
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ConfigurationQuery.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ConfigurationQuery.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.schema
+
+import cats.syntax.all._
+import lucuma.odb.api.repo.OdbRepo
+import cats.effect.Effect
+import sangria.schema._
+
+trait ConfigurationQuery {
+
+  import ConfigurationAlternativesSchema._
+
+  // TBD Add return type and hook it to the basic case algorithm
+  def spectroscopy[F[_]: Effect]: Field[OdbRepo[F], Unit] =
+    Field(
+      name        = "spectroscopy",
+      fieldType   = IntType,
+      description = None,
+      arguments   = List(ArgumentConfigurationAlternativesModelSearch),
+      // TODO Return a real result
+      resolve     = c => c.arg(ArgumentConfigurationAlternativesModelSearch).wavelength.foldMap(_.nanometers.foldMap(_.toInt))
+    )
+
+  def allFields[F[_]: Effect]: List[Field[OdbRepo[F], Unit]] =
+    List(
+      spectroscopy
+    )
+
+}
+
+object ConfigurationQuery extends ConfigurationQuery

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/QueryType.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/QueryType.scala
@@ -17,6 +17,7 @@ object QueryType {
       name   = "Query",
       fields =
         AsterismQuery.allFields[F]      ++
+        ConfigurationQuery.allFields[F] ++
         ConstraintSetQuery.allFields[F] ++
         ObservationQuery.allFields[F]   ++
         ProgramQuery.allFields[F]       ++

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SpatialProfileSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SpatialProfileSchema.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.schema
+
+import lucuma.odb.api.model.SpatialProfileModel
+import lucuma.odb.api.schema.syntax.`enum`._
+import sangria.schema._
+import sangria.macros.derive._
+
+object SpatialProfileSchema {
+  import NumericUnitsSchema._
+
+  implicit val EnumSpatialProfileModelUnits: EnumType[SpatialProfileModel.Units] =
+    EnumType.fromEnumerated(
+      "WavelengthUnits",
+      "Wavelength units"
+    )
+
+  implicit val InputGaussianSourceAngleInput: InputType[SpatialProfileModel.GaussianSourceAngleInput] =
+    deriveInputObjectType[SpatialProfileModel.GaussianSourceAngleInput](
+      InputObjectTypeName("GaussianSourceAngleInput"),
+      InputObjectTypeDescription("Gaussian source angle in appropriate units"),
+    )
+
+  implicit val EnumSpatialProfileType: EnumType[SpatialProfileModel.SpatialProfileType] =
+    EnumType.fromEnumerated(
+      "SpatialProfileType",
+      "Spatial profile type: Point/Uniform/Gaussian"
+    )
+
+  implicit val InputSpatialProfileModelInput: InputObjectType[SpatialProfileModel.Input] =
+    deriveInputObjectType[SpatialProfileModel.Input](
+      InputObjectTypeName("SpatialProfileModelInput"),
+      InputObjectTypeDescription("Spatial profile PointSource/UniformSource/GaussianSource"),
+      DocumentInputField("sourceType", "Spatial profile type: Point/Uniform/Gaussian"),
+      DocumentInputField("fwhm", "Full width half maximum (including seeing) in suitable units. Required for the Gaussian spatial profile, ignored otherwise."),
+    )
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SpectralDistributionModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SpectralDistributionModel.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import io.circe.Decoder
+import io.circe.generic.semiauto._
+import lucuma.core.util.Enumerated
+
+object SpectralDistributionModel {
+
+  sealed trait Input extends Product with Serializable
+
+  case object BlackBody  extends Input
+  case object PowerLaw   extends Input
+  case object Stellar    extends Input
+  case object NonStellar extends Input
+
+  object Input {
+    implicit val EnumeratedInput: Enumerated[Input] =
+      Enumerated.of(
+        BlackBody,
+        PowerLaw,
+        Stellar,
+        NonStellar
+      )
+
+    implicit val DecoderSpectralDistributionInput: Decoder[SpectralDistributionModel.Input] =
+      deriveDecoder[SpectralDistributionModel.Input]
+
+  }
+}
+

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SpectralDistributionSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SpectralDistributionSchema.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.schema
+
+import lucuma.odb.api.model.SpectralDistributionModel
+import lucuma.odb.api.schema.syntax.`enum`._
+import sangria.schema._
+
+object SpectralDistributionSchema {
+
+  implicit val EnumSpectralDistributionModelInput: EnumType[SpectralDistributionModel.Input] =
+    EnumType.fromEnumerated(
+      "SpctralDistribution",
+      "Spectral distribution variant"
+    )
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/WavelengthSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/WavelengthSchema.scala
@@ -5,12 +5,16 @@ package lucuma.odb.api.schema
 
 import cats.effect.Effect
 import lucuma.core.math.Wavelength
+import lucuma.odb.api.model.WavelengthModel
 import lucuma.odb.api.repo.OdbRepo
+import sangria.macros.derive._
 import sangria.schema._
 
 import java.math.RoundingMode.HALF_UP
 
 object WavelengthSchema {
+  import NumericUnitsSchema._
+  import syntax.enum._
 
   def WavelengthType[F[_]: Effect]: ObjectType[OdbRepo[F], Wavelength] =
     ObjectType(
@@ -45,6 +49,18 @@ object WavelengthSchema {
           resolve     = _.value.micrometer.value.toBigDecimal(6, HALF_UP)
         )
       )
+    )
+
+  implicit val EnumWavelengthModelUnits: EnumType[WavelengthModel.Units]=
+    EnumType.fromEnumerated(
+      "WavelengthUnits",
+      "Wavelength units"
+    )
+
+  implicit val InputWavelengthModelInput: InputObjectType[WavelengthModel.Input] =
+    deriveInputObjectType[WavelengthModel.Input](
+      InputObjectTypeName("WavelengthModelInput"),
+      InputObjectTypeDescription("Wavelength, choose one of the available units")
     )
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/api/service/OdbService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/OdbService.scala
@@ -29,7 +29,6 @@ trait OdbService[F[_]] {
 
 }
 
-
 object OdbService {
 
   def apply[F[_]: Logger](


### PR DESCRIPTION
This PR is the first to get basic-case ported into lucuma-tmp-api. It defines a single query endpoint to get a list of confgurations for spectroscopy

This PR only defines the input types and also to get familiar with sangria and graphql, we still need to define the return type and hook it to the algorithm.

Sample of a query:
```
query{
  spectroscopy(input: {
    wavelength: {
      nanometers: 1000
    },
    simultaneousCoverage: {
      nanometers: 610
    },
    resolution: 2,
    signalToNoise: 10,
    spatialProfile: {
      sourceType: GAUSSIAN_SOURCE,
      fwhm: {
        arcseconds: 1
      }
    },
    spectralDistribution:BLACK_BODY,
    magnitude: {
      value: 3.55,
      band: J,
      system: VEGA
    },
    redshift: 1.5
  })
}	
```