### PR TITLE
update observations query, make `first` parameter optional

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/AsterismRepo.scala
@@ -19,7 +19,7 @@ sealed trait AsterismRepo[F[_]] extends TopLevelRepo[F, Asterism.Id, AsterismMod
 
   def selectPageForProgram(
     pid:            Program.Id,
-    count:          Int                 = Integer.MAX_VALUE,
+    count:          Option[Int]         = None,
     afterGid:       Option[Asterism.Id] = None,
     includeDeleted: Boolean             = false
   ): F[ResultPage[AsterismModel]]
@@ -27,7 +27,7 @@ sealed trait AsterismRepo[F[_]] extends TopLevelRepo[F, Asterism.Id, AsterismMod
   def selectPageForTarget(
     tid:            Target.Id,
     pid:            Option[Program.Id]  = None,
-    count:          Int                 = Integer.MAX_VALUE,
+    count:          Option[Int]         = None,
     afterGid:       Option[Asterism.Id] = None,
     includeDeleted: Boolean             = false
   ): F[ResultPage[AsterismModel]]
@@ -80,7 +80,7 @@ object AsterismRepo {
 
       override def selectPageForProgram(
         pid:            Program.Id,
-        count:          Int,
+        count:          Option[Int],
         afterGid:       Option[Asterism.Id],
         includeDeleted: Boolean
       ): F[ResultPage[AsterismModel]] =
@@ -90,7 +90,7 @@ object AsterismRepo {
       override def selectPageForTarget(
         tid:            Target.Id,
         pid:            Option[Program.Id],
-        count:          Int,
+        count:          Option[Int],
         afterGid:       Option[Asterism.Id],
         includeDeleted: Boolean
       ): F[ResultPage[AsterismModel]] =

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ConstraintSetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ConstraintSetRepo.scala
@@ -21,7 +21,7 @@ trait ConstraintSetRepo[F[_]] extends TopLevelRepo[F, ConstraintSet.Id, Constrai
 
   def selectPageForProgram(
     pid:            Program.Id,
-    count:          Int                      = Integer.MAX_VALUE,
+    count:          Option[Int]              = None,
     afterGid:       Option[ConstraintSet.Id] = None,
     includeDeleted: Boolean                  = false
   ): F[ResultPage[ConstraintSetModel]]
@@ -59,7 +59,7 @@ object ConstraintSetRepo {
 
       override def selectPageForProgram(
         pid:            Program.Id,
-        count:          Int,
+        count:          Option[Int],
         afterGid:       Option[ConstraintSet.Id],
         includeDeleted: Boolean
       ): F[ResultPage[ConstraintSetModel]] =

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ExecutionEventRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ExecutionEventRepo.scala
@@ -21,9 +21,9 @@ sealed trait ExecutionEventRepo[F[_]] {
     eid: ExecutionEvent.Id
   ): F[Option[ExecutionEventModel]]
 
-  def selectEventsForObservation(
+  def selectPageForObservation(
     oid:      Observation.Id,
-    count:    Int,
+    count:    Option[Int],
     afterGid: Option[ExecutionEvent.Id] = None
   ): F[ResultPage[ExecutionEventModel]]
 
@@ -53,9 +53,9 @@ object ExecutionEventRepo {
       ): F[Option[ExecutionEventModel]] =
         tablesRef.get.map(Tables.executionEvent(eid).get)
 
-      override def selectEventsForObservation(
+      override def selectPageForObservation(
         oid:      Observation.Id,
-        count:    Int,
+        count:    Option[Int],
         afterGid: Option[ExecutionEvent.Id]
       ): F[ResultPage[ExecutionEventModel]] =
         tablesRef.get.map { tables =>

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
@@ -22,21 +22,28 @@ sealed trait ObservationRepo[F[_]] extends TopLevelRepo[F, Observation.Id, Obser
   def selectPageForAsterism(
     aid:            Asterism.Id,
     pid:            Option[Program.Id]     = None,
-    count:          Int                    = Integer.MAX_VALUE,
+    count:          Option[Int]            = None,
     afterGid:       Option[Observation.Id] = None,
     includeDeleted: Boolean                = false
   ): F[ResultPage[ObservationModel]]
 
   def selectPageForConstraintSet(
     csid:           ConstraintSet.Id,
-    count:          Int                    = Integer.MAX_VALUE,
+    count:          Option[Int]            = None,
+    afterGid:       Option[Observation.Id] = None,
+    includeDeleted: Boolean                = false
+  ): F[ResultPage[ObservationModel]]
+
+  def selectPageForObservations(
+    oids:           Set[Observation.Id],
+    count:          Option[Int]            = None,
     afterGid:       Option[Observation.Id] = None,
     includeDeleted: Boolean                = false
   ): F[ResultPage[ObservationModel]]
 
   def selectPageForProgram(
     pid:            Program.Id,
-    count:          Int                    = Integer.MAX_VALUE,
+    count:          Option[Int]            = None,
     afterGid:       Option[Observation.Id] = None,
     includeDeleted: Boolean                = false
   ): F[ResultPage[ObservationModel]]
@@ -44,7 +51,7 @@ sealed trait ObservationRepo[F[_]] extends TopLevelRepo[F, Observation.Id, Obser
   def selectPageForTarget(
     tid:            Target.Id,
     pid:            Option[Program.Id]     = None,
-    count:          Int                    = Integer.MAX_VALUE,
+    count:          Option[Int]            = None,
     afterGid:       Option[Observation.Id] = None,
     includeDeleted: Boolean                = false
   ): F[ResultPage[ObservationModel]]
@@ -78,7 +85,7 @@ object ObservationRepo {
       override def selectPageForAsterism(
         aid:            Asterism.Id,
         pid:            Option[Program.Id],
-        count:          Int,
+        count:          Option[Int],
         afterGid:       Option[Observation.Id],
         includeDeleted: Boolean
       ): F[ResultPage[ObservationModel]] =
@@ -89,16 +96,25 @@ object ObservationRepo {
 
       override def selectPageForConstraintSet(
         csid:           ConstraintSet.Id,
-        count:          Int,
+        count:          Option[Int],
         afterGid:       Option[Observation.Id],
         includeDeleted: Boolean
       ): F[ResultPage[ObservationModel]] =
 
         selectPageFiltered(count, afterGid, includeDeleted) { _.constraintSetId.exists(_ === csid) }
 
+      override def selectPageForObservations(
+        oids:           Set[Observation.Id],
+        count:          Option[Int],
+        afterGid:       Option[Observation.Id],
+        includeDeleted: Boolean
+      ): F[ResultPage[ObservationModel]] =
+
+        selectPageFiltered(count, afterGid, includeDeleted) { o => oids(o.id) }
+
       override def selectPageForProgram(
         pid:            Program.Id,
-        count:          Int,
+        count:          Option[Int],
         afterGid:       Option[Observation.Id],
         includeDeleted: Boolean
       ): F[ResultPage[ObservationModel]] =
@@ -108,7 +124,7 @@ object ObservationRepo {
       override def selectPageForTarget(
         tid:            Target.Id,
         pid:            Option[Program.Id],
-        count:          Int,
+        count:          Option[Int],
         afterGid:       Option[Observation.Id],
         includeDeleted: Boolean
       ): F[ResultPage[ObservationModel]] =

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
@@ -32,9 +32,16 @@ trait ProgramRepo[F[_]] extends TopLevelRepo[F, Program.Id, ProgramModel] {
   def selectPageForAsterism(
     aid:                 Asterism.Id,
     includeObservations: Boolean            = true,
-    count:               Int                = Integer.MAX_VALUE,
+    count:               Option[Int]        = None,
     afterGid:            Option[Program.Id] = None,
     includeDeleted:      Boolean            = false
+  ): F[ResultPage[ProgramModel]]
+
+  def selectPageForPrograms(
+    pids:           Set[Program.Id],
+    count:          Option[Int]        = None,
+    afterGid:       Option[Program.Id] = None,
+    includeDeleted: Boolean            = false
   ): F[ResultPage[ProgramModel]]
 
   /**
@@ -54,7 +61,7 @@ trait ProgramRepo[F[_]] extends TopLevelRepo[F, Program.Id, ProgramModel] {
   def selectPageForTarget(
     tid:                 Target.Id,
     includeObservations: Boolean            = true,
-    count:               Int                = Integer.MAX_VALUE,
+    count:               Option[Int]        = None,
     afterGid:            Option[Program.Id] = None,
     includeDeleted:      Boolean            = false
   ): F[ResultPage[ProgramModel]]
@@ -88,7 +95,7 @@ object ProgramRepo {
       override def selectPageForAsterism(
         aid:                 Asterism.Id,
         includeObservations: Boolean,
-        count:               Int,
+        count:               Option[Int],
         afterGid:            Option[Program.Id],
         includeDeleted:      Boolean
       ): F[ResultPage[ProgramModel]] =
@@ -99,10 +106,19 @@ object ProgramRepo {
             else Iterable.empty[Program.Id])
         }
 
+      override def selectPageForPrograms(
+        pids:           Set[Program.Id],
+        count:          Option[Int]        = None,
+        afterGid:       Option[Program.Id] = None,
+        includeDeleted: Boolean            = false
+      ): F[ResultPage[ProgramModel]] =
+
+        selectPageFiltered(count, afterGid, includeDeleted) { p => pids(p.id) }
+
       override def selectPageForTarget(
         tid:                 Target.Id,
         includeObservations: Boolean,
-        count:               Int,
+        count:               Option[Int],
         afterGid:            Option[Program.Id],
         includeDeleted:      Boolean
       ): F[ResultPage[ProgramModel]] =

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ResultPage.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ResultPage.scala
@@ -20,18 +20,18 @@ object ResultPage {
     ResultPage(Nil, hasNextPage = false, 0)
 
   private def fromIterator[A](
-    count:      Int,
+    count:      Option[Int],
     it:         Iterator[A],
     totalCount: Int
   ): ResultPage[A] = {
     val res = scala.collection.mutable.Buffer.empty[A]
-    while (it.hasNext && (res.size < count)) res += it.next()
+    while (it.hasNext && (res.size < count.getOrElse(Int.MaxValue))) res += it.next()
     ResultPage(res.toList, it.hasNext, totalCount)
   }
 
   def fromSeq[A, B: Eq](
     all:   Seq[A],
-    count: Int,
+    count: Option[Int],
     after: Option[B],
     toB:   A => B
   ): ResultPage[A] =
@@ -45,7 +45,7 @@ object ResultPage {
     )
 
   def select[A: Order, B](
-    count:   Int,
+    count:   Option[Int],
     after:   Option[A],
     keys:    SortedSet[A],
     lookup:  A => B,

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
@@ -17,14 +17,14 @@ sealed trait TargetRepo[F[_]] extends TopLevelRepo[F, Target.Id, TargetModel] {
 
   def selectPageForProgram(
     pid:            Program.Id,
-    count:          Int               = Integer.MAX_VALUE,
+    count:          Option[Int]       = None,
     afterGid:       Option[Target.Id] = None,
     includeDeleted: Boolean           = false
   ): F[ResultPage[TargetModel]]
 
   def selectPageForAsterism(
     aid:            Asterism.Id,
-    count:          Int               = Integer.MAX_VALUE,
+    count:          Option[Int]       = None,
     afterGid:       Option[Target.Id] = None,
     includeDeleted: Boolean           = false
   ): F[ResultPage[TargetModel]]
@@ -61,7 +61,7 @@ object TargetRepo {
 
       override def selectPageForProgram(
         pid:            Program.Id,
-        count:          Int               = Integer.MAX_VALUE,
+        count:          Option[Int]       = None,
         afterGid:       Option[Target.Id] = None,
         includeDeleted: Boolean           = false
       ): F[ResultPage[TargetModel]] =
@@ -75,7 +75,7 @@ object TargetRepo {
 
       override def selectPageForAsterism(
         aid:            Asterism.Id,
-        count:          Int               = Integer.MAX_VALUE,
+        count:          Option[Int]       = None,
         afterGid:       Option[Target.Id] = None,
         includeDeleted: Boolean           = false
       ): F[ResultPage[TargetModel]] =

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TopLevelRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TopLevelRepo.scala
@@ -33,24 +33,24 @@ trait TopLevelRepo[F[_], I, T] {
   ): F[List[T]]
 
   def selectPage(
-    count:          Int       = Integer.MAX_VALUE,
-    afterGid:       Option[I] = None,
-    includeDeleted: Boolean   = false
+    count:          Option[Int] = None,
+    afterGid:       Option[I]   = None,
+    includeDeleted: Boolean     = false
   ): F[ResultPage[T]] =
     selectPageFiltered(count, afterGid, includeDeleted) { Function.const(true) }
 
   def selectPageFiltered(
-    count:          Int       = Integer.MAX_VALUE,
-    afterGid:       Option[I] = None,
-    includeDeleted: Boolean   = false
+    count:          Option[Int] = None,
+    afterGid:       Option[I]   = None,
+    includeDeleted: Boolean     = false
   )(
     predicate: T => Boolean
   ): F[ResultPage[T]]
 
   def selectPageFromIds(
-    count:          Int       = Integer.MAX_VALUE,
-    afterGid:       Option[I] = None,
-    includeDeleted: Boolean   = false
+    count:          Option[Int] = None,
+    afterGid:       Option[I]   = None,
+    includeDeleted: Boolean     = false
   )(
     ids: Tables => scala.collection.immutable.SortedSet[I]
   ): F[ResultPage[T]]
@@ -108,13 +108,13 @@ abstract class TopLevelRepoBase[F[_]: Monad, I: Gid, T: TopLevelModel[I, *]: Eq]
     includeDeleted: Boolean
   ): F[List[T]] =
     selectPage(
-      count          = Integer.MAX_VALUE,
+      count          = Some(Integer.MAX_VALUE),
       afterGid       = None,
       includeDeleted = includeDeleted
     ).map(_.nodes)
 
   def selectPageFiltered(
-    count:          Int,
+    count:          Option[Int],
     afterGid:       Option[I],
     includeDeleted: Boolean
   )(
@@ -134,7 +134,7 @@ abstract class TopLevelRepoBase[F[_]: Monad, I: Gid, T: TopLevelModel[I, *]: Eq]
     }
 
   def selectPageFromIds(
-    count:          Int,
+    count:          Option[Int],
     afterGid:       Option[I],
     includeDeleted: Boolean
   )(

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionRecordSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionRecordSchema.scala
@@ -90,7 +90,7 @@ object ExecutionRecordSchema {
               c.pagingExecutionEventId,
               (e: ExecutionEventModel) => Cursor.gid[ExecutionEvent.Id].reverseGet(e.id),
               // TODO: here we're going to want the events sorted by timestamp, not GID
-              eid => c.ctx.executionEvent.selectEventsForObservation(c.value, c.pagingFirst, eid)
+              eid => c.ctx.executionEvent.selectPageForObservation(c.value, c.pagingFirst, eid)
             )
         )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObjectIdSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObjectIdSchema.scala
@@ -17,7 +17,7 @@ import sangria.validation.ValueCoercionViolation
 object ObjectIdSchema {
 
   private def formatString[A: Gid]: String =
-    s"${Gid[A].tag}-(0|[1-9a-f][0-9a-f]*)"
+    s"${Gid[A].tag}-([1-9a-f][0-9a-f]*)"
 
   final case class IdViolation[A: Gid]() extends ValueCoercionViolation(s"Expected an ID of type ${formatString[A]}")
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationQuery.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationQuery.scala
@@ -5,6 +5,7 @@ package lucuma.odb.api.schema
 
 import lucuma.odb.api.repo.OdbRepo
 import cats.effect.Effect
+import cats.syntax.all._
 import sangria.schema._
 
 trait ObservationQuery {
@@ -12,24 +13,32 @@ trait ObservationQuery {
   import ConstraintSetSchema.ConstraintSetIdArgument
   import GeneralSchema.ArgumentIncludeDeleted
   import Paging._
-  import ProgramSchema.ProgramIdArgument
-  import ObservationSchema.{ObservationIdArgument, ObservationType, ObservationConnectionType}
+  import ProgramSchema.OptionalProgramIdArgument
+  import ObservationSchema.{ObservationIdArgument, ObservationType, ObservationConnectionType, OptionalListObservationIdArgument}
   import context._
 
-  def allForProgram[F[_]: Effect]: Field[OdbRepo[F], Unit] =
+  def observations[F[_]: Effect]: Field[OdbRepo[F], Unit] =
     Field(
       name        = "observations",
       fieldType   = ObservationConnectionType[F],
-      description = Some("Returns all observations associated with the given program."),
+      description = "Returns all observations associated with the given ids or program, or all observations if neither is specified.".some,
       arguments   = List(
-        ProgramIdArgument,
+        OptionalListObservationIdArgument.copy(description = "(Optional) listing of specific observations to retrieve".some),
+        OptionalProgramIdArgument.copy(description = "(Optional) program whose observations are sought".some),
         ArgumentPagingFirst,
         ArgumentPagingCursor,
         ArgumentIncludeDeleted
       ),
       resolve     = c =>
         unsafeSelectTopLevelPageFuture(c.pagingObservationId) { gid =>
-          c.ctx.observation.selectPageForProgram(c.programId, c.pagingFirst, gid, c.includeDeleted)
+          (c.arg(OptionalListObservationIdArgument), c.arg(OptionalProgramIdArgument)) match {
+            case (Some(oids), _) =>
+              c.ctx.observation.selectPageForObservations(oids.toSet, c.pagingFirst, gid, c.includeDeleted)
+            case (_, Some(pid))  =>
+              c.ctx.observation.selectPageForProgram(pid, c.pagingFirst, gid, c.includeDeleted)
+            case _               =>
+              c.ctx.observation.selectPage(c.pagingFirst, gid, c.includeDeleted)
+          }
         }
     )
 
@@ -37,7 +46,7 @@ trait ObservationQuery {
     Field(
       name        = "observations",
       fieldType   = ObservationConnectionType[F],
-      description = Some("Returns all observations associated with the give constraint set."),
+      description = "Returns all observations associated with the give constraint set.".some,
       arguments   = List(
         ConstraintSetIdArgument,
         ArgumentPagingFirst,
@@ -53,14 +62,14 @@ trait ObservationQuery {
     Field(
       name        = "observation",
       fieldType   = OptionType(ObservationType[F]),
-      description = Some("Returns the observation with the given id, if any."),
+      description = "Returns the observation with the given id, if any.".some,
       arguments   = List(ObservationIdArgument, ArgumentIncludeDeleted),
       resolve     = c => c.observation(_.select(c.observationId, c.includeDeleted))
     )
 
   def allFields[F[_]: Effect]: List[Field[OdbRepo[F], Unit]] =
     List(
-      allForProgram,
+      observations,
       forId
     )
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
@@ -12,6 +12,7 @@ import cats.effect.Effect
 import cats.effect.implicits._
 import cats.syntax.all._
 import sangria.schema._
+import scala.collection.immutable.Seq
 
 
 object ObservationSchema {
@@ -47,6 +48,13 @@ object ObservationSchema {
       name         = "observationId",
       argumentType = OptionInputType(ObservationIdType),
       description  = "Observation ID"
+    )
+
+  val OptionalListObservationIdArgument: Argument[Option[Seq[Observation.Id]]] =
+    Argument(
+      name         = "observationIds",
+      argumentType = OptionInputType(ListInputType(ObservationIdType)),
+      description  = "Observation IDs"
     )
 
   def ObservationTargetType[F[_]: Effect]: OutputType[Either[AsterismModel, TargetModel]] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/Paging.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/Paging.scala
@@ -73,10 +73,10 @@ object Paging {
       }
     )
 
-  val ArgumentPagingFirst: Argument[Int] =
+  val ArgumentPagingFirst: Argument[Option[Int]] =
     Argument(
       name         = "first",
-      argumentType = IntType,
+      argumentType = OptionInputType(IntType),
       description  = "Retrieve `first` values after the given cursor"
     )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramQuery.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramQuery.scala
@@ -5,28 +5,34 @@ package lucuma.odb.api.schema
 
 import lucuma.odb.api.repo.OdbRepo
 import cats.effect.Effect
+import cats.syntax.all._
 import sangria.schema._
 
 trait ProgramQuery {
 
   import GeneralSchema.ArgumentIncludeDeleted
   import Paging._
-  import ProgramSchema.{ProgramIdArgument, ProgramType, ProgramConnectionType}
+  import ProgramSchema.{OptionalListProgramIdArgument, ProgramIdArgument, ProgramType, ProgramConnectionType}
   import context._
 
-  def all[F[_]: Effect]: Field[OdbRepo[F], Unit] =
+  def programs[F[_]: Effect]: Field[OdbRepo[F], Unit] =
     Field(
       name        = "programs",
       fieldType   = ProgramConnectionType[F],
-      description = Some("Pages through all programs."),
+      description = Some("Pages through all requested programs (or all programs if no ids are given)."),
       arguments   = List(
+        OptionalListProgramIdArgument.copy(description = "(Optional) listing of programs to retrieve (all programs if empty)".some),
         ArgumentPagingFirst,
         ArgumentPagingCursor,
         ArgumentIncludeDeleted
       ),
       resolve = c =>
         unsafeSelectTopLevelPageFuture(c.pagingProgramId) { gid =>
-          c.ctx.program.selectPage(c.pagingFirst, gid, c.includeDeleted)
+          c.arg(OptionalListProgramIdArgument).fold(
+            c.ctx.program.selectPage(c.pagingFirst, gid, c.includeDeleted)
+          ) { pids =>
+            c.ctx.program.selectPageForPrograms(pids.toSet, c.pagingFirst, gid, c.includeDeleted)
+          }
         }
     )
 
@@ -41,7 +47,7 @@ trait ProgramQuery {
 
   def allFields[F[_]: Effect]: List[Field[OdbRepo[F], Unit]] =
     List(
-      all,
+      programs,
       forId
     )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
@@ -10,6 +10,7 @@ import cats.effect.Effect
 import cats.syntax.foldable._
 import cats.syntax.functor._
 import sangria.schema._
+import scala.collection.immutable.Seq
 
 object ProgramSchema {
 
@@ -35,6 +36,13 @@ object ProgramSchema {
       name         = "programId",
       argumentType = OptionInputType(ProgramIdType),
       description  = "Program ID"
+    )
+
+  val OptionalListProgramIdArgument: Argument[Option[Seq[Program.Id]]] =
+    Argument(
+      name         = "programIds",
+      argumentType = OptionInputType(ListInputType(ProgramIdType)),
+      description  = "Program Ids"
     )
 
   def ProgramType[F[_]: Effect]: ObjectType[OdbRepo[F], ProgramModel] =
@@ -121,7 +129,7 @@ object ProgramSchema {
           description = Some("Program planned time calculation."),
           arguments   = List(ArgumentIncludeDeleted),
           resolve     = c => c.observation {
-            _.selectPageForProgram(c.value.id, Integer.MAX_VALUE, None, c.includeDeleted)
+            _.selectPageForProgram(c.value.id, Some(Integer.MAX_VALUE), None, c.includeDeleted)
              .map(_.nodes.foldMap(_.plannedTimeSummary))
           }
         )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/RepoContext.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/RepoContext.scala
@@ -55,7 +55,7 @@ final class RepoContextOps[F[_]: Effect](val self: Context[OdbRepo[F], _]) {
   def includeDeleted: Boolean =
     self.arg(GeneralSchema.ArgumentIncludeDeleted)
 
-  def pagingFirst: Int =
+  def pagingFirst: Option[Int] =
     self.arg(Paging.ArgumentPagingFirst)
 
   def pagingCursor[A](msg: String)(f: Paging.Cursor => Option[A]): Either[InputError, Option[A]] = {

--- a/modules/core/src/test/scala/lucuma/odb/api/repo/OdbRepoTest.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/repo/OdbRepoTest.scala
@@ -45,7 +45,7 @@ trait OdbRepoTest {
     predicate: T => Boolean
   ): F[List[ResultPage[T]]] =
     Stream.unfoldLoopEval(afterGid) { gid =>
-      repo.selectPageFiltered(pageSize.value, gid)(predicate).map { page =>
+      repo.selectPageFiltered(Some(pageSize.value), gid)(predicate).map { page =>
         val next =
           if (page.hasNextPage)
             page.nodes.lastOption.map(t => Option(TopLevelModel[I, T].id(t)))


### PR DESCRIPTION
Updates the `observations` query to make `programId` optional and accept an optional `observationIds` list.  Now it works like:

* Only `programId` specified => Retrieve observations associated with the program
* Only `observationIds` specified => Retrieve matching observations (regardless of program)
* Neither specified => Retrieve all observations
* Both specified => Error

Updates `programs` query in a similar way, accepting an optional `programIds` list.  I would update the other top-level items similarly but it is unclear whether sharing with ids will live on.

Changes `first` parameter to be optional, defaulting for now to `Integer.MaxValue`.