### PR TITLE
Reorder ObservationModel

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -144,8 +144,8 @@ object ObservationModel extends ObservationOptics {
     activeStatus:        Input[ObsActiveStatus]                = Input.ignore,
     asterismId:          Input[Asterism.Id]                    = Input.ignore,
     targetId:            Input[Target.Id]                      = Input.ignore,
-    scienceRequirements: Option[ScienceRequirementsModel.Edit] = None,
-    constraintSet:       Option[ConstraintSetModel.Edit]       = None
+    constraintSet:       Option[ConstraintSetModel.Edit]       = None,
+    scienceRequirements: Option[ScienceRequirementsModel.Edit] = None
   ) {
 
     def id: Observation.Id =
@@ -161,19 +161,19 @@ object ObservationModel extends ObservationOptics {
       (existence   .validateIsNotNull("existence"),
        status      .validateIsNotNull("status"),
        activeStatus.validateIsNotNull("active"),
-       scienceRequirements.traverse(_.editor),
-       constraintSet.traverse(_.editor)
-      ).mapN { (e, s, a, r, c) =>
+       constraintSet.traverse(_.editor),
+       scienceRequirements.traverse(_.editor)
+      ).mapN { (e, s, a, c, r) =>
         for {
           _ <- ObservationModel.existence    := e
           _ <- ObservationModel.name         := name.toOptionOption
           _ <- ObservationModel.status       := s
           _ <- ObservationModel.activeStatus := a
           _ <- State.modify[ObservationModel] { o =>
-            r.fold(o) { ed => ObservationModel.scienceRequirements.modify(ed.runS(_).value)(o) }
+            c.fold(o) { ed => ObservationModel.constraintSet.modify(ed.runS(_).value)(o) }
           }
           _ <- State.modify[ObservationModel] { o =>
-            c.fold(o) { ed => ObservationModel.constraintSet.modify(ed.runS(_).value)(o) }
+            r.fold(o) { ed => ObservationModel.scienceRequirements.modify(ed.runS(_).value)(o) }
           }
         } yield ()
       }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ScienceRequirements.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ScienceRequirements.scala
@@ -46,6 +46,12 @@ object ScienceRequirementsModel {
 
     implicit val DecoderCreate: Decoder[Create] = deriveDecoder
 
+    implicit val EqCreate: Eq[Create] =
+      Eq.by { a => (
+        a.mode,
+        a.spectroscopyRequirements
+      )}
+
   }
 
   final case class Edit(

--- a/modules/core/src/main/scala/lucuma/odb/api/model/SpectroscopyRequirements.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/SpectroscopyRequirements.scala
@@ -38,7 +38,8 @@ final case class SpectroscopyScienceRequirements(
 )
 
 object SpectroscopyScienceRequirements extends SpectroscopyScienceRequirementsOptics {
-  val Default = SpectroscopyScienceRequirements(None, refineMV[Positive](1).some, None, None, None, None, None, None)
+  val Default: SpectroscopyScienceRequirements =
+    SpectroscopyScienceRequirements(None, refineMV[Positive](1).some, None, None, None, None, None, None)
 
   implicit val eqSpectroscopyConfigurationOptions: Eq[SpectroscopyScienceRequirements] = Eq.by(x =>
     (x.wavelength,
@@ -79,6 +80,18 @@ object SpectroscopyScienceRequirementsModel {
     val Default: Create = Create(None, None, None, None, None, None, None, None)
 
     implicit val DecoderCreate: Decoder[Create] = deriveDecoder
+
+    implicit val EqCreate: Eq[Create] =
+      Eq.by { a => (
+        a.wavelength,
+        a.resolution,
+        a.signalToNoise,
+        a.signalToNoiseAt,
+        a.wavelengthRange,
+        a.focalPlane,
+        a.focalPlaneAngle,
+        a.capabilities
+      )}
   }
 
   final case class Edit(
@@ -137,6 +150,13 @@ object SpectroscopyScienceRequirementsModel {
   object FocalPlaneAngleInput {
     implicit def DecoderFocalPlaneAngleInput: Decoder[FocalPlaneAngleInput] =
       deriveDecoder[FocalPlaneAngleInput]
+
+    implicit val EqFocalPlaneAngleInput: Eq[FocalPlaneAngleInput] =
+      Eq.by { a => (
+        a.microarcseconds,
+        a.milliarcseconds,
+        a.arcseconds
+      )}
 
   }
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
@@ -31,7 +31,7 @@ trait ArbObservationModel {
         ts <- arbitrary[Option[Either[Asterism.Id, Target.Id]]]
         cs <- arbitrary[ConstraintSetModel]
         sr <- arbitrary[ScienceRequirements]
-      } yield ObservationModel(id, ex, pid, nm, os, as, ts, cs, PlannedTimeSummaryModel.Zero, None, sr)
+      } yield ObservationModel(id, ex, pid, nm, os, as, ts, cs, sr, PlannedTimeSummaryModel.Zero, None)
     }
 
   implicit val arbObservationModel: Arbitrary[ObservationModel] =
@@ -71,19 +71,19 @@ trait ArbObservationModel {
         id <- arbitrary[Option[Observation.Id]]
         pd <- arbitrary[Program.Id]
         nm <- arbitrary[Option[NonEmptyString]]
-        ts <- arbitrary[Option[Either[Asterism.Id, Target.Id]]]
-        cs <- arbitrary[Option[ConstraintSetModel.Create]]
         st <- arbitrary[Option[ObsStatus]]
         as <- arbitrary[Option[ObsActiveStatus]]
+        ts <- arbitrary[Option[Either[Asterism.Id, Target.Id]]]
+        cs <- arbitrary[Option[ConstraintSetModel.Create]]
       } yield ObservationModel.Create(
         id,
         pd,
         nm,
+        st,
+        as,
         ts.flatMap(_.swap.toOption),
         ts.flatMap(_.toOption),
         cs,
-        st,
-        as,
         None,
         None
       )
@@ -94,20 +94,20 @@ trait ArbObservationModel {
       Option[Observation.Id],
       Program.Id,
       Option[String],
+      Option[ObsStatus],
+      Option[ObsActiveStatus],
       Option[Asterism.Id],
       Option[Target.Id],
-      Option[ConstraintSetModel.Create],
-      Option[ObsStatus],
-      Option[ObsActiveStatus]
+      Option[ConstraintSetModel.Create]
     )].contramap { in => (
       in.observationId,
       in.programId,
       in.name.map(_.value),
+      in.status,
+      in.activeStatus,
       in.asterismId,
       in.targetId,
-      in.constraintSet,
-      in.status,
-      in.activeStatus
+      in.constraintSet
     )}
 
 }


### PR DESCRIPTION
This is a minor, mostly content-free PR that simply reorders the `ObservationModel` fields to keep target, constraints, and requirements together and in that order (matching the Observation tab in Explore).  Having just gone through a lengthy conflict resolution, my hope is that this will help simplify future rebases. 