### PR TITLE
generalize grouping

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ConstraintSetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ConstraintSetModel.scala
@@ -18,7 +18,6 @@ import lucuma.odb.api.model.syntax.input._
 import monocle.{Fold, Lens, Optional}
 import monocle.macros.GenLens
 
-import scala.collection.immutable.SortedSet
 
 final case class ConstraintSetModel(
   name:            NonEmptyString,  // maybe we eliminate this?
@@ -123,21 +122,6 @@ object ConstraintSetModel extends ConstraintSetModelOptics {
 
     implicit val EqBulkEdit: Eq[BulkEdit] =
       Eq.fromUniversalEquals
-
-  }
-
-  final case class Group(
-    constraints:    ConstraintSetModel,
-    observationIds: SortedSet[Observation.Id]
-  )
-
-  object Group {
-
-    implicit val EqGroup: Eq[Group] =
-      Eq.by { a => (
-        a.constraints,
-        a.observationIds
-      )}
 
   }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -20,6 +20,8 @@ import io.circe.generic.semiauto._
 import io.circe.refined._
 import monocle.{Focus, Lens, Optional}
 
+import scala.collection.immutable.SortedSet
+
 final case class ObservationModel(
   id:                   Observation.Id,
   existence:            Existence,
@@ -254,6 +256,27 @@ object ObservationModel extends ObservationOptics {
 
     def updated(value: ObservationModel)(id: Long): ObservationEvent =
       ObservationEvent(id, Event.EditType.Updated, value)
+  }
+
+  /**
+   * A grouping of observations according to some commonly held value.
+   *
+   * @param value value held in common
+   * @param observationIds observations sharing the same value
+   */
+  final case class Group[A](
+    value:          A,
+    observationIds: SortedSet[Observation.Id]
+  )
+
+  object Group {
+
+    implicit def EqGroup[A: Eq]: Eq[Group[A]] =
+      Eq.by { a => (
+        a.value,
+        a.observationIds
+      )}
+
   }
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationGroupSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationGroupSchema.scala
@@ -1,0 +1,137 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.schema
+
+import lucuma.odb.api.model.ObservationModel
+import lucuma.odb.api.repo.{ObservationRepo, OdbRepo, ResultPage}
+import cats.MonadError
+import cats.effect.std.Dispatcher
+import cats.syntax.all._
+import lucuma.core.model.{Observation, Program}
+import sangria.schema._
+
+
+object ObservationGroupSchema {
+
+  import context._
+  import GeneralSchema.ArgumentIncludeDeleted
+  import ObservationSchema.{ObservationConnectionType, ObservationIdType}
+  import Paging._
+  import ProgramSchema.ProgramIdArgument
+
+  def ObservationGroupType[F[_]: Dispatcher, A](
+    prefix:      String,
+    valueName:   String,
+    fieldType:   ObjectType[OdbRepo[F], A]
+  )(implicit ev: MonadError[F, Throwable]): ObjectType[OdbRepo[F], ObservationModel.Group[A]] =
+
+    ObjectType(
+      name     = s"${prefix}Group",
+      fieldsFn = () => fields(
+
+        Field(
+          name        = "observationIds",
+          fieldType   = ListType(ObservationIdType),
+          description = Some("IDs of observations that use the same constraints"),
+          resolve     = _.value.observationIds.toList
+        ),
+
+        Field(
+          name        = "observations",
+          fieldType   = ObservationConnectionType[F],
+          description = Some("Observations that use this constraint set"),
+          arguments   = List(
+            ArgumentPagingFirst,
+            ArgumentPagingCursor,
+            ArgumentIncludeDeleted
+          ),
+          resolve     = c =>
+            unsafeSelectTopLevelPageFuture(c.pagingObservationId) { gid =>
+              c.ctx.observation.selectPageFromIds(c.pagingFirst, gid, c.includeDeleted) { _ =>
+                c.value.observationIds
+              }
+            }
+        ),
+
+        Field(
+          name        = valueName,
+          fieldType   = fieldType,
+          description = s"Commonly held value across the observations".some,
+          resolve     = _.value.value
+        )
+
+      )
+    )
+
+  def ObservationGroupEdgeType[F[_], A](
+    groupType: ObjectType[OdbRepo[F], ObservationModel.Group[A]]
+  ): ObjectType[OdbRepo[F], Paging.Edge[ObservationModel.Group[A]]] =
+
+    Paging.EdgeType[F, ObservationModel.Group[A]](
+      s"${groupType.name}Edge",
+      "An observation group and its cursor",
+      groupType
+    )
+
+  def ObservationGroupConnectionType[F[_], A](
+    groupType: ObjectType[OdbRepo[F], ObservationModel.Group[A]],
+    edgeType:  ObjectType[OdbRepo[F], Paging.Edge[ObservationModel.Group[A]]]
+  ): ObjectType[OdbRepo[F], Paging.Connection[ObservationModel.Group[A]]] =
+
+    Paging.ConnectionType[F, ObservationModel.Group[A]](
+      s"${groupType.name}Connection",
+      "Observations grouped by common properties",
+      groupType,
+      edgeType
+    )
+
+  def groupingField[F[_]: Dispatcher, A](
+    name:        String,
+    description: String,
+    objectType:  ObjectType[OdbRepo[F], A],
+    lookupAll:   (ObservationRepo[F], Program.Id) => F[List[ObservationModel.Group[A]]]
+  )(
+    implicit ev: MonadError[F, Throwable]
+  ): Field[OdbRepo[F], Unit] = {
+
+    val groupType =
+      ObservationGroupSchema.ObservationGroupType[F, A](
+        name.capitalize,
+        name,
+        objectType
+      )
+
+    val edgeType =
+      ObservationGroupSchema.ObservationGroupEdgeType[F, A](
+        groupType
+      )
+
+    val connectionType =
+      ObservationGroupSchema.ObservationGroupConnectionType[F, A](
+        groupType,
+        edgeType
+      )
+
+    Field(
+      name        = s"${name}Group",
+      fieldType   = connectionType,
+      description = description.some,
+      arguments   = List(
+        ProgramIdArgument,
+        ArgumentPagingFirst,
+        ArgumentPagingCursor,
+        ArgumentIncludeDeleted
+      ),
+      resolve    = c =>
+        Paging.unsafeSelectPageFuture[F, Observation.Id, ObservationModel.Group[A]](
+          c.pagingObservationId,
+          g   => Cursor.gid[Observation.Id].reverseGet(g.observationIds.head),
+          oid => lookupAll(c.ctx.observation, c.programId).map { gs =>
+            ResultPage.fromSeq(gs, c.arg(ArgumentPagingFirst), oid, _.observationIds.head)
+          }
+        )
+    )
+  }
+
+}


### PR DESCRIPTION
We will be adding grouping of observations by various criteria.  The existing grouping-by-constraint-set code was very specific to constraint sets so I generalized it to make it available for reuse.