### PR TITLE
generalize bulk edit

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ConstraintSetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ConstraintSetModel.scala
@@ -12,7 +12,6 @@ import io.circe.Decoder
 import io.circe.generic.semiauto._
 import io.circe.refined._
 import lucuma.core.enum._
-import lucuma.core.model.Observation
 import lucuma.core.optics.syntax.lens._
 import lucuma.odb.api.model.syntax.input._
 import monocle.{Fold, Lens, Optional}
@@ -107,22 +106,6 @@ object ConstraintSetModel extends ConstraintSetModelOptics {
     implicit val DecoderEdit: Decoder[Edit] = deriveConfiguredDecoder[Edit]
 
     implicit val EqEdit: Eq[Edit] = Eq.fromUniversalEquals
-  }
-
-
-  final case class BulkEdit(
-    constraintSet:  Edit,
-    observationIds: List[Observation.Id]
-  )
-
-  object BulkEdit {
-
-    implicit val DecoderEdit: Decoder[BulkEdit] =
-      deriveDecoder[BulkEdit]
-
-    implicit val EqBulkEdit: Eq[BulkEdit] =
-      Eq.fromUniversalEquals
-
   }
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -15,7 +15,7 @@ import cats.syntax.all._
 import clue.data.{Assign, Input}
 import eu.timepit.refined.cats._
 import eu.timepit.refined.types.string._
-import io.circe.Decoder
+import io.circe.{Decoder, HCursor}
 import io.circe.generic.semiauto._
 import io.circe.refined._
 import monocle.{Focus, Lens, Optional}
@@ -278,6 +278,31 @@ object ObservationModel extends ObservationOptics {
       )}
 
   }
+
+  final case class BulkEdit[A](
+    input:          A,
+    observationIds: List[Observation.Id]
+  )
+
+  object BulkEdit {
+
+    def decoder[A: Decoder](
+      editorName: String
+    ): Decoder[BulkEdit[A]] =
+      (c: HCursor) =>
+        for {
+          input <- c.downField(editorName).as[A]
+          oids  <- c.downField("observationIds").as[List[Observation.Id]]
+        } yield BulkEdit(input, oids)
+
+    implicit def EqBulkEdit[A: Eq]: Eq[BulkEdit[A]] =
+      Eq.by { a => (
+        a.input,
+        a.observationIds
+      )}
+
+  }
+
 
 }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ScienceRequirements.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ScienceRequirements.scala
@@ -9,7 +9,6 @@ import cats.data.State
 import io.circe.Decoder
 import io.circe.generic.semiauto._
 import lucuma.core.optics.syntax.lens._
-import lucuma.core.model.Observation
 import lucuma.odb.api.model.syntax.input._
 import clue.data.Input
 import monocle.Lens
@@ -77,21 +76,6 @@ object ScienceRequirementsModel {
     implicit val customConfig: Configuration = Configuration.default.withDefaults
 
     implicit val DecoderEdit: Decoder[Edit] = deriveConfiguredDecoder
-  }
-
-  final case class BulkEdit(
-    scienceRequirements: Edit,
-    observationIds:      List[Observation.Id]
-  )
-
-  object BulkEdit {
-
-    implicit val DecoderEdit: Decoder[BulkEdit] =
-      deriveDecoder[BulkEdit]
-
-    implicit val EqBulkEdit: Eq[BulkEdit] =
-      Eq.fromUniversalEquals
-
   }
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetMutation.scala
@@ -3,20 +3,16 @@
 
 package lucuma.odb.api.schema
 
-import lucuma.odb.api.model.ConstraintSetModel
-
+import lucuma.odb.api.model.{AirmassRange, ConstraintSetModel, ElevationRangeModel, HourAngleRange}
 import lucuma.odb.api.schema.syntax.inputtype._
-
 import sangria.macros.derive._
 import sangria.marshalling.circe._
 import sangria.schema._
-import lucuma.odb.api.model.{AirmassRange, ElevationRangeModel, HourAngleRange}
 
 trait ConstraintSetMutation {
 
   import GeneralSchema.NonEmptyStringType
   import ConstraintSetSchema._
-  import ObservationSchema.ObservationIdType
   import syntax.inputobjecttype._
 
   implicit val InputObjectTypeAirmassRangeCreate: InputObjectType[AirmassRange.Create] =
@@ -63,18 +59,6 @@ trait ConstraintSetMutation {
       ReplaceInputField("elevationRange",
                         InputObjectTypeElevationRangeCreate.notNullableField("elevationRange")
       )
-    )
-
-  implicit val InputObjectTypeConstraintSetBulkEdit: InputObjectType[ConstraintSetModel.BulkEdit] =
-    deriveInputObjectType[ConstraintSetModel.BulkEdit](
-      InputObjectTypeName("BulkEditConstraintSetInput"),
-      InputObjectTypeDescription("Bulk edit constraint set of multiple observations")
-    )
-
-  val ArgumentConstraintSetBulkEdit: Argument[ConstraintSetModel.BulkEdit] =
-    InputObjectTypeConstraintSetBulkEdit.argument(
-      "input",
-      "Bulk edit constraint set"
     )
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceRequirementsMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceRequirementsMutation.scala
@@ -6,7 +6,6 @@ package lucuma.odb.api.schema
 import lucuma.odb.api.model.ScienceRequirementsModel
 
 import sangria.macros.derive._
-import sangria.marshalling.circe._
 import sangria.schema._
 import lucuma.odb.api.model.SpectroscopyScienceRequirementsModel
 
@@ -15,9 +14,7 @@ trait ScienceRequirementsMutation {
   import ScienceRequirementsSchema._
   import WavelengthSchema._
   import RefinedSchema._
-  import ObservationSchema.ObservationIdType
   import syntax.inputtype._
-  import syntax.inputobjecttype._
 
   implicit val InputObjectTypeSpectroscopyRequirements: InputObjectType[SpectroscopyScienceRequirementsModel.Create] =
     deriveInputObjectType[SpectroscopyScienceRequirementsModel.Create](
@@ -53,17 +50,6 @@ trait ScienceRequirementsMutation {
       ReplaceInputField("capabilities", EnumTypeSpectroscopyCapabilities.notNullableField("capabilities")),
     )
 
-  implicit val InputObjectTypeScienceRequirementsSetBulkEdit: InputObjectType[ScienceRequirementsModel.BulkEdit] =
-    deriveInputObjectType[ScienceRequirementsModel.BulkEdit](
-      InputObjectTypeName("BulkEditScienceRequirementSetInput"),
-      InputObjectTypeDescription("Bulk edit science requirements set of multiple observations")
-    )
-
-  val ArgumentScienceRequirementsBulkEdit: Argument[ScienceRequirementsModel.BulkEdit] =
-    InputObjectTypeScienceRequirementsSetBulkEdit.argument(
-      "input",
-      "Bulk edit science requirements set"
-    )
 }
 
 object ScienceRequirementsMutation extends ScienceRequirementsMutation


### PR DESCRIPTION
Removes a bit of code duplication but more importantly makes it easier to add new observation bulk edit operations.