### PR TITLE
Add warn after flag and remove nowarn annotation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,8 @@ lazy val core = project
   .settings(
     name := "lucuma-odb-api-core",
     scalacOptions ++= Seq(
-      "-Ymacro-annotations"
+      "-Ymacro-annotations",
+      "-Ywarn-macros:after"
     ),
     libraryDependencies ++= Seq(
       "co.fs2"                     %% "fs2-core"                  % fs2Version,

--- a/modules/core/src/main/scala/lucuma/odb/api/model/AtomModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/AtomModel.scala
@@ -12,7 +12,6 @@ import cats.mtl.Stateful
 import cats.syntax.all._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
-import scala.annotation.nowarn
 
 final case class AtomModel[A](
   id:    Atom.Id,
@@ -97,7 +96,6 @@ object AtomModel {
     def continueTo[A](step: CreateStepConfig[A]): Create[A] =
       singleton(StepModel.Create.continueTo(step))
 
-    @nowarn
     implicit def DecoderCreate[A: Decoder]: Decoder[Create[A]] =
       deriveDecoder[Create[A]]
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
@@ -19,7 +19,6 @@ import io.circe.generic.extras.Configuration
 import monocle.Optional
 
 import scala.concurrent.duration._
-import scala.annotation.nowarn
 import monocle.Lens
 import monocle.macros.GenLens
 
@@ -437,7 +436,6 @@ object GmosModel {
     def wavelength[D]: Lens[CreateGrating[D], WavelengthModel.Input] =
       GenLens[CreateGrating[D]](_.wavelength)
 
-    @nowarn
     implicit def DecoderCreateGrating[D: Decoder]: Decoder[CreateGrating[D]] =
       deriveDecoder[CreateGrating[D]]
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/NumericUnits.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/NumericUnits.scala
@@ -8,7 +8,6 @@ import lucuma.core.util.Enumerated
 import cats.Eq
 import io.circe.Decoder
 import io.circe.generic.semiauto._
-import scala.annotation.nowarn
 
 trait NumericUnits[A, U] {
 
@@ -46,7 +45,6 @@ object NumericUnits {
 
   object LongInput {
 
-    @nowarn
     implicit def DecoderLongInput[U: Enumerated]: Decoder[LongInput[U]] =
       deriveDecoder[LongInput[U]]
 
@@ -67,7 +65,6 @@ object NumericUnits {
 
   object DecimalInput {
 
-    @nowarn
     implicit def DecoderDecimalInput[U: Enumerated]: Decoder[DecimalInput[U]] =
       deriveDecoder[DecimalInput[U]]
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/SequenceModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/SequenceModel.scala
@@ -10,7 +10,6 @@ import cats.syntax.all._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 import lucuma.core.util.Enumerated
-import scala.annotation.nowarn
 
 /**
  * Sequence representation.
@@ -62,7 +61,6 @@ object SequenceModel {
     implicit def EdCreate[D: Eq]: Eq[Create[D]] =
       Eq.by { _.atoms }
 
-    @nowarn
     implicit def DecoderCreate[D: Decoder]:Decoder[Create[D]] =
       deriveDecoder[Create[D]]
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/StepConfig.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/StepConfig.scala
@@ -11,7 +11,6 @@ import cats.syntax.all._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 import monocle.{Lens, Optional}
-import scala.annotation.nowarn
 import monocle.macros.GenLens
 
 // For now, just bias, dark, gcal and science.  Pending smart-gcal.
@@ -169,7 +168,6 @@ object StepConfig {
         a.offset
       )}
 
-    @nowarn
     implicit def DecoderCreateScience[A: Decoder]: Decoder[CreateScience[A]] =
       deriveDecoder[CreateScience[A]]
 
@@ -190,7 +188,6 @@ object StepConfig {
     implicit def EqCreateBias[A: Eq]: Eq[CreateBias[A]] =
       Eq.by(_.config)
 
-    @nowarn
     implicit def DecoderCreateBias[A: Decoder]: Decoder[CreateBias[A]] =
       deriveDecoder[CreateBias[A]]
 
@@ -211,7 +208,6 @@ object StepConfig {
     implicit def EqCreateDark[A: Eq]: Eq[CreateDark[A]] =
       Eq.by(_.config)
 
-    @nowarn
     implicit def DecoderCreateDark[A: Decoder]: Decoder[CreateDark[A]] =
       deriveDecoder[CreateDark[A]]
 
@@ -238,7 +234,6 @@ object StepConfig {
         a.gcalConfig
       )}
 
-    @nowarn
     implicit def DecoderCreateGcal[A: Decoder]: Decoder[CreateGcal[A]] =
       deriveDecoder[CreateGcal[A]]
 
@@ -284,7 +279,6 @@ object StepConfig {
         a.science
       )}
 
-    @nowarn
     implicit def DecoderCreateStep[A: Decoder]: Decoder[CreateStepConfig[A]] =
       deriveDecoder[CreateStepConfig[A]]
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/StepModel.scala
@@ -10,7 +10,6 @@ import cats.mtl.Stateful
 import cats.syntax.all._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
-import scala.annotation.nowarn
 
 final case class StepModel[A](
   id:         Step.Id,
@@ -85,7 +84,6 @@ object StepModel {
         a.config
       )}
 
-    @nowarn
     implicit def DecoderCreate[A: Decoder]: Decoder[Create[A]] =
       deriveDecoder[Create[A]]
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SharingMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SharingMutation.scala
@@ -14,7 +14,6 @@ import sangria.macros.derive._
 import sangria.marshalling.FromInput
 import sangria.marshalling.circe._
 import sangria.schema._
-import scala.annotation.nowarn
 
 trait SharingMutation {
 
@@ -25,7 +24,6 @@ trait SharingMutation {
   import context._
   import syntax.inputobjecttype._
 
-  @nowarn
   def linksArg[A: ScalarType: Decoder, B: ScalarType: Decoder](
     aName:       String,
     bName:       String


### PR DESCRIPTION
Adds the `warn-macros:after` flag and saves the need for `@nowarn` annotations.