### PR TITLE
Allow expecting error messages

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ValidatedInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ValidatedInput.scala
@@ -45,10 +45,11 @@ object ValidatedInput {
     value: T,
     low:   T,
     high:  T
-  )(implicit
-    v:     Validate[T, Interval.Closed[low.type, high.type]]
+  )(
+    implicit v: Validate[T, Interval.Closed[low.type, high.type]]
   ): ValidatedInput[T Refined Interval.Closed[low.type, high.type]] =
+
     refineV[Interval.Closed[low.type, high.type]](value)
-      .leftMap(_ => InputError.fromMessage(s"'$name' out of range: must be $low<= $name <= $high "))
+      .leftMap(_ => InputError.fromMessage(s"'$name' out of range: must be $low <= $name <= $high"))
       .toValidatedNec
 }

--- a/modules/service/src/test/scala/MutationSuite.scala
+++ b/modules/service/src/test/scala/MutationSuite.scala
@@ -109,4 +109,43 @@ class MutationSuite extends OdbSuite {
     """)
   )
 
+  queryTestFailure(
+    query =
+      """
+        mutation BulkEditConstraints($bulkEditConstraints: BulkEditConstraintSetInput!) {
+          updateConstraintSet(input: $bulkEditConstraints) {
+            id
+            constraintSet {
+              skyBackground
+              elevationRange {
+                ... on AirMassRange {
+                  min
+                  max
+                }
+              }
+            }
+          }
+        }
+      """,
+    errors = List(
+      "'min' out of range: must be 1.0 <= min <= 3.0"
+    ),
+    variables = Some(json"""
+      {
+        "bulkEditConstraints": {
+          "observationIds": [ "o-3" ],
+          "constraintSet": {
+            "skyBackground": "GRAY",
+            "elevationRange": {
+              "airmassRange": {
+                "min": 0.0,
+                "max": 2.0
+              }
+            }
+          }
+        }
+      }
+      """)
+  )
+
 }


### PR DESCRIPTION
Adds an update to `OdbSuite` to allow testing queries that are expected to fail.  It also introduces some cruft that will be removed when the next clue update is published.