### PR TITLE
Add includeDeleted flag in grouping queries

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
@@ -7,6 +7,7 @@ import lucuma.core.model.{Observation, Program, Target}
 import lucuma.core.optics.state.all._
 import lucuma.odb.api.model.ObservationModel.{BulkEdit, Create, Edit, Group, ObservationEvent}
 import lucuma.odb.api.model.{ConstraintSetModel, Event, InputError, InstrumentConfigModel, ObservationModel, PlannedTimeSummaryModel, ScienceRequirements, ScienceRequirementsModel, TargetEnvironmentModel, TargetModel, ValidatedInput}
+import lucuma.odb.api.model.syntax.toplevel._
 import lucuma.odb.api.model.syntax.validatedinput._
 import cats.data.{EitherT, State}
 import cats.effect.{Async, Ref}
@@ -36,16 +37,30 @@ sealed trait ObservationRepo[F[_]] extends TopLevelRepo[F, Observation.Id, Obser
 
   def edit(edit: Edit): F[ObservationModel]
 
+  def groupBySingleScienceTarget(
+    pid:            Program.Id,
+    includeDeleted: Boolean
+  ): F[List[Group[Target]]]
 
-  def groupBySingleScienceTarget(pid: Program.Id): F[List[Group[Target]]]
+  def groupByAllScienceTargets(
+    pid:            Program.Id,
+    includeDeleted: Boolean
+  ): F[List[Group[List[Target]]]]
 
-  def groupByAllScienceTargets(pid: Program.Id): F[List[Group[List[Target]]]]
+  def groupByTargetEnvironment(
+    pid:            Program.Id,
+    includeDeleted: Boolean
+  ): F[List[Group[TargetEnvironmentModel]]]
 
-  def groupByTargetEnvironment(pid: Program.Id): F[List[Group[TargetEnvironmentModel]]]
+  def groupByConstraintSet(
+    pid:            Program.Id,
+    includeDeleted: Boolean
+  ): F[List[Group[ConstraintSetModel]]]
 
-  def groupByConstraintSet(pid: Program.Id): F[List[Group[ConstraintSetModel]]]
-
-  def groupByScienceRequirements(pid: Program.Id): F[List[Group[ScienceRequirements]]]
+  def groupByScienceRequirements(
+    pid:            Program.Id,
+    includeDeleted: Boolean
+  ): F[List[Group[ScienceRequirements]]]
 
   def bulkEditScienceTarget(
     be: BulkEdit[TargetModel.Edit]
@@ -158,25 +173,27 @@ object ObservationRepo {
       }
 
       private def groupBy[A](
-         pid: Program.Id
-       )(
-         f: ObservationModel => A
-       ): F[List[Group[A]]] =
-         tablesRef.get.map { t =>
-           t.observations
-            .filter { case (_, o) => o.programId === pid }
-            .groupMap(tup => f(tup._2))(_._1)
-            .toList
-            .map { case (a, oids) => Group.from(a, oids) }
-            .sortBy(_.observationIds.head)
-         }
+        pid:            Program.Id,
+        includeDeleted: Boolean
+      )(
+        f: ObservationModel => A
+      ): F[List[Group[A]]] =
+        tablesRef.get.map { t =>
+          t.observations
+           .filter { case (_, o) => (o.programId === pid) && (includeDeleted || o.isPresent) }
+           .groupMap(tup => f(tup._2))(_._1)
+           .toList
+           .map { case (a, oids) => Group.from(a, oids) }
+           .sortBy(_.observationIds.head)
+        }
 
       override def groupBySingleScienceTarget(
-        pid: Program.Id
+        pid:            Program.Id,
+        includeDeleted: Boolean
       ): F[List[Group[Target]]] =
         tablesRef.get.map { t =>
           t.observations
-           .filter { case (_, o) => o.programId === pid }
+           .filter { case (_, o) => (o.programId === pid) && (includeDeleted || o.isPresent) }
            .toList
            .flatMap { case (k, o) => o.targets.science.values.toList.tupleRight(k) }
            .groupMap(_._1)(_._2)
@@ -186,24 +203,28 @@ object ObservationRepo {
         }
 
       override def groupByAllScienceTargets(
-        pid: Program.Id
+        pid:            Program.Id,
+        includeDeleted: Boolean
       ): F[List[Group[List[Target]]]] =
-        groupBy(pid) { _.targets.science.values.toList }
+        groupBy(pid, includeDeleted) { _.targets.science.values.toList }
 
       override def groupByTargetEnvironment(
-        pid: Program.Id
+        pid:            Program.Id,
+        includeDeleted: Boolean
       ): F[List[Group[TargetEnvironmentModel]]] =
-        groupBy(pid) { _.targets }
+        groupBy(pid, includeDeleted) { _.targets }
 
       override def groupByConstraintSet(
-        pid: Program.Id
+        pid:            Program.Id,
+        includeDeleted: Boolean
       ): F[List[Group[ConstraintSetModel]]] =
-        groupBy(pid)(_.constraintSet)
+        groupBy(pid, includeDeleted)(_.constraintSet)
 
       override def groupByScienceRequirements(
-        pid: Program.Id
+        pid:            Program.Id,
+        includeDeleted: Boolean
       ): F[List[Group[ScienceRequirements]]] =
-        groupBy(pid)(_.scienceRequirements)
+        groupBy(pid, includeDeleted)(_.scienceRequirements)
 
 
       private def selectObservations(

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/Tables.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/Tables.scala
@@ -28,7 +28,6 @@ object Tables extends TableOptics {
   val empty: Tables =
     Tables(
       ids             = Ids.zero,
-
       atoms           = TreeMap.empty[Atom.Id, AtomModel[Step.Id]],
       executionEvents = TreeMap.empty[ExecutionEvent.Id, ExecutionEventModel],
       observations    = TreeMap.empty[Observation.Id, ObservationModel],

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationGroupSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationGroupSchema.scala
@@ -90,7 +90,7 @@ object ObservationGroupSchema {
     name:        String,
     description: String,
     outType:     OutputType[A],
-    lookupAll:   (ObservationRepo[F], Program.Id) => F[List[ObservationModel.Group[A]]]
+    lookupAll:   (ObservationRepo[F], Program.Id, Boolean) => F[List[ObservationModel.Group[A]]]
   )(
     implicit ev: MonadError[F, Throwable]
   ): Field[OdbRepo[F], Unit] = {
@@ -127,7 +127,7 @@ object ObservationGroupSchema {
         Paging.unsafeSelectPageFuture[F, Observation.Id, ObservationModel.Group[A]](
           c.pagingObservationId,
           g   => Cursor.gid[Observation.Id].reverseGet(g.observationIds.head),
-          oid => lookupAll(c.ctx.observation, c.programId).map { gs =>
+          oid => lookupAll(c.ctx.observation, c.programId, c.includeDeleted).map { gs =>
             ResultPage.fromSeq(gs, c.arg(ArgumentPagingFirst), oid, _.observationIds.head)
           }
         )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationQuery.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationQuery.scala
@@ -68,7 +68,7 @@ trait ObservationQuery {
       "scienceTarget",
       "Observations grouped by commonly held individual science targets",
       TargetType[F],
-      (repo, pid) => repo.groupBySingleScienceTarget(pid)
+      (repo, pid, includeDeleted) => repo.groupBySingleScienceTarget(pid, includeDeleted)
     )
 
   def groupByAllScienceTargets[F[_]: Dispatcher](implicit ev: MonadError[F, Throwable]): Field[OdbRepo[F], Unit] =
@@ -77,7 +77,7 @@ trait ObservationQuery {
       "allScienceTargets",
       "Observations grouped by commonly held collections of science targets",
       ListType(TargetType[F]),
-      (repo, pid) => repo.groupByAllScienceTargets(pid).map(_.map(_.map(_.toSeq)))
+      (repo, pid, includeDeleted) => repo.groupByAllScienceTargets(pid, includeDeleted).map(_.map(_.map(_.toSeq)))
     )
 
   def groupByTargetEnvironment[F[_]: Dispatcher](implicit ev: MonadError[F, Throwable]): Field[OdbRepo[F], Unit] =
@@ -86,7 +86,7 @@ trait ObservationQuery {
       "targetEnvironment",
       "Observations grouped by commonly held target environment",
       TargetEnvironmentType[F],
-      (repo, pid) => repo.groupByTargetEnvironment(pid)
+      (repo, pid, includeDeleted) => repo.groupByTargetEnvironment(pid, includeDeleted)
     )
 
   def groupByConstraintSet[F[_]: Dispatcher](implicit ev: MonadError[F, Throwable]): Field[OdbRepo[F], Unit] =
@@ -95,7 +95,7 @@ trait ObservationQuery {
       "constraintSet",
       "Observations grouped by commonly held constraints",
       ConstraintSetType[F],
-      (repo, pid) => repo.groupByConstraintSet(pid)
+      (repo, pid, includeDeleted) => repo.groupByConstraintSet(pid, includeDeleted)
     )
 
   def groupByScienceRequirements[F[_]: Dispatcher](implicit ev: MonadError[F, Throwable]): Field[OdbRepo[F], Unit] =
@@ -104,7 +104,7 @@ trait ObservationQuery {
       "scienceRequirements",
       "Observations grouped by commonly held science requirements",
       ScienceRequirementsType[F],
-      (repo, pid) => repo.groupByScienceRequirements(pid)
+      (repo, pid, includeDeleted) => repo.groupByScienceRequirements(pid, includeDeleted)
     )
 
   def allFields[F[_]: Dispatcher](implicit ev: MonadError[F, Throwable]): List[Field[OdbRepo[F], Unit]] =

--- a/modules/service/src/test/scala/test/GroupIncludeDeletedSuite.scala
+++ b/modules/service/src/test/scala/test/GroupIncludeDeletedSuite.scala
@@ -1,0 +1,87 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package test
+
+import io.circe.literal._
+
+class GroupIncludeDeletedSuite extends OdbSuite {
+
+  queryTest(
+    query ="""
+      mutation DeleteObservation {
+        deleteObservation(observationId: "o-5") {
+          id
+        }
+      }
+    """,
+    expected = json"""
+      {
+        "deleteObservation": {
+          "id": "o-5"
+        }
+      }
+    """
+  )
+
+  // After deletion of "o-5", the grouping will not contain it
+  queryTest(
+    query = """
+      query ObservationsByConstraintSet {
+        constraintSetGroup(programId:"p-2", includeDeleted: false) {
+          nodes {
+            observationIds
+          }
+        }
+      }
+    """,
+    expected = json"""
+      {
+        "constraintSetGroup" : {
+          "nodes" : [
+            {
+              "observationIds" : [
+                "o-2",
+                "o-3",
+                "o-4",
+                "o-6",
+                "o-7"
+              ]
+            }
+          ]
+        }
+      }
+    """
+  )
+
+  // After deletion of "o-5", the grouping will contain it if includeDeleted is true
+  queryTest(
+    query = """
+      query ObservationsByConstraintSet {
+        constraintSetGroup(programId:"p-2", includeDeleted: true) {
+          nodes {
+            observationIds
+          }
+        }
+      }
+    """,
+    expected = json"""
+      {
+        "constraintSetGroup" : {
+          "nodes" : [
+            {
+              "observationIds" : [
+                "o-2",
+                "o-3",
+                "o-4",
+                "o-5",
+                "o-6",
+                "o-7"
+              ]
+            }
+          ]
+        }
+      }
+    """
+  )
+}


### PR DESCRIPTION
Adds the `includeDeleted` argument to the grouping queries (or rather makes use of it instead of ignoring it as before).