### PR TITLE
Add IDs for target groupings

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/CommonTarget.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/CommonTarget.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model.targetModel
+
+import cats.Order
+import cats.implicits.catsKernelOrderingForOrder
+import lucuma.core.model.Target
+
+import scala.collection.immutable.SortedSet
+
+/**
+ * `CommonTarget` expresses what is the same across of collection of
+ * `TargetModel` (the core model `Target` itself) along with a reference
+ * to the ids of individual `TargetModel`s with this `Target`.
+ */
+final case class CommonTarget(
+  target: Target,
+  ids:    SortedSet[Target.Id]
+) extends TargetHolder
+
+object CommonTarget {
+
+  implicit val OrderCommonTarget: Order[CommonTarget] =
+    Order.from { (a, b) =>
+      Target.TargetNameOrder.compare(a.target, b.target) match {
+        case 0 => Order[SortedSet[Target.Id]].compare(a.ids, b.ids)
+        case i => i
+      }
+    }
+
+  def from(target: Target, ids: IterableOnce[Target.Id]): CommonTarget =
+    CommonTarget(target, SortedSet.from(ids))
+
+  /**
+   * Finds the `CommonTarget`s in a list of `TargetModel` by grouping on their
+   * `lucuma.core.model.Target`s.
+   */
+  def extractFromTargetModels(tms: List[TargetModel]): SortedSet[CommonTarget] =
+    SortedSet.from(tms.groupMap(_.target)(_.id).map((from _).tupled))
+
+}
+

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/CommonTargetEnvironment.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/CommonTargetEnvironment.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model.targetModel
+
+import cats.Order
+import lucuma.core.math.Coordinates
+
+import scala.collection.immutable.SortedSet
+
+/**
+ * `CommonTargetEnvironment` expresses what is the same across a collection of
+ * `TargetEnvironmentModel`s (explicit base and the set of targets) along with
+ * the ids of individual `TargetEnvironmentModel`s with these properties.
+ */
+final case class CommonTargetEnvironment(
+  explicitBase: Option[Coordinates],
+  science:      SortedSet[CommonTarget],
+  ids:          SortedSet[TargetEnvironment.Id]
+)
+
+object CommonTargetEnvironment {
+
+  implicit val OrderCommonTargetEnvironment: Order[CommonTargetEnvironment] =
+    Order.by { a => (
+      a.explicitBase,
+      a.science,
+      a.ids
+    )}
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetEnvironmentGroup.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetEnvironmentGroup.scala
@@ -4,6 +4,7 @@
 package lucuma.odb.api.model.targetModel
 
 import cats.{Eq, Functor}
+import cats.implicits.catsKernelOrderingForOrder
 
 import scala.collection.immutable.SortedSet
 
@@ -17,7 +18,7 @@ final case class TargetEnvironmentGroup[A](
 
 object TargetEnvironmentGroup {
 
-  implicit def EqGroup[A: Eq]: Eq[TargetEnvironmentGroup[A]] =
+  implicit def EqTargetEnvironmentGroup[A: Eq]: Eq[TargetEnvironmentGroup[A]] =
     Eq.by { tem => (
       tem.value,
       tem.targetEnvironmentIds
@@ -28,5 +29,8 @@ object TargetEnvironmentGroup {
       override def map[A, B](fa: TargetEnvironmentGroup[A])(f: A => B): TargetEnvironmentGroup[B] =
         TargetEnvironmentGroup[B](f(fa.value), fa.targetEnvironmentIds)
     }
+
+  def from[A](value: A, vids: IterableOnce[TargetEnvironment.Id]): TargetEnvironmentGroup[A] =
+    TargetEnvironmentGroup(value, SortedSet.from(vids))
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetEnvironmentModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetEnvironmentModel.scala
@@ -4,26 +4,12 @@
 package lucuma.odb.api.model.targetModel
 
 import lucuma.core.math.Coordinates
-import lucuma.core.model.{Observation, Program, Target, WithId}
+import lucuma.core.model.{Observation, Program, WithId}
 import cats.Eq
 import eu.timepit.refined.auto._
 import monocle.Lens
 
-
-final case class CommonTargetEnvironment(
-  explicitBase: Option[Coordinates],
-  science:      Set[Target]
-)
-
-object CommonTargetEnvironment {
-  implicit val EqGroupingTargetEnvironment: Eq[CommonTargetEnvironment] =
-    Eq.by { a => (
-      a.explicitBase,
-      a.science
-    )}
-
-}
-
+// Will eventually come from lucuma.core.model
 object TargetEnvironment extends WithId('v')
 
 /**
@@ -37,14 +23,7 @@ final case class TargetEnvironmentModel(
   observationId: Option[Observation.Id],
 
   explicitBase:  Option[Coordinates]
-)  {
-
-  def toCommon(
-    science: Iterable[Target]
-  ): CommonTargetEnvironment =
-    CommonTargetEnvironment(explicitBase, Set.from(science))
-
-}
+)
 
 object TargetEnvironmentModel extends TargetEnvironmentModelOptics {
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetHolder.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetHolder.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model.targetModel
+
+import lucuma.core.model.Target
+
+/**
+ * An interface for objects that contain a `lucuma.core.model.Target`.
+ */
+trait TargetHolder {
+
+  def target: Target
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
@@ -13,14 +13,10 @@ import monocle.{Lens, Optional}
 
 import scala.collection.immutable.SortedMap
 
-sealed trait TargetHolder {
-  def target:     Target
-}
-
-final case class CommonTarget(
-  target: Target
-) extends TargetHolder
-
+/**
+ * TargetModel pairs an id with a `lucuma.core.model.Target` and tracks the
+ * target environment in which the target is found.
+ */
 final case class TargetModel(
   id:                  Target.Id,
   targetEnvironmentId: TargetEnvironment.Id,

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetQuery.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetQuery.scala
@@ -130,7 +130,7 @@ trait TargetQuery {
       ),
       resolve     = c => c.target { repo =>
         Nested(repo.groupByScienceTargetList(c.programId, c.includeDeleted))
-          .map(_.map(_.toSeq))
+          .map(_.map(Seq.from))
           .value
       }
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetSchema.scala
@@ -357,7 +357,7 @@ object TargetSchema extends TargetScalars {
           name        = "epoch",
           fieldType   = EpochStringType,
           description = Some("Epoch, time of base observation"),
-          resolve     = _.value.epoch //v => math.Epoch.fromString.reverseGet(v.value.epoch)
+          resolve     = _.value.epoch
         ),
 
         Field(
@@ -435,7 +435,14 @@ object TargetSchema extends TargetScalars {
     ObjectType(
       name       = "CommonTarget",
       interfaces = List(PossibleInterface.apply[OdbRepo[F], CommonTarget](TargetInterfaceType[F])),
-      fields     = Nil
+      fields     = fields(
+        Field(
+          name        = "ids",
+          fieldType   = ListType(TargetIdType),
+          description = "Target IDs that share the common target information".some,
+          resolve     = _.value.ids.toList
+        )
+      )
     )
 
   def TargetModelType[F[_]: Dispatcher](implicit ev: MonadError[F, Throwable]): ObjectType[OdbRepo[F], TargetModel] =
@@ -510,14 +517,14 @@ object TargetSchema extends TargetScalars {
           name        = "scienceTargets",
           fieldType   = ListType(CommonTargetType[F]),
           description = "All science targets, if any".some,
-          resolve     = _.value.science.toList.sorted(Target.TargetNameOrder.toOrdering).map(CommonTarget)
+          resolve     = _.value.science.toList
         ),
 
         Field(
           name        = "firstScienceTarget",
           fieldType   = OptionType(CommonTargetType[F]),
           description = "First science target, if any".some,
-          resolve     = _.value.science.toList.sorted(Target.TargetNameOrder.toOrdering).headOption.map(CommonTarget)
+          resolve     = _.value.science.headOption
         )
       )
     )

--- a/modules/service/src/test/scala/test/targets/TargetQuerySuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetQuerySuite.scala
@@ -226,13 +226,13 @@ class TargetQuerySuite extends OdbSuite {
               ],
               "commonTargetList": [
                 {
-                  "name": "NGC 5949"
-                },
-                {
                   "name": "NGC 3269"
                 },
                 {
                   "name": "NGC 3312"
+                },
+                {
+                  "name": "NGC 5949"
                 }
               ]
             },


### PR DESCRIPTION
@toddburnside pointed out that we need the actual target IDs corresponding to target environment groupings.  For example, if you group by common science targets, each grouping contains a `Set[Target]` and the IDs of target environments that use those targets.  Previously though the actual target IDs themselves were not available.  In a subsequent edit you would have information to select target environments that need to be updated, but not to identify actual targets.

This PR corrects that shortcoming by adding the list of target IDs in groupings to the schema.