### PR TITLE
Add error to magnitudes for queries

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetSchema.scala
@@ -147,8 +147,14 @@ object TargetSchema extends TargetScalars {
           fieldType   = EnumTypeMagnitudeSystem,
           description = Some("Magnitude System"),
           resolve     = _.value.system
-        )
+        ),
 
+        Field(
+          name        = "error",
+          fieldType   = OptionType(BigDecimalType),
+          description = Some("Magnitude error (unitless)"),
+          resolve     = _.value.error.map(MagnitudeValue.fromBigDecimal.reverseGet)
+        )
       )
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -126,7 +126,8 @@ object Init {
     {
       "band": "B",
       "value": 12.63,
-      "system": "VEGA"
+      "system": "VEGA",
+      "error": 0.02
     },
     {
       "band": "V",


### PR DESCRIPTION
It was possible to specify a Magnitude error when creating a Magnitude, but they were not available in queries.