### PR TITLE
Use lucuma-core TargetEnvironment

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/DatabaseReader.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/DatabaseReader.scala
@@ -3,8 +3,8 @@
 
 package lucuma.odb.api.model
 
-import lucuma.core.model.{Atom, Observation, Program, Step, Target}
-import lucuma.odb.api.model.targetModel.{ TargetEnvironment, TargetEnvironmentModel, TargetModel }
+import lucuma.core.model.{Atom, Observation, Program, Step, Target, TargetEnvironment }
+import lucuma.odb.api.model.targetModel.{ TargetEnvironmentModel, TargetModel }
 
 trait DatabaseReader[T] {
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/DatabaseState.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/DatabaseState.scala
@@ -3,8 +3,8 @@
 
 package lucuma.odb.api.model
 
-import lucuma.core.model.{Atom, ExecutionEvent, Observation, Program, Step, Target}
-import lucuma.odb.api.model.targetModel.{ TargetEnvironment, TargetEnvironmentModel, TargetModel }
+import lucuma.core.model.{Atom, ExecutionEvent, Observation, Program, Step, Target, TargetEnvironment}
+import lucuma.odb.api.model.targetModel.{TargetEnvironmentModel, TargetModel}
 
 trait DatabaseState[T] extends DatabaseReader[T] {
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/BulkReplaceTargetListInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/BulkReplaceTargetListInput.scala
@@ -11,6 +11,7 @@ import cats.syntax.functor._
 import cats.syntax.traverse._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
+import lucuma.core.model.TargetEnvironment
 import lucuma.odb.api.model.{DatabaseState, ValidatedInput}
 import lucuma.odb.api.model.syntax.validatedinput._
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/CommonTargetEnvironment.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/CommonTargetEnvironment.scala
@@ -5,6 +5,7 @@ package lucuma.odb.api.model.targetModel
 
 import cats.Order
 import lucuma.core.math.Coordinates
+import lucuma.core.model.TargetEnvironment
 
 import scala.collection.immutable.SortedSet
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/CreateTargetEnvironmentInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/CreateTargetEnvironmentInput.scala
@@ -14,7 +14,7 @@ import cats.syntax.traverse._
 import cats.syntax.validated._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
-import lucuma.core.model.{Observation, Program}
+import lucuma.core.model.{Observation, Program, TargetEnvironment}
 import lucuma.odb.api.model.{CoordinatesModel, DatabaseState, InputError, ValidatedInput}
 
 import scala.collection.immutable.SortedSet

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/CreateTargetInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/CreateTargetInput.scala
@@ -8,6 +8,7 @@ import cats.mtl.Stateful
 import cats.syntax.option._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
+import lucuma.core.model.TargetEnvironment
 import lucuma.odb.api.model.{DatabaseState, ValidatedInput}
 
 import scala.collection.immutable.SortedSet

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/EditTargetAction.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/EditTargetAction.scala
@@ -9,6 +9,7 @@ import cats.mtl.Stateful
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.traverse._
+import lucuma.core.model.TargetEnvironment
 import lucuma.odb.api.model.{DatabaseState, ValidatedInput}
 
 import scala.collection.immutable.SortedSet
@@ -19,8 +20,10 @@ import scala.collection.immutable.SortedSet
  */
 trait EditTargetAction {
 
+  //noinspection MutatorLikeMethodIsParameterless
   def addSidereal:     Option[CreateSiderealInput]
 
+  //noinspection MutatorLikeMethodIsParameterless
   def addNonsidereal:  Option[CreateNonsiderealInput]
 
   def editSidereal:    Option[EditSiderealInput]

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SelectTargetEnvironmentInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SelectTargetEnvironmentInput.scala
@@ -15,7 +15,7 @@ import cats.syntax.traverse._
 import cats.syntax.validated._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
-import lucuma.core.model.{Observation, Program}
+import lucuma.core.model.{Observation, Program, TargetEnvironment}
 import lucuma.odb.api.model.{DatabaseState, InputError, ValidatedInput}
 
 import scala.collection.immutable.SortedSet

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SelectTargetInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SelectTargetInput.scala
@@ -9,7 +9,7 @@ import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Decoder
 import io.circe.generic.semiauto._
 import io.circe.refined._
-import lucuma.core.model.Target
+import lucuma.core.model.{Target, TargetEnvironment}
 
 //
 // # Target selection.  Choose at least one of `names` or `targetIds`.

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetCreator.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetCreator.scala
@@ -10,7 +10,7 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.traverse._
 import eu.timepit.refined.types.string.NonEmptyString
-import lucuma.core.model.Target
+import lucuma.core.model.{Target, TargetEnvironment}
 import lucuma.odb.api.model.{DatabaseState, ValidatedInput}
 import lucuma.odb.api.model.syntax.validatedinput._
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetEditor.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetEditor.scala
@@ -12,7 +12,7 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.traverse._
 import cats.syntax.validated._
-import lucuma.core.model.Target
+import lucuma.core.model.{Target, TargetEnvironment}
 import lucuma.odb.api.model.{DatabaseState, ValidatedInput}
 
 import scala.collection.immutable.SortedSet

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetEnvironmentContext.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetEnvironmentContext.scala
@@ -10,6 +10,7 @@ import cats.syntax.apply._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.traverse._
+import lucuma.core.model.TargetEnvironment
 import lucuma.odb.api.model.{DatabaseState, ObservationModel, ProgramModel, ValidatedInput}
 import lucuma.odb.api.model.syntax.validatedinput._
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetEnvironmentGroup.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetEnvironmentGroup.scala
@@ -5,7 +5,7 @@ package lucuma.odb.api.model.targetModel
 
 import cats.{Eq, Functor}
 import cats.implicits.catsKernelOrderingForOrder
-
+import lucuma.core.model.TargetEnvironment
 import scala.collection.immutable.SortedSet
 
 /**

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetEnvironmentModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetEnvironmentModel.scala
@@ -4,13 +4,10 @@
 package lucuma.odb.api.model.targetModel
 
 import lucuma.core.math.Coordinates
-import lucuma.core.model.{Observation, Program, WithId}
+import lucuma.core.model.{Observation, Program, TargetEnvironment}
 import cats.Eq
-import eu.timepit.refined.auto._
+//import eu.timepit.refined.auto._
 import monocle.Lens
-
-// Will eventually come from lucuma.core.model
-object TargetEnvironment extends WithId('v')
 
 /**
  * The TargetEnvironmentModel with id and references to the containing

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
@@ -4,7 +4,7 @@
 package lucuma.odb.api.model.targetModel
 
 import lucuma.core.math.ProperMotion
-import lucuma.core.model.{SiderealTracking, Target}
+import lucuma.core.model.{SiderealTracking, Target, TargetEnvironment}
 import cats.Eq
 import monocle.{Focus, Lens, Optional}
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/Ids.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/Ids.scala
@@ -3,8 +3,7 @@
 
 package lucuma.odb.api.repo
 
-import lucuma.core.model.{Atom, ExecutionEvent, Observation, Program, Step, Target}
-import lucuma.odb.api.model.targetModel.TargetEnvironment
+import lucuma.core.model.{Atom, ExecutionEvent, Observation, Program, Step, Target, TargetEnvironment}
 import cats.kernel.BoundedEnumerable
 import monocle.Lens
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TableState.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TableState.scala
@@ -3,10 +3,10 @@
 
 package lucuma.odb.api.repo
 
-import lucuma.core.model.{Atom, ExecutionEvent, Observation, Program, Step, Target}
+import lucuma.core.model.{Atom, ExecutionEvent, Observation, Program, Step, Target, TargetEnvironment}
 import lucuma.core.optics.state.all._
 import lucuma.odb.api.model.{AtomModel, DatabaseState, ExecutionEventModel, ObservationModel, ProgramModel, RepoState, SharingState, StepModel}
-import lucuma.odb.api.model.targetModel.{TargetEnvironment, TargetEnvironmentModel, TargetModel}
+import lucuma.odb.api.model.targetModel.{TargetEnvironmentModel, TargetModel}
 import cats.data.State
 import cats.mtl.Stateful
 import monocle.Lens

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/Tables.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/Tables.scala
@@ -3,9 +3,9 @@
 
 package lucuma.odb.api.repo
 
-import lucuma.core.model.{Atom, ExecutionEvent, Observation, Program, Step, Target}
+import lucuma.core.model.{Atom, ExecutionEvent, Observation, Program, Step, Target, TargetEnvironment}
 import lucuma.odb.api.model.{AtomModel, ExecutionEventModel, ObservationModel, ProgramModel, StepModel }
-import lucuma.odb.api.model.targetModel.{ TargetEnvironment, TargetEnvironmentModel, TargetModel}
+import lucuma.odb.api.model.targetModel.{TargetEnvironmentModel, TargetModel}
 import cats.instances.order._
 import monocle.Lens
 import monocle.function.At

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
@@ -4,14 +4,14 @@
 package lucuma.odb.api.repo
 
 import cats.data.State
-import lucuma.core.model.{Observation, Program, Target}
+import lucuma.core.model.{Observation, Program, Target, TargetEnvironment}
 import lucuma.core.util.Gid
 import lucuma.odb.api.model.ValidatedInput
 import lucuma.odb.api.model.ObservationModel.ObservationEvent
 import lucuma.odb.api.model.ProgramModel.ProgramEvent
 import lucuma.odb.api.model.syntax.validatedinput._
 import lucuma.odb.api.model.syntax.toplevel._
-import lucuma.odb.api.model.targetModel.{TargetEnvironment, _}
+import lucuma.odb.api.model.targetModel._
 import cats.effect.{Async, Ref}
 import cats.implicits.catsKernelOrderingForOrder
 import cats.syntax.applicative._

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SubscriptionType.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SubscriptionType.scala
@@ -9,7 +9,7 @@ import lucuma.odb.api.model.{ObservationModel, ProgramModel}
 import lucuma.odb.api.model.ObservationModel.ObservationEvent
 import lucuma.odb.api.model.ProgramModel.ProgramEvent
 import lucuma.odb.api.repo.OdbRepo
-import lucuma.core.model.{Observation, Program}
+import lucuma.core.model.{Observation, Program, TargetEnvironment}
 import cats.{Applicative, Eq, MonadError}
 import cats.effect.std.Dispatcher
 import cats.syntax.applicative._
@@ -17,7 +17,7 @@ import cats.syntax.apply._
 import cats.syntax.eq._
 import cats.syntax.functor._
 import fs2.Stream
-import lucuma.odb.api.model.targetModel.{TargetEnvironment, TargetEnvironmentEvent, TargetEnvironmentModel}
+import lucuma.odb.api.model.targetModel.{TargetEnvironmentEvent, TargetEnvironmentModel}
 import sangria.schema._
 import sangria.streaming.SubscriptionStream
 import sangria.streaming.SubscriptionStreamLike._

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetSchema.scala
@@ -6,11 +6,11 @@ package lucuma.odb.api.schema
 import cats.MonadError
 import lucuma.odb.api.schema.syntax.all._
 import lucuma.odb.api.model.{DeclinationModel, ParallaxModel, ProperMotionModel, RadialVelocityModel, RightAscensionModel}
-import lucuma.odb.api.model.targetModel.{CommonTarget, CommonTargetEnvironment, TargetEnvironment, TargetEnvironmentModel, TargetHolder, TargetModel}
+import lucuma.odb.api.model.targetModel.{CommonTarget, CommonTargetEnvironment, TargetEnvironmentModel, TargetHolder, TargetModel}
 import lucuma.odb.api.repo.OdbRepo
 import lucuma.core.`enum`.{CatalogName, MagnitudeBand, MagnitudeSystem,EphemerisKeyType => EphemerisKeyTypeEnum}
 import lucuma.core.math.{Coordinates, Declination, MagnitudeValue, Parallax, ProperMotion, RadialVelocity, RightAscension, VelocityAxis}
-import lucuma.core.model.{CatalogId, EphemerisKey, Magnitude, SiderealTracking, Target}
+import lucuma.core.model.{CatalogId, EphemerisKey, Magnitude, SiderealTracking, Target, TargetEnvironment}
 import cats.syntax.all._
 import cats.effect.std.Dispatcher
 import sangria.schema.{Field, _}

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbTargetModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbTargetModel.scala
@@ -11,7 +11,7 @@ import lucuma.core.`enum`.EphemerisKeyType
 import lucuma.core.math.{Coordinates, Epoch}
 import lucuma.core.math.arb.{ArbCoordinates, ArbEpoch}
 import lucuma.core.model.arb.ArbEphemerisKey
-import lucuma.core.model.{EphemerisKey, Observation, Program, Target}
+import lucuma.core.model.{EphemerisKey, Observation, Program, Target, TargetEnvironment}
 import lucuma.core.model.arb.ArbTarget
 import lucuma.core.util.arb.{ArbEnumerated, ArbGid}
 import lucuma.odb.api.model.targetModel._

--- a/modules/core/src/test/scala/lucuma/odb/api/repo/arb/ArbTables.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/repo/arb/ArbTables.scala
@@ -5,7 +5,7 @@ package lucuma.odb.api.repo
 package arb
 
 import lucuma.core.arb.ArbTime
-import lucuma.core.model.{Atom, ExecutionEvent, Observation, Program, Step, Target}
+import lucuma.core.model.{Atom, ExecutionEvent, Observation, Program, Step, Target, TargetEnvironment}
 import lucuma.odb.api.model.{AtomModel, ExecutionEventModel, InstrumentConfigModel, ObservationModel, ProgramModel, StepModel}
 import lucuma.core.util.Gid
 import lucuma.odb.api.model.SequenceModel.SequenceType.{Acquisition, Science}
@@ -13,7 +13,6 @@ import lucuma.odb.api.model.arb._
 import cats.data.{Nested, State}
 import cats.kernel.instances.order._
 import cats.syntax.all._
-import lucuma.odb.api.model.targetModel.TargetEnvironment
 import org.scalacheck._
 import org.scalacheck.cats.implicits._
 import org.scalacheck.Arbitrary.arbitrary


### PR DESCRIPTION
The `TargetEnvironment` ID was added to `lucuma-core` after it was initially created here.  This PR just switches to `lucuma-core` to be consistent with all the other ID definitions.