### PR TITLE
Remove proper motion optic

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/EditSiderealInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/EditSiderealInput.scala
@@ -51,7 +51,7 @@ final case class EditSiderealInput(
         _ <- Target.baseRA            := ra
         _ <- Target.baseDec           := dec
         _ <- Target.epoch             := epoch
-        _ <- TargetModel.properMotion := pm
+        _ <- Target.properMotion      := pm
         _ <- Target.radialVelocity    := rv
         _ <- Target.parallax          := px
         _ <- Target.magnitudes.mod(m => ms.fold(m)(_.runS(m).value))

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
@@ -3,10 +3,9 @@
 
 package lucuma.odb.api.model.targetModel
 
-import lucuma.core.math.ProperMotion
-import lucuma.core.model.{SiderealTracking, Target, TargetEnvironment}
+import lucuma.core.model.{Target, TargetEnvironment}
 import cats.Eq
-import monocle.{Focus, Lens, Optional}
+import monocle.{Focus, Lens}
 
 
 /**
@@ -36,11 +35,5 @@ trait TargetModelOptics { self: TargetModel.type =>
 
   val target: Lens[TargetModel, Target] =
     Focus[TargetModel](_.target)
-
-  // Target.properMotion is Optional[Target, ProperMotion], which makes it
-  // impossible to assign None to the ProperMotion of a SiderealTarget ?
-
-  val properMotion: Optional[Target, Option[ProperMotion]] =
-    Target.siderealTracking.andThen(SiderealTracking.properMotion)
 
 }


### PR DESCRIPTION
The `lucuma-core` version of `Target.properMotion` was updated and this project can now take advantage of it.