### PR TITLE
Sample profiles

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
@@ -17,7 +17,7 @@ import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Decoder
 import io.circe.refined._
 import io.circe.generic.semiauto._
-import lucuma.core.model.{Program, Target}
+import lucuma.core.model.{Program, SourceProfile, Target}
 import lucuma.core.optics.state.all._
 import lucuma.core.optics.syntax.lens._
 import lucuma.odb.api.model.{DatabaseState, Event, Existence, TopLevelModel, ValidatedInput}
@@ -70,7 +70,8 @@ object TargetModel extends TargetModelOptics {
   ) {
 
     def create[F[_]: Monad, T](
-      db: DatabaseState[T]
+      db:   DatabaseState[T],
+      temp: Option[SourceProfile]  // To be removed when the parameters appear in the GQL input
     )(implicit S: Stateful[F, T]): F[ValidatedInput[TargetModel]] =
 
       for {
@@ -81,7 +82,12 @@ object TargetModel extends TargetModelOptics {
           nonsidereal.map(_.toGemTarget)
         )
         tm = (i, p, t).mapN { (iʹ, _, tʹ) =>
-          TargetModel(iʹ, Existence.Present, programId, tʹ, observed = false)
+
+          // TEMP: Add the source profile if there is one
+          val withSourceProfile: Target => Target =
+            temp.fold((t: Target) => t) { p => Target.sourceProfile.replace(p) }
+
+          TargetModel(iʹ, Existence.Present, programId, withSourceProfile(tʹ), observed = false)
         }
         _ <- db.target.saveNewIfValid(tm)(_.id)
       } yield tm

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
@@ -84,9 +84,7 @@ object TargetModel extends TargetModelOptics {
         tm = (i, p, t).mapN { (iʹ, _, tʹ) =>
 
           // TEMP: Add the source profile if there is one
-          val withSourceProfile: Target => Target =
-            temp.fold((t: Target) => t) { p => Target.sourceProfile.replace(p) }
-
+          val withSourceProfile = temp.fold((t: Target) => t)(Target.sourceProfile.replace)
           TargetModel(iʹ, Existence.Present, programId, withSourceProfile(tʹ), observed = false)
         }
         _ <- db.target.saveNewIfValid(tm)(_.id)

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -91,7 +91,7 @@ object Init {
     SourceProfile.Point(
       SpectralDefinition.BandNormalized(
         UnnormalizedSED.Galaxy(GalaxySpectrum.Spiral),
-          SortedMap.from[Band, BandBrightness[Integrated]](brightnesses.map { b => b.band -> b })
+          SortedMap.from[Band, BandBrightness[Integrated]](brightnesses.fproductLeft(_.band))
       )
     )
 
@@ -128,9 +128,9 @@ object Init {
     )
 
   val targets: Either[Exception, List[(CreateSiderealInput, SourceProfile)]] =
-    targetsJson.traverse(decode[CreateSiderealInput]).map { csis =>
-      csis.zip(List(ngc5949Profile, ngc3369Profile, ngc3312Profile))
-    }
+    targetsJson.traverse(decode[CreateSiderealInput]).map(
+      _.zip(List(ngc5949Profile, ngc3369Profile, ngc3312Profile))
+    )
 
   import GmosModel.{CreateCcdReadout, CreateSouthDynamic}
   import StepConfig.CreateStepConfig


### PR DESCRIPTION
Hacks in a way to set the `SourceProfile` in the sample targets in `Init`.  I don't know whether they correspond to reality but it's good to have something set for those targets.

The source profile information will be added to the GraphQL input and the hack will be removed in a subsequent PR.