### PR TITLE
No union source profile

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
@@ -11,15 +11,14 @@ import lucuma.core.math.{BrightnessValue, Wavelength}
 import lucuma.core.math.BrightnessUnits.{Brightness, FluxDensityContinuum, Integrated, LineFlux, Surface}
 import lucuma.core.math.dimensional.{Measure, Of, Units}
 import lucuma.core.model.SpectralDefinition.{BandNormalized, EmissionLines}
-import lucuma.core.model.UnnormalizedSED.{BlackBody, CoolStarModel, Galaxy, HIIRegion, Planet, PlanetaryNebula, PowerLaw, Quasar, StellarLibrary, UserDefined}
 import lucuma.core.model.{SourceProfile, SpectralDefinition, UnnormalizedSED}
 import lucuma.core.util.Enumerated
 import lucuma.odb.api.model.targetModel.SourceProfileModel.{BandBrightnessPair, CreateBandBrightnessInput, CreateBandNormalizedInput, CreateEmissionLineInput, CreateEmissionLinesInput, CreateGaussianInput, CreateMeasureInput, CreateSourceProfileInput, CreateSpectralDefinitionInput, FluxDensityInput, UnnormalizedSedInput, WavelengthEmissionLinePair}
+import monocle.Prism
 import sangria.schema.{Field, _}
 import sangria.macros.derive._
 import sangria.marshalling.circe._
 
-import scala.reflect.ClassTag
 
 object SourceProfileSchema {
 
@@ -79,123 +78,88 @@ object SourceProfileSchema {
       "Planetary nebula spectrum"
     )
 
-  def UnnormalizedSedType: OutputType[UnnormalizedSED] =
-    UnionType(
+  def UnnormalizedSedType: ObjectType[Any, UnnormalizedSED] = {
+
+    def enumField[A, E](
+      n: String,
+      f: A => E,
+      p: Prism[UnnormalizedSED, A]
+    )(implicit ev: OutputType[E]): Field[Any, UnnormalizedSED] =
+      Field(
+        name       = n,
+        fieldType  = OptionType(ev),
+        resolve    = c => p.getOption(c.value).map(f)
+      )
+
+    import UnnormalizedSED._
+
+    ObjectType(
       name        = "UnnormalizedSed",
-      description = "Un-normalized spectral energy distribution".some,
-      types       = List(
-        StellarLibraryType,
-        CoolStarModelType,
-        GalaxyType,
-        PlanetType,
-        QuasarType,
-        HiiRegionType,
-        PlanetaryNebulaType,
-        PowerLawType,
-        BlackBodyType,
-        UserDefinedType
-      )
-    ).mapValue[UnnormalizedSED](identity)
-
-  private def SpectrumEnumBasedSed[T: ClassTag, E](
-    name:        String,
-    enumType:    EnumType[E],
-    extractEnum: T => E
-  ): ObjectType[Any, T] =
-    ObjectType(
-      name        = name,
+      description = "Un-normalized spectral energy distribution",
       fieldsFn    = () => fields(
 
+        enumField[StellarLibrary, StellarLibrarySpectrum](
+          "stellarLibrary",
+          _.librarySpectrum,
+          stellarLibrary
+        ),
+
+        enumField[CoolStarModel, CoolStarTemperature](
+          "coolStar",
+          _.temperature,
+          coolStarModel
+        ),
+
+        enumField[Galaxy, GalaxySpectrum](
+          "galaxy",
+          _.galaxySpectrum,
+          galaxy
+        ),
+
+        enumField[Planet, PlanetSpectrum](
+          "planet",
+          _.planetSpectrum,
+          planet
+        ),
+
+        enumField[Quasar, QuasarSpectrum](
+          "quasar",
+          _.quasarSpectrum,
+          quasar
+        ),
+
+        enumField[HIIRegion, HIIRegionSpectrum](
+          "hiiRegion",
+          _.hiiRegionSpectrum,
+          hiiRegion
+        ),
+
+        enumField[PlanetaryNebula, PlanetaryNebulaSpectrum](
+          "planetaryNebula",
+          _.planetaryNebulaSpectrum,
+          planetaryNebula
+        ),
+
         Field(
-          name        = "spectrum",
-          fieldType   = enumType,
-          resolve     = c => extractEnum(c.value)
+          name      = "powerLaw",
+          fieldType = OptionType(BigDecimalType),
+          resolve   = c => powerLaw.getOption(c.value).map(_.index)
+        ),
+
+        Field(
+          name      = "blackBodyTempK",
+          fieldType = OptionType(PosBigDecimalType),
+          resolve   = c => blackBody.getOption(c.value).map(_.temperature.value)
+        ),
+
+        Field(
+          name      = "fluxDensities",
+          fieldType = OptionType(ListType(FluxDensityEntryType)),
+          resolve   = c => userDefined.getOption(c.value).map(_.fluxDensities.toNel.toList)
         )
       )
     )
-
-  val StellarLibraryType: ObjectType[Any, StellarLibrary]  =
-    SpectrumEnumBasedSed[StellarLibrary, StellarLibrarySpectrum](
-      "StellarLibrary",
-      EnumTypeStellarLibrarySpectrum,
-      _.librarySpectrum
-    )
-
-  val CoolStarModelType: ObjectType[Any, CoolStarModel] =
-    ObjectType(
-      name        = "CoolStarModel",
-      fieldsFn    = () => fields(
-
-        Field(
-          name      = "temperature",
-          fieldType = EnumTypeCoolStarTemperature,
-          resolve   = _.value.temperature
-        )
-
-      )
-    )
-
-  val GalaxyType: ObjectType[Any, Galaxy]  =
-    SpectrumEnumBasedSed[Galaxy, GalaxySpectrum](
-      "Galaxy",
-      EnumTypeGalaxySpectrum,
-      _.galaxySpectrum
-    )
-
-  val PlanetType: ObjectType[Any, Planet]  =
-    SpectrumEnumBasedSed[Planet, PlanetSpectrum](
-      "Planet",
-      EnumTypePlanetSpectrum,
-      _.planetSpectrum
-    )
-
-  val QuasarType: ObjectType[Any, Quasar]  =
-    SpectrumEnumBasedSed[Quasar, QuasarSpectrum](
-      "Quasar",
-      EnumTypeQuasarSpectrum,
-      _.quasarSpectrum
-    )
-
-  val HiiRegionType: ObjectType[Any, HIIRegion]  =
-    SpectrumEnumBasedSed[HIIRegion, HIIRegionSpectrum](
-      "HiiRegion",
-      EnumTypeHiiRegionSpectrum,
-      _.hiiRegionSpectrum
-    )
-
-  val PlanetaryNebulaType: ObjectType[Any, PlanetaryNebula] =
-    SpectrumEnumBasedSed[PlanetaryNebula, PlanetaryNebulaSpectrum](
-      "PlanetaryNebula",
-      EnumTypePlanetaryNebulaSpectrum,
-      _.planetaryNebulaSpectrum
-    )
-
-  val PowerLawType: ObjectType[Any, PowerLaw] =
-    ObjectType(
-      name        = "PowerLaw",
-      description = "Power law SED",
-      fieldsFn    = () => fields(
-        Field(
-          name        = "index",
-          fieldType   = BigDecimalType,
-          resolve     = _.value.index
-        )
-      )
-    )
-
-  val BlackBodyType: ObjectType[Any, BlackBody] =
-    ObjectType(
-      name        = "BlackBody",
-      description = "Black body SED",
-      fieldsFn    = () => fields(
-        Field(
-          name        = "temperature",
-          description = "Kelvin".some,
-          fieldType   = PosBigDecimalType,
-          resolve     = _.value.temperature.value
-        )
-      )
-    )
+  }
 
   val FluxDensityEntryType: ObjectType[Any, (Wavelength, PosBigDecimal)] =
     ObjectType(
@@ -209,22 +173,9 @@ object SourceProfileSchema {
         ),
 
         Field(
-          name      = "value",
+          name      = "density",
           fieldType = PosBigDecimalType,
           resolve   = _.value._2
-        )
-      )
-    )
-
-  val UserDefinedType: ObjectType[Any, UserDefined] =
-    ObjectType(
-      name        = "UserDefined",
-      description = "User defined SED",
-      fieldsFn    = () => fields(
-        Field(
-          name        = "fluxDensities",
-          fieldType   = ListType(FluxDensityEntryType),
-          resolve     = _.value.fluxDensities.toNel.toList
         )
       )
     )
@@ -740,4 +691,8 @@ object SourceProfileSchema {
 
   val ArgumentCreateBandNormalizedIntegrated: Argument[CreateBandNormalizedInput[Integrated]] =
     InputObjectCreateBandNormalizedIntegrated.argument("mag", "magnitude")
+
+  val ArgumentCreateSourceProfile: Argument[CreateSourceProfileInput] =
+    InputObjectCreateSourceProfile.argument("sourceProfile", "source profile description")
+
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
@@ -95,7 +95,7 @@ object SourceProfileSchema {
 
     ObjectType(
       name        = "UnnormalizedSed",
-      description = "Un-normalized spectral energy distribution",
+      description = "Un-normalized spectral energy distribution.  Exactly one of the definitions will be non-null.",
       fieldsFn    = () => fields(
 
         enumField[StellarLibrary, StellarLibrarySpectrum](
@@ -484,7 +484,7 @@ object SourceProfileSchema {
   ): ObjectType[Any, SpectralDefinition[T]] =
     ObjectType(
       name         = s"SpectralDefinition${unitCategoryName.capitalize}",
-      description  = s"Spectral definition ${unitCategoryName.toLowerCase}",
+      description  = s"Spectral definition ${unitCategoryName.toLowerCase}.  Exactly one of the fields will be defined.",
       fieldsFn     = () => spectralDefinitionFields[SpectralDefinition[T], T](identity, bandNormalizedType, emissionLinesType)
     )
 
@@ -505,7 +505,7 @@ object SourceProfileSchema {
   val GaussianType: ObjectType[Any, SourceProfile.Gaussian] =
     ObjectType[Any, SourceProfile.Gaussian](
       name        = "GaussianSource",
-      description = "Gaussian source",
+      description = "Gaussian source, one of bandNormalized and emissionLines will be defined.",
       fieldsFn    = () =>
 
         Field(
@@ -523,7 +523,7 @@ object SourceProfileSchema {
   val SourceProfileType: ObjectType[Any, SourceProfile] =
     ObjectType(
       name        = "SourceProfile",
-      description = "source profile",
+      description = "Source profile, exactly one of the fields will be defined",
       fieldsFn    = () => fields(
 
         Field(


### PR DESCRIPTION
I'm not sure where this falls on the spectrum from dumb to good so I'd like some input.  The idea is to make the source profile query output match the JSON input required to create it.  Eventually this idea would be applied to the entire `Target` type.

So practically speaking this means removing all the GraphQL `union`s that would otherwise be present.  Instead all the possible values turn into fields with `Option` values.  A few tradeoffs occur to me:

### Advantages

* If what you get from a query matches the form and content of what you need to do to create an object, then it makes copy/paste/edit script or playground sessions easier?  
* You don't need to see the input type if you know the output type and vice-versa.
* Less verbose / cumbersome than the `... on Whatever` query syntax

### Disadvantages

* You can not tell that exactly one of the cases will always be present.  `SourceProfile` for example would need option `point`, `uniform` and `gaussian` fields and exactly one of them would be present, though there's no way to express that in the SDL.  
* The `__typename` field won't help with parsing query results.

### Example

Ignoring the brightnesses for conciseness, instead of

```
sourceProfile {
  ... on PointSource {
    spectralDefinition {
      ... on BandNormalizedIntegrated {
        sed {
          ... on Galaxy {
            spectrum
          }
        }
      }
    }
  }
}
```

you could write 

```
sourceProfile {
  point {
     bandNormalized {
       sed {
         galaxy
       }
     }
  }
}
```

and the output looks like the values you need for input 

```
"sourceProfile": {  
  "point": {
    "bandNormalized": {
      "sed": {
        "galaxy": "ELLIPTICAL"
      }
    }
  }
}
```

Of course for a random target it may not be `point`/`bandNormalized`/`galaxy` in which case you get `null` values at the point where it doesn't match.  For example, if this were a uniform source you'd see

```
"sourceProfile": {
  "point": null
}
```

This doesn't seem any worse than when `union`s are used.  If you want to be prepared for anything you have to expand all the cases either way.

So, is this dumb?