### PR TITLE
Editable source profile (Part 1)

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/syntax/LensOps.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/syntax/LensOps.scala
@@ -12,6 +12,9 @@ final class LensOps[S, A](val self: Lens[S, A]) extends AnyVal {
   def transform(st: StateT[EitherInput, A, Unit]): StateT[EitherInput, S, Unit] =
     st.transformS[S](self.get, (s, a) => self.replace(a)(s))
 
+  def :<(st: Option[StateT[EitherInput, A, Unit]]): StateT[EitherInput, S, Unit] =
+    st.fold(StateT.empty[EitherInput, S, Unit])(transform)
+
   def toState: StateT[EitherInput, S, A] =
     StateT(s => Right((s, self.get(s))))
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/NonsiderealInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/NonsiderealInput.scala
@@ -47,7 +47,7 @@ final case class NonsiderealInput(
     name:          NonEmptyString,
     sourceProfile: SourceProfileInput
   ): ValidatedInput[Target] =
-    (create, sourceProfile.toSourceProfile).mapN { (key, profile) =>
+    (create, sourceProfile.create).mapN { (key, profile) =>
       Target.Nonsidereal(name, key, profile)
     }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/NonsiderealInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/NonsiderealInput.scala
@@ -17,7 +17,7 @@ import io.circe.refined._
 import lucuma.core.`enum`.EphemerisKeyType
 import lucuma.core.model.{EphemerisKey, Target}
 import lucuma.odb.api.model.{EditorInput, EitherInput, InputError, ValidatedInput}
-import lucuma.odb.api.model.targetModel.SourceProfileModel.CreateSourceProfileInput
+import lucuma.odb.api.model.targetModel.SourceProfileModel.SourceProfileInput
 
 
 /**
@@ -45,7 +45,7 @@ final case class NonsiderealInput(
 
   def createTarget(
     name:          NonEmptyString,
-    sourceProfile: CreateSourceProfileInput
+    sourceProfile: SourceProfileInput
   ): ValidatedInput[Target] =
     (create, sourceProfile.toSourceProfile).mapN { (key, profile) =>
       Target.Nonsidereal(name, key, profile)

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SiderealInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SiderealInput.scala
@@ -59,7 +59,7 @@ final case class SiderealInput(
     name:          NonEmptyString,
     sourceProfile: SourceProfileInput
   ): ValidatedInput[Target] =
-    (create, sourceProfile.toSourceProfile).mapN { case ((track, catInfo), profile) =>
+    (create, sourceProfile.create).mapN { case ((track, catInfo), profile) =>
       Target.Sidereal(name, track, profile, catInfo)
     }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SiderealInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SiderealInput.scala
@@ -18,7 +18,7 @@ import lucuma.odb.api.model.json.target._
 import lucuma.odb.api.model.syntax.input._
 import lucuma.odb.api.model.syntax.lens._
 import lucuma.odb.api.model.syntax.optional._
-import lucuma.odb.api.model.targetModel.SourceProfileModel.CreateSourceProfileInput
+import lucuma.odb.api.model.targetModel.SourceProfileModel.SourceProfileInput
 import monocle.{Focus, Lens, Optional}
 
 
@@ -57,7 +57,7 @@ final case class SiderealInput(
 
   def createTarget(
     name:          NonEmptyString,
-    sourceProfile: CreateSourceProfileInput
+    sourceProfile: SourceProfileInput
   ): ValidatedInput[Target] =
     (create, sourceProfile.toSourceProfile).mapN { case ((track, catInfo), profile) =>
       Target.Sidereal(name, track, profile, catInfo)

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SourceProfileModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SourceProfileModel.scala
@@ -11,6 +11,8 @@ import cats.syntax.functor._
 import cats.syntax.option._
 import cats.syntax.traverse._
 import cats.syntax.validated._
+import clue.data.Input
+import clue.data.syntax._
 import coulomb.Quantity
 import coulomb.si.Kelvin
 import eu.timepit.refined.cats._
@@ -424,44 +426,48 @@ object SourceProfileModel {
 
   }
 
-  final case class CreateSourceProfileInput(
-    point:    Option[CreateSpectralDefinitionInput[Integrated]],
-    uniform:  Option[CreateSpectralDefinitionInput[Surface]],
-    gaussian: Option[CreateGaussianInput]
+  final case class SourceProfileInput(
+    point:    Input[CreateSpectralDefinitionInput[Integrated]] = Input.ignore,
+    uniform:  Input[CreateSpectralDefinitionInput[Surface]]    = Input.ignore,
+    gaussian: Input[CreateGaussianInput]                       = Input.ignore
   ) {
 
     def toSourceProfile: ValidatedInput[SourceProfile] =
       ValidatedInput.requireOne("sourceProfile",
-        point.map(_.toSpectralDefinition.map(SourceProfile.Point(_))),
-        uniform.map(_.toSpectralDefinition.map(SourceProfile.Uniform(_))),
-        gaussian.map(_.toGaussian)
+        point.map(_.toSpectralDefinition.map(SourceProfile.Point(_))).toOption,
+        uniform.map(_.toSpectralDefinition.map(SourceProfile.Uniform(_))).toOption,
+        gaussian.map(_.toGaussian).toOption
       )
 
   }
 
-  object CreateSourceProfileInput {
+  object SourceProfileInput {
 
-    implicit val DecoderCreateSourceProfileInput: Decoder[CreateSourceProfileInput] =
-      deriveDecoder[CreateSourceProfileInput]
+    import io.circe.generic.extras.semiauto._
+    import io.circe.generic.extras.Configuration
+    implicit val customConfig: Configuration = Configuration.default.withDefaults
 
-    implicit val EqCreateSourceProfileInput: Eq[CreateSourceProfileInput] =
+    implicit val DecoderSourceProfileInput: Decoder[SourceProfileInput] =
+      deriveConfiguredDecoder[SourceProfileInput]
+
+    implicit val EqSourceProfileInput: Eq[SourceProfileInput] =
       Eq.by { a => (
         a.point,
         a.uniform,
         a.gaussian
       )}
 
-    val Empty: CreateSourceProfileInput =
-      CreateSourceProfileInput(None, None, None)
+    val Empty: SourceProfileInput =
+      SourceProfileInput(Input.ignore, Input.ignore, Input.ignore)
 
-    def point(sd: CreateSpectralDefinitionInput[Integrated]): CreateSourceProfileInput =
-      Empty.copy(point = sd.some)
+    def point(sd: CreateSpectralDefinitionInput[Integrated]): SourceProfileInput =
+      Empty.copy(point = sd.assign)
 
-    def uniform(sd: CreateSpectralDefinitionInput[Surface]): CreateSourceProfileInput =
-      Empty.copy(uniform = sd.some)
+    def uniform(sd: CreateSpectralDefinitionInput[Surface]): SourceProfileInput =
+      Empty.copy(uniform = sd.assign)
 
-    def gaussian(g: CreateGaussianInput): CreateSourceProfileInput =
-      Empty.copy(gaussian = g.some)
+    def gaussian(g: CreateGaussianInput): SourceProfileInput =
+      Empty.copy(gaussian = g.assign)
 
   }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
@@ -4,7 +4,7 @@
 package lucuma.odb.api.model.targetModel
 
 import cats.{Eq, Monad, Order}
-import cats.data.{EitherNec, StateT}
+import cats.data.StateT
 import cats.mtl.Stateful
 import cats.syntax.apply._
 import cats.syntax.flatMap._
@@ -16,8 +16,8 @@ import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Decoder
 import io.circe.generic.semiauto._
 import io.circe.refined._
-import lucuma.core.model.{Program, Target}
-import lucuma.odb.api.model.{DatabaseState, Event, Existence, InputError, TopLevelModel, ValidatedInput}
+import lucuma.core.model.{Program, SourceProfile, Target}
+import lucuma.odb.api.model.{DatabaseState, EitherInput, Event, Existence, TopLevelModel, ValidatedInput}
 import lucuma.odb.api.model.syntax.input._
 import lucuma.odb.api.model.syntax.lens._
 import lucuma.odb.api.model.targetModel.SourceProfileModel.SourceProfileInput
@@ -122,31 +122,31 @@ object TargetModel extends TargetModelOptics {
   }
 
   final case class Edit(
-    targetId:    Target.Id,
-    existence:   Input[Existence]         = Input.ignore,
-    name:        Input[NonEmptyString]    = Input.ignore,
-    sidereal:    Option[SiderealInput]    = None,
-    nonsidereal: Option[NonsiderealInput] = None
+    targetId:      Target.Id,
+    existence:     Input[Existence]          = Input.ignore,
+    name:          Input[NonEmptyString]     = Input.ignore,
+    sidereal:      Option[SiderealInput]     = None,
+    nonsidereal:   Option[NonsiderealInput]  = None,
+    sourceProfile: Input[SourceProfileInput] = Input.ignore
   ) {
 
-    val editor: StateT[EitherNec[InputError, *], TargetModel, Unit] = {
+    val editor: StateT[EitherInput, TargetModel, Unit] = {
 
       val validArgs =
         (
-          existence.validateIsNotNull("existence"),
-          name     .validateIsNotNull("name")
+          existence    .validateIsNotNull("existence"),
+          name         .validateIsNotNull("name"),
+          sourceProfile.validateIsNotNull("sourceProfile")
         ).tupled.toEither
-
-      def editTarget(s: Option[StateT[EitherNec[InputError, *], Target, Unit]]): StateT[EitherNec[InputError, *], TargetModel, Unit] =
-        TargetModel.target.transform(s.getOrElse(StateT.empty[EitherNec[InputError, *], Target, Unit]))
 
       for {
         args <- StateT.liftF(validArgs)
-        (e, n) = args
-        _ <- TargetModel.existence := e
-        _ <- TargetModel.name      := n
-        _ <- editTarget(sidereal.map(_.targetEditor))
-        _ <- editTarget(nonsidereal.map(_.targetEditor))
+        (e, n, p) = args
+        _ <- TargetModel.existence     := e
+        _ <- TargetModel.name          := n
+        _ <- TargetModel.target        :< sidereal.map(_.targetEditor)
+        _ <- TargetModel.target        :< nonsidereal.map(_.targetEditor)
+        _ <- TargetModel.sourceProfile :< p.map(_.edit)
       } yield ()
     }
 
@@ -202,6 +202,9 @@ trait TargetModelOptics { self: TargetModel.type =>
 
   val name: Lens[TargetModel, NonEmptyString] =
     target.andThen(Target.name)
+
+  val sourceProfile: Lens[TargetModel, SourceProfile] =
+    target.andThen(Target.sourceProfile)
 
   val observed: Lens[TargetModel, Boolean] =
     Focus[TargetModel](_.observed)

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
@@ -20,7 +20,7 @@ import lucuma.core.model.{Program, Target}
 import lucuma.odb.api.model.{DatabaseState, Event, Existence, InputError, TopLevelModel, ValidatedInput}
 import lucuma.odb.api.model.syntax.input._
 import lucuma.odb.api.model.syntax.lens._
-import lucuma.odb.api.model.targetModel.SourceProfileModel.CreateSourceProfileInput
+import lucuma.odb.api.model.targetModel.SourceProfileModel.SourceProfileInput
 import monocle.{Focus, Lens}
 
 
@@ -67,7 +67,7 @@ object TargetModel extends TargetModelOptics {
     name:          NonEmptyString,
     sidereal:      Option[SiderealInput],
     nonsidereal:   Option[NonsiderealInput],
-    sourceProfile: CreateSourceProfileInput
+    sourceProfile: SourceProfileInput
   ) {
 
     def create[F[_]: Monad, T](
@@ -96,7 +96,7 @@ object TargetModel extends TargetModelOptics {
       targetId:      Option[Target.Id],
       name:          NonEmptyString,
       input:         SiderealInput,
-      sourceProfile: CreateSourceProfileInput
+      sourceProfile: SourceProfileInput
     ): Create =
       Create(targetId, name, input.some, None, sourceProfile)
 
@@ -104,7 +104,7 @@ object TargetModel extends TargetModelOptics {
       targetId:      Option[Target.Id],
       name:          NonEmptyString,
       input:         NonsiderealInput,
-      sourceProfile: CreateSourceProfileInput
+      sourceProfile: SourceProfileInput
     ): Create =
       Create(targetId, name, None, input.some, sourceProfile)
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
@@ -680,7 +680,7 @@ object SourceProfileSchema {
       InputObjectTypeDescription("Create a gaussian source")
     )
 
-  implicit val InputObjectCreateSourceProfile: InputObjectType[SourceProfileInput] =
+  implicit val InputObjectSourceProfile: InputObjectType[SourceProfileInput] =
     deriveInputObjectType(
       InputObjectTypeName("SourceProfileInput"),
       InputObjectTypeDescription("Create or edit a source profile"),
@@ -697,7 +697,7 @@ object SourceProfileSchema {
   val ArgumentCreateBandNormalizedIntegrated: Argument[CreateBandNormalizedInput[Integrated]] =
     InputObjectCreateBandNormalizedIntegrated.argument("mag", "magnitude")
 
-  val ArgumentCreateSourceProfile: Argument[SourceProfileInput] =
-    InputObjectCreateSourceProfile.argument("sourceProfile", "source profile description")
+  val ArgumentSourceProfile: Argument[SourceProfileInput] =
+    InputObjectSourceProfile.argument("sourceProfile", "source profile description")
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
@@ -13,7 +13,8 @@ import lucuma.core.math.dimensional.{Measure, Of, Units}
 import lucuma.core.model.SpectralDefinition.{BandNormalized, EmissionLines}
 import lucuma.core.model.{SourceProfile, SpectralDefinition, UnnormalizedSED}
 import lucuma.core.util.Enumerated
-import lucuma.odb.api.model.targetModel.SourceProfileModel.{BandBrightnessPair, CreateBandBrightnessInput, CreateBandNormalizedInput, CreateEmissionLineInput, CreateEmissionLinesInput, CreateGaussianInput, CreateMeasureInput, CreateSourceProfileInput, CreateSpectralDefinitionInput, FluxDensityInput, UnnormalizedSedInput, WavelengthEmissionLinePair}
+import lucuma.odb.api.model.targetModel.SourceProfileModel.{BandBrightnessPair, CreateBandBrightnessInput, CreateBandNormalizedInput, CreateEmissionLineInput, CreateEmissionLinesInput, CreateGaussianInput, CreateMeasureInput, CreateSpectralDefinitionInput, FluxDensityInput, SourceProfileInput, UnnormalizedSedInput, WavelengthEmissionLinePair}
+import lucuma.odb.api.schema.syntax.inputtype._
 import monocle.Prism
 import sangria.schema.{Field, _}
 import sangria.macros.derive._
@@ -679,10 +680,14 @@ object SourceProfileSchema {
       InputObjectTypeDescription("Create a gaussian source")
     )
 
-  implicit val InputObjectCreateSourceProfile: InputObjectType[CreateSourceProfileInput] =
+  implicit val InputObjectCreateSourceProfile: InputObjectType[SourceProfileInput] =
     deriveInputObjectType(
-      InputObjectTypeName("CreateSourceProfile"),
-      InputObjectTypeDescription("Create a source profile")
+      InputObjectTypeName("SourceProfileInput"),
+      InputObjectTypeDescription("Create or edit a source profile"),
+
+      ReplaceInputField("point",    InputObjectCreateSpectralDefinitionIntegrated.notNullableField("point")),
+      ReplaceInputField("uniform",  InputObjectCreateSpectralDefinitionSurface.notNullableField("uniform")),
+      ReplaceInputField("gaussian", InputObjectCreateGaussian.notNullableField("gaussian"))
     )
 
   // Arguments
@@ -692,7 +697,7 @@ object SourceProfileSchema {
   val ArgumentCreateBandNormalizedIntegrated: Argument[CreateBandNormalizedInput[Integrated]] =
     InputObjectCreateBandNormalizedIntegrated.argument("mag", "magnitude")
 
-  val ArgumentCreateSourceProfile: Argument[CreateSourceProfileInput] =
+  val ArgumentCreateSourceProfile: Argument[SourceProfileInput] =
     InputObjectCreateSourceProfile.argument("sourceProfile", "source profile description")
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
@@ -24,7 +24,7 @@ trait TargetMutation extends TargetScalars {
   import GeneralSchema.{EnumTypeExistence, NonEmptyStringType}
   import NumericUnitsSchema._
   import ProgramSchema.ProgramIdArgument
-  import SourceProfileSchema.InputObjectCreateSourceProfile
+  import SourceProfileSchema.InputObjectSourceProfile
   import TargetSchema.{EnumTypeCatalogName, EphemerisKeyTypeEnumType, ArgumentTargetId, TargetIdType, TargetType}
 
   import syntax.inputtype._
@@ -149,22 +149,26 @@ trait TargetMutation extends TargetScalars {
 
   implicit val InputObjectEditTargetInput: InputObjectType[TargetModel.Edit] = {
 
-      // Not able to derive this for some reason, TBD.
+    // Not able to derive this for some reason, TBD.
 //    deriveInputObjectType[TargetModel.Edit](
 //      InputObjectTypeName("EditTargetInput"),
 //      InputObjectTypeDescription("Single target edit options"),
-//      ReplaceInputField("existence",  EnumTypeExistence.notNullableField("existence"))
+//
+//      ReplaceInputField("existence",     EnumTypeExistence.notNullableField("existence")),
+//      ReplaceInputField("name",          NonEmptyStringType.notNullableField("name")),
+//      ReplaceInputField("sourceProfile", InputObjectSourceProfile.notNullableField("sourceProfile"))
 //    )
 
     InputObjectType[TargetModel.Edit](
       "EditTargetInput",
       "Single target edit options",
       List(
-        InputField("targetId",    TargetIdType),
-        InputField("existence",   OptionInputType(EnumTypeExistence)),
-        InputField("name",        OptionInputType(NonEmptyStringType)),
-        InputField("sidereal",    OptionInputType(InputObjectTypeSidereal)),
-        InputField("nonsidereal", OptionInputType(InputObjectTypeNonsidereal))
+        InputField("targetId",      TargetIdType),
+        InputField("existence",     OptionInputType(EnumTypeExistence)),
+        InputField("name",          OptionInputType(NonEmptyStringType)),
+        InputField("sidereal",      OptionInputType(InputObjectTypeSidereal)),
+        InputField("nonsidereal",   OptionInputType(InputObjectTypeNonsidereal)),
+        InputField("sourceProfile", OptionInputType(InputObjectSourceProfile))
       )
     )
   }

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
@@ -4,6 +4,7 @@
 package lucuma.odb.api.model
 package arb
 
+import clue.data.Input
 import eu.timepit.refined.types.all.PosBigDecimal
 import lucuma.core.`enum`.{Band, CoolStarTemperature, GalaxySpectrum, HIIRegionSpectrum, PlanetSpectrum, PlanetaryNebulaSpectrum, StellarLibrarySpectrum}
 import lucuma.core.math.BrightnessUnits.{Brightness, FluxDensityContinuum, Integrated, LineFlux, Surface}
@@ -19,6 +20,7 @@ trait ArbSourceProfileModel {
 
   import ArbAngleModel._
   import ArbEnumerated._
+  import ArbInput._
   import ArbRefined._
   import ArbWavelengthModel._
 
@@ -234,20 +236,20 @@ trait ArbSourceProfileModel {
       in.spectralDefinition
     )}
 
-  implicit val arbCreateSourceProfileInput: Arbitrary[CreateSourceProfileInput] =
+  implicit val arbSourceProfileInput: Arbitrary[SourceProfileInput] =
     Arbitrary {
       Gen.oneOf(
-        arbitrary[CreateSpectralDefinitionInput[Integrated]].map(CreateSourceProfileInput.point),
-        arbitrary[CreateSpectralDefinitionInput[Surface]].map(CreateSourceProfileInput.uniform),
-        arbitrary[CreateGaussianInput].map(CreateSourceProfileInput.gaussian)
+        arbitrary[CreateSpectralDefinitionInput[Integrated]].map(SourceProfileInput.point),
+        arbitrary[CreateSpectralDefinitionInput[Surface]].map(SourceProfileInput.uniform),
+        arbitrary[CreateGaussianInput].map(SourceProfileInput.gaussian)
       )
     }
 
-  implicit val cogCreateSourceProfileInput: Cogen[CreateSourceProfileInput] =
+  implicit val cogSourceProfileInput: Cogen[SourceProfileInput] =
     Cogen[(
-      Option[CreateSpectralDefinitionInput[Integrated]],
-      Option[CreateSpectralDefinitionInput[Surface]],
-      Option[CreateGaussianInput]
+      Input[CreateSpectralDefinitionInput[Integrated]],
+      Input[CreateSpectralDefinitionInput[Surface]],
+      Input[CreateGaussianInput]
     )].contramap { in => (
       in.point,
       in.uniform,

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbTargetModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbTargetModel.scala
@@ -14,7 +14,7 @@ import lucuma.core.math.arb.{ArbCoordinates, ArbEpoch}
 import lucuma.core.model.{Program, Target}
 import lucuma.core.model.arb.ArbTarget
 import lucuma.core.util.arb.{ArbEnumerated, ArbGid}
-import lucuma.odb.api.model.targetModel.SourceProfileModel.CreateSourceProfileInput
+import lucuma.odb.api.model.targetModel.SourceProfileModel.SourceProfileInput
 import lucuma.odb.api.model.targetModel._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck._
@@ -153,7 +153,7 @@ trait ArbTargetModel {
         m <- arbitrary[NonEmptyString]
         s <- arbitrary[Option[SiderealInput]]
         n <- arbitrary[Option[NonsiderealInput]]
-        p <- arbitrary[CreateSourceProfileInput]
+        p <- arbitrary[SourceProfileInput]
       } yield TargetModel.Create(t, m, s, n, p)
     }
 
@@ -163,7 +163,7 @@ trait ArbTargetModel {
       String,
       Option[SiderealInput],
       Option[NonsiderealInput],
-      CreateSourceProfileInput
+      SourceProfileInput
     )].contramap { a => (
       a.targetId,
       a.name.value,


### PR DESCRIPTION
Swaps `CreateSourceProfileInput` for `SourceProfileInput` which will be used for both creating and editing.  Adds a `sourceProfile` field to the target editor.  At the moment, you have to replace the entire source profile if you want to replace any part of it.  That will be addressed in the next PR, when it comes.