### PR TITLE
Editable source profile (Part 2)

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/EditorInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/EditorInput.scala
@@ -4,6 +4,14 @@
 package lucuma.odb.api.model
 
 import cats.data.StateT
+import cats.syntax.either._
+import clue.data.Input
+import lucuma.odb.api.model.syntax.prism._
+import monocle.Prism
+
+import scala.reflect.ClassTag
+//import scala.reflect.api._
+//import scala.reflect.runtime.universe._
 
 /**
  * Describes how to validate arguments and create a new A or else validate
@@ -11,10 +19,91 @@ import cats.data.StateT
  *
  * @tparam A type of the editing target
  */
-trait EditorInput[A] {
+trait EditorInput[A] { self =>
 
   def create: ValidatedInput[A]
 
   def edit: StateT[EitherInput, A, Unit]
+
+  def imap[B](f: A => B, g: B => A): EditorInput[B] =
+
+    new EditorInput[B] {
+      override def create: ValidatedInput[B] =
+        self.create.map(f)
+
+      override def edit: StateT[EitherInput, B, Unit] =
+        self.edit.transformS(g, (_, a) => f(a))
+    }
+
+}
+
+object EditorInput {
+
+  def editOneOf[S, A1 <: S, A2 <: S](
+    in1: (String, Input[EditorInput[A1]], Prism[S, A1]),
+    in2: (String, Input[EditorInput[A2]], Prism[S, A2]),
+  )(implicit ev1: ClassTag[A1], ev2: ClassTag[A2]): StateT[EitherInput, S, Unit] = {
+
+    def fold(
+      a1: StateT[EitherInput, S, Unit],
+      a2: StateT[EitherInput, S, Unit]
+    ): StateT[EitherInput, S, Unit] =
+      StateT.get[EitherInput, S].flatMap {
+        case _: A1 => a1
+        case _: A2 => a2
+        case _     => StateT.setF(InputError.fromMessage(s"Unexpected type, not one of $ev1 or $ev2").leftNec)
+      }
+
+    val (name1, input1, prism1) = in1
+    val (name2, input2, prism2) = in2
+
+    (input1.toOption, input2.toOption) match {
+      case (Some(a1), None    ) =>
+        fold(prism1.editOrIgnore(a1), prism1.create(a1))
+
+      case (None,     Some(a2)) =>
+        fold(prism2.create(a2), prism2.editOrIgnore(a2))
+
+      case _                    =>
+        StateT.setF(InputError.fromMessage(s"""exactly one of "$name1" or "$name2" must be set """).leftNec)
+    }
+  }
+
+  def editOneOf[S, A1 <: S, A2 <: S, A3 <: S](
+    in1: (String, Input[EditorInput[A1]], Prism[S, A1]),
+    in2: (String, Input[EditorInput[A2]], Prism[S, A2]),
+    in3: (String, Input[EditorInput[A3]], Prism[S, A3])
+  )(implicit ev1: ClassTag[A1], ev2: ClassTag[A2], ev3: ClassTag[A3]): StateT[EitherInput, S, Unit] = {
+
+    def fold(
+      a1: StateT[EitherInput, S, Unit],
+      a2: StateT[EitherInput, S, Unit],
+      a3: StateT[EitherInput, S, Unit]
+    ): StateT[EitherInput, S, Unit] =
+      StateT.get[EitherInput, S].flatMap {
+        case _: A1 => a1
+        case _: A2 => a2
+        case _: A3 => a3
+        case _     => StateT.setF(InputError.fromMessage(s"Unexpected type, not one of $ev1, $ev2 or $ev3").leftNec)
+      }
+
+    val (name1, input1, prism1) = in1
+    val (name2, input2, prism2) = in2
+    val (name3, input3, prism3) = in3
+
+    (input1.toOption, input2.toOption, input3.toOption) match {
+      case (Some(a1), None,     None    ) =>
+        fold(prism1.editOrIgnore(a1), prism1.create(a1), prism1.create(a1))
+
+      case (None,     Some(a2), None    ) =>
+        fold(prism2.create(a2), prism2.editOrIgnore(a2), prism2.create(a2))
+
+      case (None,     None,     Some(a3)) =>
+        fold(prism3.create(a3), prism3.create(a3), prism3.editOrIgnore(a3))
+
+      case _                              =>
+        StateT.setF(InputError.fromMessage(s"""exactly one of "$name1", "$name2" or $name3" must be set """).leftNec)
+    }
+  }
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/EditorInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/EditorInput.scala
@@ -65,8 +65,8 @@ object EditorInput {
   )(implicit ev1: ClassTag[A1], ev2: ClassTag[A2]): StateT[EitherInput, S, Unit] = {
 
     def fold(
-      a1: StateT[EitherInput, S, Unit],
-      a2: StateT[EitherInput, S, Unit]
+      a1: => StateT[EitherInput, S, Unit],
+      a2: => StateT[EitherInput, S, Unit]
     ): StateT[EitherInput, S, Unit] =
       StateT.get[EitherInput, S].flatMap {
         case _: A1 => a1

--- a/modules/core/src/main/scala/lucuma/odb/api/model/EditorInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/EditorInput.scala
@@ -10,8 +10,6 @@ import lucuma.odb.api.model.syntax.prism._
 import monocle.Prism
 
 import scala.reflect.ClassTag
-//import scala.reflect.api._
-//import scala.reflect.runtime.universe._
 
 /**
  * Describes how to validate arguments and create a new A or else validate
@@ -39,6 +37,24 @@ trait EditorInput[A] { self =>
 
 object EditorInput {
 
+  /**
+   * Provides an editor of a sum type `S` with two mutually exclusive options
+   * `A1` and `A2`.  When the existing object is an `A1`, an edit for `A1` may
+   * be used (which implies only supplying arguments that need to change) but
+   * to switch to an `A2` requires creation (which implies specifying all
+   * required `A2` inputs).  Similarly when the existing object is an instance
+   * of `A2` an editor for `A2` is used but to switch to `A1` requires
+   * creation.
+   *
+   * @param in1 triplet containing name of the input field, the input itself, and a prism for editing
+   * @param in2 triplet containing name of the input field, the input itself, and a prism for editing
+   *
+   * @tparam S sum type
+   * @tparam A1 type of option 1
+   * @tparam A2 type of option 2
+   *
+   * @return editor of the sum type
+   */
   def editOneOf[S, A1 <: S, A2 <: S](
     in1: (String, Input[EditorInput[A1]], Prism[S, A1]),
     in2: (String, Input[EditorInput[A2]], Prism[S, A2]),
@@ -69,6 +85,21 @@ object EditorInput {
     }
   }
 
+  /**
+   * Provides an editor of a sum type `S` with three mutually exclusive options
+   * `A1`, `A2` and `A3`.  See `editOnOf` with two arguments above.
+   *
+   * @param in1 triplet containing name of the input field, the input itself, and a prism for editing
+   * @param in2 triplet containing name of the input field, the input itself, and a prism for editing
+   * @param in3 triplet containing name of the input field, the input itself, and a prism for editing
+   *
+   * @tparam S sum type
+   * @tparam A1 type of option 1
+   * @tparam A2 type of option 2
+   * @tparam A3 type of option 3
+   *
+   * @return editor of the sum type
+   */
   def editOneOf[S, A1 <: S, A2 <: S, A3 <: S](
     in1: (String, Input[EditorInput[A1]], Prism[S, A1]),
     in2: (String, Input[EditorInput[A2]], Prism[S, A2]),

--- a/modules/core/src/main/scala/lucuma/odb/api/model/EditorInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/EditorInput.scala
@@ -4,12 +4,6 @@
 package lucuma.odb.api.model
 
 import cats.data.StateT
-import clue.data.{Assign, Ignore, Input, Unassign}
-import cats.syntax.either._
-import cats.syntax.functor._
-import cats.syntax.option._
-import lucuma.odb.api.model.syntax.optional._
-import monocle.{Lens, Optional}
 
 /**
  * Describes how to validate arguments and create a new A or else validate
@@ -22,59 +16,5 @@ trait EditorInput[A] {
   def create: ValidatedInput[A]
 
   def edit: StateT[EitherInput, A, Unit]
-
-}
-
-object EditorInput {
-
-  /**
-   * Using the provided optic, applies the update described by the given `Input`
-   * in the resulting state computation.
-   */
-  def editNullable[S, A](
-    optional: Optional[S, Option[A]],
-    input:    Input[EditorInput[A]]
-  ): StateT[EitherInput, S, Unit] =
-
-    input match {
-
-      // Do nothing.
-      case Ignore    =>
-        StateT.empty[EitherInput, S, Unit]
-
-      // Unset the A in S.
-      case Unassign  =>
-        (optional := Option.empty[A].some).void
-
-      // Create a new instance of A for the state S or else edit the existing
-      // A instance in the state S.  Arguments to the input are validated
-      // appropriately either way.
-      case Assign(n) =>
-        StateT.modifyF[EitherInput, S] { s =>
-          optional
-            .modifyA[EitherInput](_.fold(n.create.toEither)(n.edit.runS).map(_.some))(s)
-        }
-    }
-
-  def editNotNullable[S, A](
-    name: String,
-    lens: Lens[S, A],
-    input: Input[EditorInput[A]]
-  ): StateT[EitherInput, S, Unit] =
-
-    input match {
-
-      // Do nothing
-      case Ignore   =>
-        StateT.empty[EitherInput, S, Unit]
-
-      // Cannot unset.
-      case Unassign =>
-        StateT.setF(InputError.fromMessage(s""""$name" cannot be unassigned""").leftNec)
-
-      case Assign(n) =>
-        StateT.modifyF[EitherInput, S](lens.modifyF(n.edit.runS))
-
-    }
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/syntax/LensOps.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/syntax/LensOps.scala
@@ -13,6 +13,13 @@ import monocle.Lens
 
 final class LensOps[S, A](val self: Lens[S, A]) extends AnyVal {
 
+  /**
+   * Uses the lens to create an editor of a nullable field of type `A` in `S`.
+   * When assigning the value, if there is an existing value of type `A` then
+   * it may be edited (which implies only specifying changes).  If there is no
+   * existing `A` then it must be created (which implies specifying all required
+   * values).
+   */
   def :?[B](input: Input[EditorInput[B]])(implicit ev: Option[B] =:= A): StateT[EitherInput, S, Unit] =
     input match {
 
@@ -40,6 +47,11 @@ final class LensOps[S, A](val self: Lens[S, A]) extends AnyVal {
 
     }
 
+  /**
+   * Uses the lens to create an editor of a required, non-nullable field of type
+   * `A` in `S`.  Since there will always be a value of type `A`, it can always
+   * be edited and need not be created with all required inputs.
+   */
   def :!(input: Input[EditorInput[A]]): StateT[EitherInput, S, Unit] =
     input match {
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/syntax/PrismOps.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/syntax/PrismOps.scala
@@ -36,9 +36,6 @@ final class PrismOps[S, A](val self: Prism[S, A]) extends AnyVal {
       }
     }
 
-  def create(ed: EditorInput[A]): StateT[EitherInput, S, Unit] =
-    StateT.modifyF { s => ed.create.toEither.map(a => self.replace(a)(s)) }
-
   def editOrIgnore(ed: EditorInput[A]): StateT[EitherInput, S, Unit] =
     transformOrIgnore(ed.edit)
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/syntax/PrismOps.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/syntax/PrismOps.scala
@@ -5,7 +5,7 @@ package lucuma.odb.api.model.syntax
 
 import cats.syntax.either._
 import cats.data.StateT
-import lucuma.odb.api.model.{EitherInput, InputError}
+import lucuma.odb.api.model.{EditorInput, EitherInput, InputError}
 import monocle.Prism
 
 final class PrismOps[S, A](val self: Prism[S, A]) extends AnyVal {
@@ -35,6 +35,12 @@ final class PrismOps[S, A](val self: Prism[S, A]) extends AnyVal {
         st.runS(a).map(aʹ => (self.replace(aʹ)(s), ()))
       }
     }
+
+  def create(ed: EditorInput[A]): StateT[EitherInput, S, Unit] =
+    StateT.modifyF { s => ed.create.toEither.map(a => self.replace(a)(s)) }
+
+  def editOrIgnore(ed: EditorInput[A]): StateT[EitherInput, S, Unit] =
+    transformOrIgnore(ed.edit)
 
 }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SiderealInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SiderealInput.scala
@@ -85,7 +85,7 @@ final case class SiderealInput(
       _ <- optics.properMotion   := pm
       _ <- optics.radialVelocity := rv
       _ <- optics.parallax       := px
-      _ <- EditorInput.editNullable(optics.catalogInfo.asOptional, catalogInfo)
+      _ <- optics.catalogInfo    :? catalogInfo
     } yield ()
 
   }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SiderealInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SiderealInput.scala
@@ -85,7 +85,7 @@ final case class SiderealInput(
       _ <- optics.properMotion   := pm
       _ <- optics.radialVelocity := rv
       _ <- optics.parallax       := px
-      _ <- EditorInput.nullable(optics.catalogInfo.asOptional, catalogInfo)
+      _ <- EditorInput.editNullable(optics.catalogInfo.asOptional, catalogInfo)
     } yield ()
 
   }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SourceProfileModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SourceProfileModel.scala
@@ -32,7 +32,6 @@ import lucuma.odb.api.model.{AngleModel, EditorInput, EitherInput, InputError, V
 import lucuma.odb.api.model.syntax.input._
 import lucuma.odb.api.model.syntax.prism._
 import lucuma.odb.api.model.syntax.lens._
-//import lucuma.odb.api.model.syntax.optional._
 
 import scala.collection.immutable.SortedMap
 
@@ -40,6 +39,8 @@ import scala.collection.immutable.SortedMap
  * SourceProfile GraphQL schema support model.
  */
 object SourceProfileModel {
+
+  // TODO: a more appropriate place for this stuff
 
   def error[S](m: String): StateT[EitherInput, S, Unit] =
     StateT.setF[EitherInput, S](InputError.fromMessage(m).leftNec)
@@ -476,12 +477,8 @@ object SourceProfileModel {
     override val edit: StateT[EitherInput, SourceProfile.Gaussian, Unit] = {
       for {
         a <- StateT.liftF(fwhm.validateNotNullable("fwhm")(_.toAngle).toEither)
-        _ <- SourceProfile.Gaussian.fwhm := a
-        _ <- EditorInput.editNotNullable(
-               "spectralDefinition",
-               SourceProfile.Gaussian.spectralDefinition,
-               spectralDefinition
-             )
+        _ <- SourceProfile.Gaussian.fwhm               := a
+        _ <- SourceProfile.Gaussian.spectralDefinition :! spectralDefinition
       } yield ()
     }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
@@ -584,7 +584,10 @@ object SourceProfileSchema {
   )(implicit ev: InputType[CreateBandBrightnessInput[T]]): InputObjectType[BandNormalizedInput[T]] =
     deriveInputObjectType(
       InputObjectTypeName(s"BandNormalized${groupName.capitalize}Input"),
-      InputObjectTypeDescription(s"Create or edit a band normalized value with $groupName magnitude units")
+      InputObjectTypeDescription(s"Create or edit a band normalized value with $groupName magnitude units"),
+
+      ReplaceInputField("sed", InputObjectUnnormalizedSed.createRequiredEditOptional("sed", "BandNormalized")),
+      ReplaceInputField("brightnesses", ListInputType(ev).createRequiredEditOptional("brightnesses", "BandNormalized"))
     )
 
   implicit val InputObjectBandNormalizedIntegrated: InputObjectType[BandNormalizedInput[Integrated]] =
@@ -648,7 +651,10 @@ object SourceProfileSchema {
   )(implicit ev0: InputType[CreateEmissionLineInput[T]], ev1: InputType[CreateMeasureInput[PosBigDecimal, FluxDensityContinuum[T]]]): InputObjectType[EmissionLinesInput[T]] =
     deriveInputObjectType(
       InputObjectTypeName(s"EmissionLines${groupName.capitalize}Input"),
-      InputObjectTypeDescription(s"Create or edit emission lines with $groupName line flux and flux density continuum units")
+      InputObjectTypeDescription(s"Create or edit emission lines with $groupName line flux and flux density continuum units"),
+
+      ReplaceInputField("lines", ListInputType(ev0).createRequiredEditOptional("lines", "EmissionLines")),
+      ReplaceInputField("fluxDensityContinuum", ev1.createRequiredEditOptional("fluxDensityContinuum", "EmissionLines"))
     )
 
   implicit val InputObjectEmissionLinesIntegrated: InputObjectType[EmissionLinesInput[Integrated]] =
@@ -685,7 +691,7 @@ object SourceProfileSchema {
       InputObjectTypeName("GaussianInput"),
       InputObjectTypeDescription("Create a gaussian source"),
 
-      ReplaceInputField("fwhm", InputObjectAngle.createRequiredEditOptional("fwhm", "Gaussian")),
+      ReplaceInputField("fwhm",               InputObjectAngle.createRequiredEditOptional("fwhm", "Gaussian")),
       ReplaceInputField("spectralDefinition", InputObjectSpectralDefinitionIntegrated.createRequiredEditOptional("spectralDefinition", "Gaussian"))
     )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
@@ -13,7 +13,7 @@ import lucuma.core.math.dimensional.{Measure, Of, Units}
 import lucuma.core.model.SpectralDefinition.{BandNormalized, EmissionLines}
 import lucuma.core.model.{SourceProfile, SpectralDefinition, UnnormalizedSED}
 import lucuma.core.util.Enumerated
-import lucuma.odb.api.model.targetModel.SourceProfileModel.{BandBrightnessPair, CreateBandBrightnessInput, CreateBandNormalizedInput, CreateEmissionLineInput, CreateEmissionLinesInput, GaussianInput, CreateMeasureInput, SpectralDefinitionInput, FluxDensityInput, SourceProfileInput, UnnormalizedSedInput, WavelengthEmissionLinePair}
+import lucuma.odb.api.model.targetModel.SourceProfileModel.{BandBrightnessPair, CreateBandBrightnessInput, BandNormalizedInput, CreateEmissionLineInput, EmissionLinesInput, GaussianInput, CreateMeasureInput, SpectralDefinitionInput, FluxDensityInput, SourceProfileInput, UnnormalizedSedInput, WavelengthEmissionLinePair}
 import lucuma.odb.api.schema.syntax.inputtype._
 import monocle.Prism
 import sangria.schema.{Field, _}
@@ -581,16 +581,16 @@ object SourceProfileSchema {
 
   private def createBandNormalizedInputObjectType[T](
     groupName: String
-  )(implicit ev: InputType[CreateBandBrightnessInput[T]]): InputObjectType[CreateBandNormalizedInput[T]] =
+  )(implicit ev: InputType[CreateBandBrightnessInput[T]]): InputObjectType[BandNormalizedInput[T]] =
     deriveInputObjectType(
-      InputObjectTypeName(s"CreateBandNormalized${groupName.capitalize}"),
-      InputObjectTypeDescription(s"Create a band normalized value with $groupName magnitude units")
+      InputObjectTypeName(s"BandNormalized${groupName.capitalize}Input"),
+      InputObjectTypeDescription(s"Create or edit a band normalized value with $groupName magnitude units")
     )
 
-  implicit val InputObjectCreateBandNormalizedIntegrated: InputObjectType[CreateBandNormalizedInput[Integrated]] =
+  implicit val InputObjectBandNormalizedIntegrated: InputObjectType[BandNormalizedInput[Integrated]] =
     createBandNormalizedInputObjectType[Integrated]("integrated")
 
-  implicit val InputObjectCreateBandNormalizedSurface: InputObjectType[CreateBandNormalizedInput[Surface]] =
+  implicit val InputObjectBandNormalizedSurface: InputObjectType[BandNormalizedInput[Surface]] =
     createBandNormalizedInputObjectType[Surface]("surface")
 
   private def createLineFluxInputObjectType[T](
@@ -645,23 +645,23 @@ object SourceProfileSchema {
 
   private def createEmissionLinesInputObjectType[T](
     groupName: String
-  )(implicit ev0: InputType[CreateEmissionLineInput[T]], ev1: InputType[CreateMeasureInput[PosBigDecimal, FluxDensityContinuum[T]]]): InputObjectType[CreateEmissionLinesInput[T]] =
+  )(implicit ev0: InputType[CreateEmissionLineInput[T]], ev1: InputType[CreateMeasureInput[PosBigDecimal, FluxDensityContinuum[T]]]): InputObjectType[EmissionLinesInput[T]] =
     deriveInputObjectType(
-      InputObjectTypeName(s"CreateEmissionLines${groupName.capitalize}"),
-      InputObjectTypeDescription(s"Create an emission lines with $groupName line flux and flux density continuum units")
+      InputObjectTypeName(s"EmissionLines${groupName.capitalize}Input"),
+      InputObjectTypeDescription(s"Create or edit emission lines with $groupName line flux and flux density continuum units")
     )
 
-  implicit val InputObjectCreateEmissionLinesIntegrated: InputObjectType[CreateEmissionLinesInput[Integrated]] =
+  implicit val InputObjectEmissionLinesIntegrated: InputObjectType[EmissionLinesInput[Integrated]] =
     createEmissionLinesInputObjectType("integrated")
 
-  implicit val InputObjectCreateEmissionLinesSurface: InputObjectType[CreateEmissionLinesInput[Surface]] =
+  implicit val InputObjectEmissionLinesSurface: InputObjectType[EmissionLinesInput[Surface]] =
     createEmissionLinesInputObjectType("surface")
 
   private def spectralDefinitionInputObjectType[T](
     groupName: String
   )(
-    implicit ev0: InputType[CreateBandNormalizedInput[T]],
-             ev1: InputType[CreateEmissionLinesInput[T]]
+    implicit ev0: InputType[BandNormalizedInput[T]],
+             ev1: InputType[EmissionLinesInput[T]]
   ): InputObjectType[SpectralDefinitionInput[T]] = {
     val message = """Exactly one of "bandNormalized" or "emissionLines" is required"""
 
@@ -670,7 +670,7 @@ object SourceProfileSchema {
       InputObjectTypeDescription(s"Spectral definition input with $groupName units"),
 
       ReplaceInputField("bandNormalized", ev0.optionField("bandNormalized", message)),
-      ReplaceInputField("emissionLines", ev1.optionField("emissionLines", message))
+      ReplaceInputField("emissionLines",  ev1.optionField("emissionLines",  message))
     )
   }
 
@@ -706,8 +706,8 @@ object SourceProfileSchema {
 
   // TODO: Remove
 
-  val ArgumentCreateBandNormalizedIntegrated: Argument[CreateBandNormalizedInput[Integrated]] =
-    InputObjectCreateBandNormalizedIntegrated.argument("mag", "magnitude")
+  val ArgumentCreateBandNormalizedIntegrated: Argument[BandNormalizedInput[Integrated]] =
+    InputObjectBandNormalizedIntegrated.argument("mag", "magnitude")
 
   val ArgumentSourceProfile: Argument[SourceProfileInput] =
     InputObjectSourceProfile.argument("sourceProfile", "source profile description")

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetQuery.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetQuery.scala
@@ -93,7 +93,7 @@ trait TargetQuery {
       description = "test source profile".some,
       arguments   = List(ArgumentCreateBandNormalizedIntegrated),
       resolve     = c => {
-        val big = c.arg(ArgumentCreateBandNormalizedIntegrated).toBandNormalized.toOption.get
+        val big = c.arg(ArgumentCreateBandNormalizedIntegrated).create.toOption.get
         SourceProfile.Point(big)
       }
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/syntax/InputType.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/syntax/InputType.scala
@@ -7,18 +7,25 @@ import sangria.schema._
 
 final class InputTypeOps[A](self: InputType[A]) {
 
+  def optionField(name: String, message: String): InputField[Option[A]] =
+    InputField(name, OptionInputType(self), message)
+
   def nullableField(name: String): InputField[Option[A]] =
-    InputField(
+    optionField(
       name,
-      OptionInputType(self),
       s"The $name field may be unset by assigning a null value, or ignored by skipping it altogether"
     )
 
   def notNullableField(name: String): InputField[Option[A]] =
-    InputField(
+    optionField(
       name,
-      OptionInputType(self),
       s"The $name field must be either specified or skipped altogether.  It cannot be unset with a null value."
+    )
+
+  def createRequiredEditOptional(name: String, item: String): InputField[Option[A]] =
+    optionField(
+      name,
+      s"The $name field is required when creating a new instance of $item, but optional when editing"
     )
 
 }

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
@@ -126,7 +126,7 @@ trait ArbSourceProfileModel {
       in.error
     )}
 
-  implicit def arbCreateBandNormalizedInput[T](
+  implicit def arbBandNormalizedInput[T](
     implicit ev: Enumerated[Units Of Brightness[T]]
   ): Arbitrary[BandNormalizedInput[T]] =
     Arbitrary {
@@ -136,7 +136,7 @@ trait ArbSourceProfileModel {
       } yield BandNormalizedInput(s, b)
     }
 
-  implicit def cogCreateBandNormalizedInput[T](
+  implicit def cogBandNormalizedInput[T](
     implicit ev: Enumerated[Units Of Brightness[T]]
   ): Cogen[BandNormalizedInput[T]] =
     Cogen[(
@@ -171,7 +171,7 @@ trait ArbSourceProfileModel {
       in.lineFlux
     )}
 
-  implicit def arbCreateEmissionLinesInput[T](
+  implicit def arbEmissionLinesInput[T](
     implicit ev0: Enumerated[Units Of LineFlux[T]],
              ev1: Enumerated[Units Of FluxDensityContinuum[T]]
   ): Arbitrary[EmissionLinesInput[T]] =
@@ -182,7 +182,7 @@ trait ArbSourceProfileModel {
       } yield EmissionLinesInput(ls, fdc)
     }
 
-  implicit def cogCreateCreateEmissionLinesInput[T](
+  implicit def cogCreateEmissionLinesInput[T](
     implicit ev0: Enumerated[Units Of LineFlux[T]],
              ev1: Enumerated[Units Of FluxDensityContinuum[T]]
   ): Cogen[EmissionLinesInput[T]] =

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
@@ -194,43 +194,43 @@ trait ArbSourceProfileModel {
       in.fluxDensityContinuum
     )}
 
-  implicit def arbCreateSpectralDefinition[T](
+  implicit def arbSpectralDefinition[T](
     implicit ev0: Enumerated[Units Of Brightness[T]],
              ev1: Enumerated[Units Of LineFlux[T]],
              ev2: Enumerated[Units Of FluxDensityContinuum[T]]
-  ): Arbitrary[CreateSpectralDefinitionInput[T]] =
+  ): Arbitrary[SpectralDefinitionInput[T]] =
     Arbitrary {
       Gen.oneOf(
-        arbitrary[CreateBandNormalizedInput[T]].map(CreateSpectralDefinitionInput.bandNormalized),
-        arbitrary[CreateEmissionLinesInput[T]].map(CreateSpectralDefinitionInput.emissionLines)
+        arbitrary[CreateBandNormalizedInput[T]].map(SpectralDefinitionInput.bandNormalized),
+        arbitrary[CreateEmissionLinesInput[T]].map(SpectralDefinitionInput.emissionLines)
       )
     }
 
-  implicit def cogCreateSpectralDefinition[T](
+  implicit def cogSpectralDefinition[T](
     implicit ev0: Enumerated[Units Of Brightness[T]],
              ev1: Enumerated[Units Of LineFlux[T]],
              ev2: Enumerated[Units Of FluxDensityContinuum[T]]
-  ): Cogen[CreateSpectralDefinitionInput[T]] =
+  ): Cogen[SpectralDefinitionInput[T]] =
     Cogen[(
-      Option[CreateBandNormalizedInput[T]],
-      Option[CreateEmissionLinesInput[T]]
+      Input[CreateBandNormalizedInput[T]],
+      Input[CreateEmissionLinesInput[T]]
     )].contramap { in => (
       in.bandNormalized,
       in.emissionLines
     )}
 
-  implicit val arbCreateGaussianInput: Arbitrary[CreateGaussianInput] =
+  implicit val arbGaussianInput: Arbitrary[GaussianInput] =
     Arbitrary {
       for {
-        f <- arbitrary[AngleModel.AngleInput]
-        s <- arbitrary[CreateSpectralDefinitionInput[Integrated]]
-      } yield CreateGaussianInput(f, s)
+        f <- arbitrary[Input[AngleModel.AngleInput]]
+        s <- arbitrary[Input[SpectralDefinitionInput[Integrated]]]
+      } yield GaussianInput(f, s)
     }
 
-  implicit val cogCreateGaussianInput: Cogen[CreateGaussianInput] =
+  implicit val cogGaussianInput: Cogen[GaussianInput] =
     Cogen[(
-      AngleModel.AngleInput,
-      CreateSpectralDefinitionInput[Integrated]
+      Input[AngleModel.AngleInput],
+      Input[SpectralDefinitionInput[Integrated]]
     )].contramap { in => (
       in.fwhm,
       in.spectralDefinition
@@ -239,17 +239,17 @@ trait ArbSourceProfileModel {
   implicit val arbSourceProfileInput: Arbitrary[SourceProfileInput] =
     Arbitrary {
       Gen.oneOf(
-        arbitrary[CreateSpectralDefinitionInput[Integrated]].map(SourceProfileInput.point),
-        arbitrary[CreateSpectralDefinitionInput[Surface]].map(SourceProfileInput.uniform),
-        arbitrary[CreateGaussianInput].map(SourceProfileInput.gaussian)
+        arbitrary[SpectralDefinitionInput[Integrated]].map(SourceProfileInput.point),
+        arbitrary[SpectralDefinitionInput[Surface]].map(SourceProfileInput.uniform),
+        arbitrary[GaussianInput].map(SourceProfileInput.gaussian)
       )
     }
 
   implicit val cogSourceProfileInput: Cogen[SourceProfileInput] =
     Cogen[(
-      Input[CreateSpectralDefinitionInput[Integrated]],
-      Input[CreateSpectralDefinitionInput[Surface]],
-      Input[CreateGaussianInput]
+      Input[SpectralDefinitionInput[Integrated]],
+      Input[SpectralDefinitionInput[Surface]],
+      Input[GaussianInput]
     )].contramap { in => (
       in.point,
       in.uniform,

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
@@ -128,17 +128,17 @@ trait ArbSourceProfileModel {
 
   implicit def arbCreateBandNormalizedInput[T](
     implicit ev: Enumerated[Units Of Brightness[T]]
-  ): Arbitrary[CreateBandNormalizedInput[T]] =
+  ): Arbitrary[BandNormalizedInput[T]] =
     Arbitrary {
       for {
         s <- arbitrary[UnnormalizedSedInput]
         b <- arbitrary[List[CreateBandBrightnessInput[T]]]
-      } yield CreateBandNormalizedInput(s, b)
+      } yield BandNormalizedInput(s, b)
     }
 
   implicit def cogCreateBandNormalizedInput[T](
     implicit ev: Enumerated[Units Of Brightness[T]]
-  ): Cogen[CreateBandNormalizedInput[T]] =
+  ): Cogen[BandNormalizedInput[T]] =
     Cogen[(
       UnnormalizedSedInput,
       List[CreateBandBrightnessInput[T]]
@@ -174,18 +174,18 @@ trait ArbSourceProfileModel {
   implicit def arbCreateEmissionLinesInput[T](
     implicit ev0: Enumerated[Units Of LineFlux[T]],
              ev1: Enumerated[Units Of FluxDensityContinuum[T]]
-  ): Arbitrary[CreateEmissionLinesInput[T]] =
+  ): Arbitrary[EmissionLinesInput[T]] =
     Arbitrary {
       for {
         ls  <- arbitrary[List[CreateEmissionLineInput[T]]]
         fdc <- arbitrary[CreateMeasureInput[PosBigDecimal, FluxDensityContinuum[T]]]
-      } yield CreateEmissionLinesInput(ls, fdc)
+      } yield EmissionLinesInput(ls, fdc)
     }
 
   implicit def cogCreateCreateEmissionLinesInput[T](
     implicit ev0: Enumerated[Units Of LineFlux[T]],
              ev1: Enumerated[Units Of FluxDensityContinuum[T]]
-  ): Cogen[CreateEmissionLinesInput[T]] =
+  ): Cogen[EmissionLinesInput[T]] =
     Cogen[(
       List[CreateEmissionLineInput[T]],
       CreateMeasureInput[PosBigDecimal, FluxDensityContinuum[T]]
@@ -201,8 +201,8 @@ trait ArbSourceProfileModel {
   ): Arbitrary[SpectralDefinitionInput[T]] =
     Arbitrary {
       Gen.oneOf(
-        arbitrary[CreateBandNormalizedInput[T]].map(SpectralDefinitionInput.bandNormalized),
-        arbitrary[CreateEmissionLinesInput[T]].map(SpectralDefinitionInput.emissionLines)
+        arbitrary[BandNormalizedInput[T]].map(SpectralDefinitionInput.bandNormalized),
+        arbitrary[EmissionLinesInput[T]].map(SpectralDefinitionInput.emissionLines)
       )
     }
 
@@ -212,8 +212,8 @@ trait ArbSourceProfileModel {
              ev2: Enumerated[Units Of FluxDensityContinuum[T]]
   ): Cogen[SpectralDefinitionInput[T]] =
     Cogen[(
-      Input[CreateBandNormalizedInput[T]],
-      Input[CreateEmissionLinesInput[T]]
+      Input[BandNormalizedInput[T]],
+      Input[EmissionLinesInput[T]]
     )].contramap { in => (
       in.bandNormalized,
       in.emissionLines

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
@@ -131,8 +131,8 @@ trait ArbSourceProfileModel {
   ): Arbitrary[BandNormalizedInput[T]] =
     Arbitrary {
       for {
-        s <- arbitrary[UnnormalizedSedInput]
-        b <- arbitrary[List[CreateBandBrightnessInput[T]]]
+        s <- arbitrary[Input[UnnormalizedSedInput]]
+        b <- arbitrary[Input[List[CreateBandBrightnessInput[T]]]]
       } yield BandNormalizedInput(s, b)
     }
 
@@ -140,8 +140,8 @@ trait ArbSourceProfileModel {
     implicit ev: Enumerated[Units Of Brightness[T]]
   ): Cogen[BandNormalizedInput[T]] =
     Cogen[(
-      UnnormalizedSedInput,
-      List[CreateBandBrightnessInput[T]]
+      Input[UnnormalizedSedInput],
+      Input[List[CreateBandBrightnessInput[T]]]
     )].contramap { in => (
       in.sed,
       in.brightnesses
@@ -177,18 +177,18 @@ trait ArbSourceProfileModel {
   ): Arbitrary[EmissionLinesInput[T]] =
     Arbitrary {
       for {
-        ls  <- arbitrary[List[CreateEmissionLineInput[T]]]
-        fdc <- arbitrary[CreateMeasureInput[PosBigDecimal, FluxDensityContinuum[T]]]
+        ls  <- arbitrary[Input[List[CreateEmissionLineInput[T]]]]
+        fdc <- arbitrary[Input[CreateMeasureInput[PosBigDecimal, FluxDensityContinuum[T]]]]
       } yield EmissionLinesInput(ls, fdc)
     }
 
-  implicit def cogCreateEmissionLinesInput[T](
+  implicit def cogEmissionLinesInput[T](
     implicit ev0: Enumerated[Units Of LineFlux[T]],
              ev1: Enumerated[Units Of FluxDensityContinuum[T]]
   ): Cogen[EmissionLinesInput[T]] =
     Cogen[(
-      List[CreateEmissionLineInput[T]],
-      CreateMeasureInput[PosBigDecimal, FluxDensityContinuum[T]]
+      Input[List[CreateEmissionLineInput[T]]],
+      Input[CreateMeasureInput[PosBigDecimal, FluxDensityContinuum[T]]]
     )].contramap { in => (
       in.lines,
       in.fluxDensityContinuum


### PR DESCRIPTION
Next installment in editable source profiles.  Continues turning the `CreateFooInput`s that work for creation only into `FooInput`s that work for creation or editing.  All the fields becomes optional but on creation required fields are checked and flagged if missing.  On editing you only need to specify the things that are changing.  For example, switching from one type of `SourceProfile` to another (e.g., `Point` to `Gaussian`) requires specifying both the `fwhm` and the spectral definition whereas editing the fwhm of an existing `Gaussian` doesn't require the spectral definition.

I'm working my way down from the top and have `SourceProfileInput`, `GaussianInput`, `SpectralDefinitionInput`, `EmissionLinesInput`, and `BandNormalizedInput` converted so far.