### PR TITLE
Editable source profile (Part 4)

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SourceProfileModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SourceProfileModel.scala
@@ -235,7 +235,7 @@ object SourceProfileModel {
 
   }
 
-  final case class CreateBandBrightnessInput[T](
+  final case class BandBrightnessInput[T](
     band:      Band,
     value:     BigDecimal,
     units:     Units Of Brightness[T],
@@ -252,21 +252,21 @@ object SourceProfileModel {
 
   }
 
-  object CreateBandBrightnessInput {
+  object BandBrightnessInput {
 
-    implicit def DecoderCreateBandBrightnessInput[T](
+    implicit def DecoderBandBrightnessInput[T](
       implicit ev: Decoder[Units Of Brightness[T]]
-    ): Decoder[CreateBandBrightnessInput[T]] =
-      deriveDecoder[CreateBandBrightnessInput[T]]
+    ): Decoder[BandBrightnessInput[T]] =
+      deriveDecoder[BandBrightnessInput[T]]
 
-    implicit def EqCreateBandBrightnessInput[T]: Eq[CreateBandBrightnessInput[T]] =
+    implicit def EqBandBrightnessInput[T]: Eq[BandBrightnessInput[T]] =
       Eq.by { a => (a.band, a.value, a.units, a.error) }
 
   }
 
   final case class BandNormalizedInput[T](
     sed:          Input[UnnormalizedSedInput]               = Input.ignore,
-    brightnesses: Input[List[CreateBandBrightnessInput[T]]] = Input.ignore
+    brightnesses: Input[List[BandBrightnessInput[T]]] = Input.ignore
   ) extends EditorInput[BandNormalized[T]] {
 
     override val create: ValidatedInput[BandNormalized[T]] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
@@ -13,7 +13,7 @@ import lucuma.core.math.dimensional.{Measure, Of, Units}
 import lucuma.core.model.SpectralDefinition.{BandNormalized, EmissionLines}
 import lucuma.core.model.{SourceProfile, SpectralDefinition, UnnormalizedSED}
 import lucuma.core.util.Enumerated
-import lucuma.odb.api.model.targetModel.SourceProfileModel.{BandBrightnessPair, BandNormalizedInput, BandBrightnessInput, CreateEmissionLineInput, CreateMeasureInput, EmissionLinesInput, FluxDensityInput, GaussianInput, SourceProfileInput, SpectralDefinitionInput, UnnormalizedSedInput, WavelengthEmissionLinePair}
+import lucuma.odb.api.model.targetModel.SourceProfileModel.{BandBrightnessInput, BandBrightnessPair, BandNormalizedInput, CreateEmissionLineInput, CreateMeasureInput, EmissionLinesInput, FluxDensityInput, GaussianInput, SourceProfileInput, SpectralDefinitionInput, UnnormalizedSedInput, WavelengthEmissionLinePair}
 import lucuma.odb.api.schema.syntax.inputtype._
 import monocle.Prism
 import sangria.schema.{Field, _}
@@ -567,11 +567,20 @@ object SourceProfileSchema {
 
   private def createBandBrightnessInputObjectType[T](
     groupName: String
-  )(implicit ev: InputType[Units Of Brightness[T]]): InputObjectType[BandBrightnessInput[T]] =
-    deriveInputObjectType[BandBrightnessInput[T]](
-      InputObjectTypeName(s"BandBrightness${groupName.capitalize}Input"),
-      InputObjectTypeDescription(s"Create a band brightness value with $groupName magnitude units")
+  )(implicit ev: InputType[Units Of Brightness[T]]): InputObjectType[BandBrightnessInput[T]] = {
+    val typeName = s"BandBrightness${groupName.capitalize}"
+
+    InputObjectType[BandBrightnessInput[T]](
+      s"${typeName}Input",
+      s"""Create or edit a band brightness value with $groupName magnitude units.  When creating a new value, all fields except "error" are required.""",
+      List(
+        InputField("band", EnumTypeBand),
+        BigDecimalType.createRequiredEditOptional("value", typeName),
+        ev.createRequiredEditOptional("units", typeName),
+        BigDecimalType.optionField("error", "Error values are optional")
+      )
     )
+  }
 
   implicit val InputObjectBandBrightnessIntegrated: InputObjectType[BandBrightnessInput[Integrated]] =
     createBandBrightnessInputObjectType[Integrated]("integrated")

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
@@ -13,7 +13,7 @@ import lucuma.core.math.dimensional.{Measure, Of, Units}
 import lucuma.core.model.SpectralDefinition.{BandNormalized, EmissionLines}
 import lucuma.core.model.{SourceProfile, SpectralDefinition, UnnormalizedSED}
 import lucuma.core.util.Enumerated
-import lucuma.odb.api.model.targetModel.SourceProfileModel.{BandBrightnessPair, BandNormalizedInput, CreateBandBrightnessInput, CreateEmissionLineInput, CreateMeasureInput, EmissionLinesInput, FluxDensityInput, GaussianInput, SourceProfileInput, SpectralDefinitionInput, UnnormalizedSedInput, WavelengthEmissionLinePair}
+import lucuma.odb.api.model.targetModel.SourceProfileModel.{BandBrightnessPair, BandNormalizedInput, BandBrightnessInput, CreateEmissionLineInput, CreateMeasureInput, EmissionLinesInput, FluxDensityInput, GaussianInput, SourceProfileInput, SpectralDefinitionInput, UnnormalizedSedInput, WavelengthEmissionLinePair}
 import lucuma.odb.api.schema.syntax.inputtype._
 import monocle.Prism
 import sangria.schema.{Field, _}
@@ -567,21 +567,21 @@ object SourceProfileSchema {
 
   private def createBandBrightnessInputObjectType[T](
     groupName: String
-  )(implicit ev: InputType[Units Of Brightness[T]]): InputObjectType[CreateBandBrightnessInput[T]] =
-    deriveInputObjectType[CreateBandBrightnessInput[T]](
-      InputObjectTypeName(s"CreateBandBrightness${groupName.capitalize}"),
+  )(implicit ev: InputType[Units Of Brightness[T]]): InputObjectType[BandBrightnessInput[T]] =
+    deriveInputObjectType[BandBrightnessInput[T]](
+      InputObjectTypeName(s"BandBrightness${groupName.capitalize}Input"),
       InputObjectTypeDescription(s"Create a band brightness value with $groupName magnitude units")
     )
 
-  implicit val InputObjectCreateBandBrightnessIntegrated: InputObjectType[CreateBandBrightnessInput[Integrated]] =
+  implicit val InputObjectBandBrightnessIntegrated: InputObjectType[BandBrightnessInput[Integrated]] =
     createBandBrightnessInputObjectType[Integrated]("integrated")
 
-  implicit val InputObjectCreateBandBrightnessSurface: InputObjectType[CreateBandBrightnessInput[Surface]] =
+  implicit val InputObjectBandBrightnessSurface: InputObjectType[BandBrightnessInput[Surface]] =
     createBandBrightnessInputObjectType[Surface]("surface")
 
   private def createBandNormalizedInputObjectType[T](
     groupName: String
-  )(implicit ev: InputType[CreateBandBrightnessInput[T]]): InputObjectType[BandNormalizedInput[T]] =
+  )(implicit ev: InputType[BandBrightnessInput[T]]): InputObjectType[BandNormalizedInput[T]] =
     InputObjectType[BandNormalizedInput[T]](
       s"BandNormalized${groupName.capitalize}Input",
       s"""Create or edit a band normalized value with $groupName magnitude units.  Specify both "sed" and "brightnesses" when creating a new BandNormalized${groupName.capitalize}.""",

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
@@ -100,25 +100,25 @@ trait ArbSourceProfileModel {
       in.units
     )}
 
-  implicit def arbCreateBandBrightnessInput[T](
+  implicit def arbBandBrightnessInput[T](
     implicit ev: Enumerated[Units Of Brightness[T]]
   ): Arbitrary[BandBrightnessInput[T]] =
     Arbitrary {
       for {
-        br <- arbitrary[CreateMeasureInput[BigDecimal, Brightness[T]]]
+        br <- arbitrary[Input[CreateMeasureInput[BigDecimal, Brightness[T]]]]
         bd <- arbitrary[Band]
-        e  <- arbitrary[Option[BigDecimal]]
-      } yield BandBrightnessInput(bd, br.value, br.units, e)
+        e  <- arbitrary[Input[BigDecimal]]
+      } yield BandBrightnessInput(bd, br.map(_.value), br.map(_.units), e)
     }
 
-  implicit def cogCreateBandBrightnessInput[T](
+  implicit def cogBandBrightnessInput[T](
     implicit ev: Enumerated[Units Of Brightness[T]]
   ): Cogen[BandBrightnessInput[T]] =
     Cogen[(
       Band,
-      BigDecimal,
-      Units Of Brightness[T],
-      Option[BigDecimal]
+      Input[BigDecimal],
+      Input[Units Of Brightness[T]],
+      Input[BigDecimal]
     )].contramap { in => (
       in.band,
       in.value,

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
@@ -102,18 +102,18 @@ trait ArbSourceProfileModel {
 
   implicit def arbCreateBandBrightnessInput[T](
     implicit ev: Enumerated[Units Of Brightness[T]]
-  ): Arbitrary[CreateBandBrightnessInput[T]] =
+  ): Arbitrary[BandBrightnessInput[T]] =
     Arbitrary {
       for {
         br <- arbitrary[CreateMeasureInput[BigDecimal, Brightness[T]]]
         bd <- arbitrary[Band]
         e  <- arbitrary[Option[BigDecimal]]
-      } yield CreateBandBrightnessInput(bd, br.value, br.units, e)
+      } yield BandBrightnessInput(bd, br.value, br.units, e)
     }
 
   implicit def cogCreateBandBrightnessInput[T](
     implicit ev: Enumerated[Units Of Brightness[T]]
-  ): Cogen[CreateBandBrightnessInput[T]] =
+  ): Cogen[BandBrightnessInput[T]] =
     Cogen[(
       Band,
       BigDecimal,
@@ -132,7 +132,7 @@ trait ArbSourceProfileModel {
     Arbitrary {
       for {
         s <- arbitrary[Input[UnnormalizedSedInput]]
-        b <- arbitrary[Input[List[CreateBandBrightnessInput[T]]]]
+        b <- arbitrary[Input[List[BandBrightnessInput[T]]]]
       } yield BandNormalizedInput(s, b)
     }
 
@@ -141,7 +141,7 @@ trait ArbSourceProfileModel {
   ): Cogen[BandNormalizedInput[T]] =
     Cogen[(
       Input[UnnormalizedSedInput],
-      Input[List[CreateBandBrightnessInput[T]]]
+      Input[List[BandBrightnessInput[T]]]
     )].contramap { in => (
       in.sed,
       in.brightnesses


### PR DESCRIPTION
Makes it possible to edit band brightness values.  You reference the bands you want to edit and then supply just the changes.  

For example, to change the value of the "H" magnitude, you don't need to specify the units (they remain unchanged).  Nor do the unchanged magnitudes of other bands need to be mentioned:

```
    "sourceProfile": {
      "point": {
        "bandNormalized": {
          "brightnesses": [
            {
              "band": "H",
              "value": 9.999
            }
          ]
        }
      }
    }
```

To remove just the error value:

```
    "sourceProfile": {
      "point": {
        "bandNormalized": {
          "brightnesses": [
            {
              "band": "H",
              "error": null
            }
          ]
        }
      }
    }
```

of course you can do both at once and edit other magnitudes at the same time

```
    "sourceProfile": {
      "point": {
        "bandNormalized": {
          "brightnesses": [
            {
              "band": "H",
              "value": 9.999
              "error": null
            },
            {
              "band": "K",
              "value": 9.0
            }
          ]
        }
      }
    }
```

When adding a new magnitude, you have to specify all the required fields (i.e., all but `error`):

    "sourceProfile": {
      "point": {
        "bandNormalized": {
          "brightnesses": [
            {
              "band": "U",
              "value": 10.0,
              "units": "VEGA_MAGNITUDE"
            }
          ]
        }
      }
    }
```

