### PR TITLE
Editable source profile 7

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SourceProfileModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SourceProfileModel.scala
@@ -313,7 +313,6 @@ object SourceProfileModel {
            .toOption
            .fold(m.validNec[InputError])(brightnessEditor[T](_).runS(m).toValidated)
        }.map { m =>
-
          // Also weird to delete bands you just made, but also should work.
          deleteBrightnesses.toOption.fold(m)(bands => m -- bands)
        }
@@ -502,13 +501,11 @@ object SourceProfileModel {
           .toOption
           .fold(m.validNec[InputError])(lineEditor[T](_).runS(m).toValidated)
       }.andThen { m =>
-
         // Also weird to delete wavelengths you just created, but also should work.
         deleteLines
           .toOption
           .traverse(_.traverse(_.toWavelength("wavelength")))
           .map(_.fold(m)(m -- _))
-
       },
        fluxDensityContinuum.notMissing("fluxDensityContinuum")
       ).mapN { (lines, fdc) => EmissionLines(lines, fdc.toMeasure) }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
@@ -594,7 +594,8 @@ object SourceProfileSchema {
       s"""Create or edit a band normalized value with $groupName magnitude units.  Specify both "sed" and "brightnesses" when creating a new BandNormalized${groupName.capitalize}.""",
       List(
         InputObjectUnnormalizedSed.createRequiredEditOptional("sed", s"BandNormalized${groupName.capitalize}"),
-        ListInputType(ev).createRequiredEditOptional("brightnesses", s"BandNormalized${groupName.capitalize}")
+        ListInputType(ev).createRequiredEditOptional("brightnesses", s"BandNormalized${groupName.capitalize}"),
+        ListInputType(ev).optionField("brightnessEdits", "Optional field that may be provided to edit existing brightness definitions or add new ones")
       )
     )
 
@@ -670,6 +671,7 @@ object SourceProfileSchema {
       s"""Create or edit emission lines with $groupName line flux and flux density continuum units. Both "lines" and "fluxDensityContinuum" are required when creating a new EmissionLines${groupName.capitalize}.""",
       List(
         ListInputType(ev0).createRequiredEditOptional("lines", s"EmissionLines${groupName.capitalize}"),
+        ListInputType(ev0).optionField("lineEdits", "Optional field that may be provided to edit existing emission line definitions or add new ones"),
         ev1.createRequiredEditOptional("fluxDensityContinuum", s"EmissionLines${groupName.capitalize}")
       )
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
@@ -595,7 +595,8 @@ object SourceProfileSchema {
       List(
         InputObjectUnnormalizedSed.createRequiredEditOptional("sed", s"BandNormalized${groupName.capitalize}"),
         ListInputType(ev).createRequiredEditOptional("brightnesses", s"BandNormalized${groupName.capitalize}"),
-        ListInputType(ev).optionField("brightnessEdits", "Optional field that may be provided to edit existing brightness definitions or add new ones")
+        ListInputType(ev).optionField("editBrightnesses", "Optional field that may be provided to edit existing brightness definitions or add new ones"),
+        ListInputType(EnumTypeBand).optionField("deleteBrightnesses", "Optional field that may be provided to delete existing brightness definitions identified by band")
       )
     )
 
@@ -671,7 +672,8 @@ object SourceProfileSchema {
       s"""Create or edit emission lines with $groupName line flux and flux density continuum units. Both "lines" and "fluxDensityContinuum" are required when creating a new EmissionLines${groupName.capitalize}.""",
       List(
         ListInputType(ev0).createRequiredEditOptional("lines", s"EmissionLines${groupName.capitalize}"),
-        ListInputType(ev0).optionField("lineEdits", "Optional field that may be provided to edit existing emission line definitions or add new ones"),
+        ListInputType(ev0).optionField("editLines", "Optional field that may be provided to edit existing emission line definitions or add new ones"),
+        ListInputType(InputWavelength).optionField("deleteLines", "Optional field that may be provided to delete existing emission lines identified by wavelength"),
         ev1.createRequiredEditOptional("fluxDensityContinuum", s"EmissionLines${groupName.capitalize}")
       )
     )

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
@@ -133,7 +133,8 @@ trait ArbSourceProfileModel {
       for {
         s <- arbitrary[Input[UnnormalizedSedInput]]
         b <- arbitrary[Input[List[BandBrightnessInput[T]]]]
-      } yield BandNormalizedInput(s, b)
+        e <- arbitrary[Input[List[BandBrightnessInput[T]]]]
+      } yield BandNormalizedInput(s, b, e)
     }
 
   implicit def cogBandNormalizedInput[T](
@@ -141,10 +142,12 @@ trait ArbSourceProfileModel {
   ): Cogen[BandNormalizedInput[T]] =
     Cogen[(
       Input[UnnormalizedSedInput],
+      Input[List[BandBrightnessInput[T]]],
       Input[List[BandBrightnessInput[T]]]
     )].contramap { in => (
       in.sed,
-      in.brightnesses
+      in.brightnesses,
+      in.brightnessEdits
     )}
 
   implicit def arbEmissionLineInput[T](
@@ -178,8 +181,9 @@ trait ArbSourceProfileModel {
     Arbitrary {
       for {
         ls  <- arbitrary[Input[List[EmissionLineInput[T]]]]
+        e   <- arbitrary[Input[List[EmissionLineInput[T]]]]
         fdc <- arbitrary[Input[MeasureInput[PosBigDecimal, FluxDensityContinuum[T]]]]
-      } yield EmissionLinesInput(ls, fdc)
+      } yield EmissionLinesInput(ls, e, fdc)
     }
 
   implicit def cogEmissionLinesInput[T](
@@ -188,9 +192,11 @@ trait ArbSourceProfileModel {
   ): Cogen[EmissionLinesInput[T]] =
     Cogen[(
       Input[List[EmissionLineInput[T]]],
+      Input[List[EmissionLineInput[T]]],
       Input[MeasureInput[PosBigDecimal, FluxDensityContinuum[T]]]
     )].contramap { in => (
       in.lines,
+      in.lineEdits,
       in.fluxDensityContinuum
     )}
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbSourceProfileModel.scala
@@ -134,7 +134,8 @@ trait ArbSourceProfileModel {
         s <- arbitrary[Input[UnnormalizedSedInput]]
         b <- arbitrary[Input[List[BandBrightnessInput[T]]]]
         e <- arbitrary[Input[List[BandBrightnessInput[T]]]]
-      } yield BandNormalizedInput(s, b, e)
+        d <- arbitrary[Input[List[Band]]]
+      } yield BandNormalizedInput(s, b, e, d)
     }
 
   implicit def cogBandNormalizedInput[T](
@@ -143,11 +144,13 @@ trait ArbSourceProfileModel {
     Cogen[(
       Input[UnnormalizedSedInput],
       Input[List[BandBrightnessInput[T]]],
-      Input[List[BandBrightnessInput[T]]]
+      Input[List[BandBrightnessInput[T]]],
+      Input[List[Band]]
     )].contramap { in => (
       in.sed,
       in.brightnesses,
-      in.brightnessEdits
+      in.editBrightnesses,
+      in.deleteBrightnesses
     )}
 
   implicit def arbEmissionLineInput[T](
@@ -182,8 +185,9 @@ trait ArbSourceProfileModel {
       for {
         ls  <- arbitrary[Input[List[EmissionLineInput[T]]]]
         e   <- arbitrary[Input[List[EmissionLineInput[T]]]]
+        d   <- arbitrary[Input[List[WavelengthModel.Input]]]
         fdc <- arbitrary[Input[MeasureInput[PosBigDecimal, FluxDensityContinuum[T]]]]
-      } yield EmissionLinesInput(ls, e, fdc)
+      } yield EmissionLinesInput(ls, e, d, fdc)
     }
 
   implicit def cogEmissionLinesInput[T](
@@ -193,10 +197,12 @@ trait ArbSourceProfileModel {
     Cogen[(
       Input[List[EmissionLineInput[T]]],
       Input[List[EmissionLineInput[T]]],
+      Input[List[WavelengthModel.Input]],
       Input[MeasureInput[PosBigDecimal, FluxDensityContinuum[T]]]
     )].contramap { in => (
       in.lines,
-      in.lineEdits,
+      in.editLines,
+      in.deleteLines,
       in.fluxDensityContinuum
     )}
 

--- a/modules/service/src/test/scala/test/targets/SourceProfileSuite.scala
+++ b/modules/service/src/test/scala/test/targets/SourceProfileSuite.scala
@@ -1,0 +1,259 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package test
+package targets
+
+import cats.syntax.option._
+import io.circe.literal._
+
+class SourceProfileSuite extends OdbSuite {
+
+  // J value set to 42
+  // H error set to null
+  // Add new U entry
+  queryTest(
+    query     = """
+      mutation EditMagnitude($targetEdit: EditTargetInput!) {
+        updateTarget(input: $targetEdit) {
+          id
+          name
+          sourceProfile {
+            point {
+              bandNormalized {
+                brightnesses {
+                  band
+                  value
+                  units
+                  error
+                }
+              }
+            }
+          }
+        }
+      }
+    """,
+    expected  = json"""
+      {
+        "updateTarget": {
+          "id": "t-3",
+          "name": "NGC 3269",
+          "sourceProfile": {
+            "point": {
+              "bandNormalized": {
+                "brightnesses": [
+                  {
+                    "band": "U",
+                    "value": 10.000,
+                    "units": "VEGA_MAGNITUDE",
+                    "error": null
+                  },
+                  {
+                    "band": "B",
+                    "value": 13.240,
+                    "units": "VEGA_MAGNITUDE",
+                    "error": null
+                  },
+                  {
+                    "band": "V",
+                    "value": 13.510,
+                    "units": "VEGA_MAGNITUDE",
+                    "error": null
+                  },
+                  {
+                    "band": "R",
+                    "value": 11.730,
+                    "units": "VEGA_MAGNITUDE",
+                    "error": null
+                  },
+                  {
+                    "band": "J",
+                    "value": 42.000,
+                    "units": "VEGA_MAGNITUDE",
+                    "error": 0.018
+                  },
+                  {
+                    "band": "H",
+                    "value": 9.387,
+                    "units": "VEGA_MAGNITUDE",
+                    "error": null
+                  },
+                  {
+                    "band": "K",
+                    "value": 9.055,
+                    "units": "VEGA_MAGNITUDE",
+                    "error": 0.031
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    """,
+    variables = json"""
+      {
+        "targetEdit": {
+          "targetId": "t-3",
+          "sourceProfile": {
+            "point": {
+              "bandNormalized": {
+                "editBrightnesses": [
+                  {
+                    "band": "J",
+                    "value": 42.0
+                  },
+                  {
+                    "band": "H",
+                    "error": null
+                  },
+                  {
+                    "band": "U",
+                    "value": 10.0,
+                    "units": "VEGA_MAGNITUDE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    """.some,
+    clients   = List(ClientOption.Http)
+  )
+
+  // Replace all magnitudes with one U entry
+  queryTest(
+    query     = """
+      mutation EditMagnitude($targetEdit: EditTargetInput!) {
+        updateTarget(input: $targetEdit) {
+          id
+          name
+          sourceProfile {
+            point {
+              bandNormalized {
+                brightnesses {
+                  band
+                  value
+                  units
+                  error
+                }
+              }
+            }
+          }
+        }
+      }
+    """,
+    expected  = json"""
+      {
+        "updateTarget": {
+          "id": "t-2",
+          "name": "NGC 5949",
+          "sourceProfile": {
+            "point": {
+              "bandNormalized": {
+                "brightnesses": [
+                  {
+                    "band": "U",
+                    "value": 10.000,
+                    "units": "VEGA_MAGNITUDE",
+                    "error": null
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    """,
+    variables = json"""
+      {
+        "targetEdit": {
+          "targetId": "t-2",
+          "sourceProfile": {
+            "point": {
+              "bandNormalized": {
+                "brightnesses": [
+                  {
+                    "band": "U",
+                    "value": 10.0,
+                    "units": "VEGA_MAGNITUDE"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    """.some,
+    clients   = List(ClientOption.Http)
+  )
+
+  // Delete all but V, set its error to 10
+  queryTest(
+    query     = """
+      mutation EditMagnitude($targetEdit: EditTargetInput!) {
+        updateTarget(input: $targetEdit) {
+          id
+          name
+          sourceProfile {
+            point {
+              bandNormalized {
+                brightnesses {
+                  band
+                  value
+                  units
+                  error
+                }
+              }
+            }
+          }
+        }
+      }
+    """,
+    expected  = json"""
+      {
+        "updateTarget": {
+          "id": "t-4",
+          "name": "NGC 3312",
+          "sourceProfile": {
+            "point": {
+              "bandNormalized": {
+                "brightnesses": [
+                  {
+                    "band": "V",
+                    "value": 13.960,
+                    "units": "VEGA_MAGNITUDE",
+                    "error": 10.000
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    """,
+    variables = json"""
+      {
+        "targetEdit": {
+          "targetId": "t-4",
+          "sourceProfile": {
+            "point": {
+              "bandNormalized": {
+                "editBrightnesses": [
+                  {
+                    "band": "V",
+                    "error": 10.0
+                  }
+                ],
+                "deleteBrightnesses": [ "B", "J", "H", "K" ]
+              }
+            }
+          }
+        }
+      }
+    """.some,
+    clients   = List(ClientOption.Http)
+  )
+
+}


### PR DESCRIPTION
Proposes adding `editBrightnesses` and `deleteBrightnesses` in addition to `brightnesses` in `BandNormalizedInput`.  So you use `brightnesses` to set the magnitudes to a given list of values.  This matches the `brightnesses` field in the output type.  If you want to make changes to existing brightnesses (adding or modifying) you can instead (or in addition) set `editBrightnesses` to the changes you want to make.  Finally `deleteBrightnesses` can be set the bands of the corresponding entries to remove.

Adds the same pattern for wavelengths and emission lines.