### PR TITLE
Constraint set makeover

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ConstraintSetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ConstraintSetModel.scala
@@ -57,7 +57,7 @@ object ConstraintSetModel extends ConstraintSetModelOptics {
     cloudExtinction: CloudExtinction,
     skyBackground:   SkyBackground,
     waterVapor:      WaterVapor,
-    elevationRange:  ElevationRangeModel.Create
+    elevationRange:  ElevationRangeInput
   ) {
 
     def create: ValidatedInput[ConstraintSetModel] =
@@ -80,11 +80,11 @@ object ConstraintSetModel extends ConstraintSetModelOptics {
   }
 
   final case class Edit(
-    imageQuality:    Input[ImageQuality]               = Input.ignore,
-    cloudExtinction: Input[CloudExtinction]            = Input.ignore,
-    skyBackground:   Input[SkyBackground]              = Input.ignore,
-    waterVapor:      Input[WaterVapor]                 = Input.ignore,
-    elevationRange:  Input[ElevationRangeModel.Create] = Input.ignore
+    imageQuality:    Input[ImageQuality]        = Input.ignore,
+    cloudExtinction: Input[CloudExtinction]     = Input.ignore,
+    skyBackground:   Input[SkyBackground]       = Input.ignore,
+    waterVapor:      Input[WaterVapor]          = Input.ignore,
+    elevationRange:  Input[ElevationRangeInput] = Input.ignore
   ) {
 
     def editor: StateT[EitherInput, ConstraintSetModel, Unit] = {

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ElevationRangeModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ElevationRangeModel.scala
@@ -79,8 +79,6 @@ object ElevationRangeInput {
   implicit val EqElevationRangeInput: Eq[ElevationRangeInput] =
     Eq.by(c => (c.airmassRange, c.hourAngleRange))
 
-//  implicit val InputValidatorCreate: InputValidator[ElevationRangeInput, ElevationRangeModel] =
-//    InputValidator.by(_.create)
 }
 
 /**

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ElevationRangeModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ElevationRangeModel.scala
@@ -93,7 +93,7 @@ sealed abstract case class AirmassRange protected (
 object AirmassRange extends AirmassRangeOptics {
   val MinValue = BigDecimal(1.0)
   val MaxValue = BigDecimal(3.0)
-  type Value = Interval.Closed[MinValue.type, MaxValue.type]
+  type Value        = Interval.Closed[MinValue.type, MaxValue.type]
   type DecimalValue = BigDecimal Refined Value
 
   val Any: AirmassRange =

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ElevationRangeModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ElevationRangeModel.scala
@@ -4,9 +4,13 @@
 package lucuma.odb.api.model
 
 import cats._
+import cats.data.StateT
 import cats.syntax.all._
+import clue.data.Input
+import clue.data.syntax._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Interval
+import eu.timepit.refined.numeric.Interval.Closed
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 import lucuma.core.math._
@@ -27,38 +31,56 @@ object ElevationRangeModel {
 
   implicit val EqElevationRange: Eq[ElevationRangeModel] = Eq.fromUniversalEquals
 
-  final case class Create(
-    airmassRange:   Option[AirmassRange.Create],
-    hourAngleRange: Option[HourAngleRange.Create]
-  ) {
-    def create: ValidatedInput[ElevationRangeModel] =
-      ValidatedInput.requireOne("elevationRange",
-                                airmassRange.map(_.create),
-                                hourAngleRange.map(_.create)
-      )
+}
+
+final case class ElevationRangeInput(
+  airmassRange:   Input[AirmassRangeInput]   = Input.ignore,
+  hourAngleRange: Input[HourAngleRangeInput] = Input.ignore
+) extends EditorInput[ElevationRangeModel] {
+
+  override val create: ValidatedInput[ElevationRangeModel] =
+    ValidatedInput.requireOne(
+      "elevationRange",
+      airmassRange.map(_.create).toOption,
+      hourAngleRange.map(_.create).toOption
+    )
+
+  override val edit: StateT[EitherInput, ElevationRangeModel, Unit] =
+    EditorInput.editOneOf(
+      ("airmassRange",   airmassRange,   ElevationRangeModel.airmassRange),
+      ("hourAngleRange", hourAngleRange, ElevationRangeModel.hourAngleRange)
+    )
+
+}
+
+/**
+ * Input parameter used to create an elevation range. Both fields
+ * are optional, but validation will check that exactly one is defined.
+ */
+object ElevationRangeInput {
+  val Empty: ElevationRangeInput =
+    ElevationRangeInput()
+
+  def airmassRange(amr: AirmassRangeInput): ElevationRangeInput =
+    Empty.copy(airmassRange = amr.assign)
+
+  def hourAngleRange(har: HourAngleRangeInput): ElevationRangeInput =
+    Empty.copy(hourAngleRange = har.assign)
+
+
+  implicit val DecoderElevationRangeInput: Decoder[ElevationRangeInput] = {
+    import io.circe.generic.extras.semiauto._
+    import io.circe.generic.extras.Configuration
+    implicit val customConfig: Configuration = Configuration.default.withDefaults
+
+    deriveConfiguredDecoder[ElevationRangeInput]
   }
 
-  /**
-   * Input parameter used to create an elevation range. Both fields
-   * are optional, but validation will check that exactly one is defined.
-   */
-  object Create {
-    val Empty: Create = Create(airmassRange = None, hourAngleRange = None)
+  implicit val EqElevationRangeInput: Eq[ElevationRangeInput] =
+    Eq.by(c => (c.airmassRange, c.hourAngleRange))
 
-    def airmassRange(amr: AirmassRange.Create): Create =
-      Empty.copy(airmassRange = amr.some)
-
-    def hourAngleRange(har: HourAngleRange.Create): Create =
-      Empty.copy(hourAngleRange = har.some)
-
-    implicit val DecoderCreate: Decoder[Create] = deriveDecoder
-
-    implicit val EqCreate: Eq[Create] =
-      Eq.by(c => (c.airmassRange, c.hourAngleRange))
-
-    implicit val InputValidatorCreate: InputValidator[Create, ElevationRangeModel] =
-      InputValidator.by(_.create)
-  }
+//  implicit val InputValidatorCreate: InputValidator[ElevationRangeInput, ElevationRangeModel] =
+//    InputValidator.by(_.create)
 }
 
 /**
@@ -73,7 +95,7 @@ sealed abstract case class AirmassRange protected (
 object AirmassRange extends AirmassRangeOptics {
   val MinValue = BigDecimal(1.0)
   val MaxValue = BigDecimal(3.0)
-  type Value        = Interval.Closed[MinValue.type, MaxValue.type]
+  type Value = Interval.Closed[MinValue.type, MaxValue.type]
   type DecimalValue = BigDecimal Refined Value
 
   val Any: AirmassRange =
@@ -85,6 +107,7 @@ object AirmassRange extends AirmassRangeOptics {
   /**
    * Construct a new AirmassRange.
    * min must be <= max.
+   *
    * @group Optics
    */
   def apply(min: DecimalValue, max: DecimalValue): Option[AirmassRange] =
@@ -100,32 +123,6 @@ object AirmassRange extends AirmassRangeOptics {
       ) {}
 
   implicit val EqAirmassRange: Eq[AirmassRange] = Eq.fromUniversalEquals
-
-  /**
-   * Input parameter used to create an airmass range. Parameter ranges
-   * are validated and min must be <= max
-   */
-  final case class Create(min: BigDecimal, max: BigDecimal) {
-    def create: ValidatedInput[AirmassRange] =
-      (ValidatedInput.closedInterval("min", min, MinValue, MaxValue),
-       ValidatedInput.closedInterval("max", max, MinValue, MaxValue)
-      ).tupled.andThen { case (min, max) =>
-        apply(min, max).toValidNec(
-          InputError.fromMessage(s"Invalid AirmassRange: 'min' must be <= 'max'")
-        )
-      }
-  }
-
-  object Create {
-    implicit val DecoderCreateAirmassRange: Decoder[Create] =
-      deriveDecoder[Create]
-
-    implicit val EqCreateAirmassRange: Eq[Create] =
-      Eq.fromUniversalEquals
-
-    implicit val ValidatorCreateAirmassRange: InputValidator[Create, AirmassRange] =
-      InputValidator.by(_.create)
-  }
 }
 
 trait AirmassRangeOptics {
@@ -134,11 +131,8 @@ trait AirmassRangeOptics {
   /** @group Optics */
   lazy val fromOrderedDecimalValues: Prism[(DecimalValue, DecimalValue), AirmassRange] =
     Prism[(DecimalValue, DecimalValue), AirmassRange] { case (min, max) =>
-      if (min.value <= max.value) (new AirmassRange(min, max) {}).some
-      else none
-    } { a =>
-      (a.min, a.max)
-    }
+      Option.when(min.value <= max.value)(new AirmassRange(min, max) {})
+    } { a => (a.min, a.max) }
 
   /** @group Optics */
   lazy val min: Getter[AirmassRange, DecimalValue] =
@@ -147,6 +141,56 @@ trait AirmassRangeOptics {
   /** @group Optics */
   lazy val max: Getter[AirmassRange, DecimalValue] =
     Getter(_.max)
+}
+
+final case class AirmassRangeInput(
+  min: Option[BigDecimal],
+  max: Option[BigDecimal]
+) extends EditorInput[AirmassRange] {
+
+  import AirmassRange._
+
+  private def invalidRange(min: DecimalValue, max: DecimalValue): InputError =
+    InputError.fromMessage(
+      s"""Invalid AirmassRange: "min" value ${min.value} must be <= "max" value ${max.value}."""
+    )
+
+  override val create: ValidatedInput[AirmassRange] = {
+
+    def checkRange(name: String, value: Option[BigDecimal]): ValidatedInput[Refined[BigDecimal, Closed[MinValue.type, MaxValue.type]]] =
+      value
+        .toValidNec(InputError.fromMessage(s""""$name" parameter of AirmassRange must be defined on creation"""))
+        .andThen(v => ValidatedInput.closedInterval(name, v, MinValue, MaxValue))
+
+    (checkRange("min", min),
+     checkRange("max", max)
+    ).tupled.andThen { case (min, max) =>
+      AirmassRange(min, max).toValidNec(invalidRange(min, max))
+    }
+  }
+
+  override val edit: StateT[EitherInput, AirmassRange, Unit] =
+    for {
+      min0 <- StateT.liftF(min.traverse(n => ValidatedInput.closedInterval("min", n, MinValue, MaxValue)).toEither)
+      max0 <- StateT.liftF(max.traverse(x => ValidatedInput.closedInterval("max", x, MinValue, MaxValue)).toEither)
+      min1 <- StateT.inspect[EitherInput, AirmassRange, DecimalValue](r => min0.getOrElse(r.min))
+      max1 <- StateT.inspect[EitherInput, AirmassRange, DecimalValue](r => max0.getOrElse(r.max))
+      _ <- StateT.setF(AirmassRange(min1, max1).toRightNec(invalidRange(min1, max1)))
+    } yield ()
+
+}
+
+object AirmassRangeInput {
+
+  implicit val DecoderAirmassRangeInput: Decoder[AirmassRangeInput] =
+    deriveDecoder[AirmassRangeInput]
+
+  implicit val EqAirmassRangeInput: Eq[AirmassRangeInput] =
+    Eq.by { a => (
+      a.min,
+      a.max
+    )}
+
 }
 
 /**
@@ -183,32 +227,6 @@ object HourAngleRange extends HourAngleRangeOptics {
     fromOrderedDecimalHours.getOption((minHours, maxHours))
 
   implicit val EqHourAngleRange: Eq[HourAngleRange] = Eq.fromUniversalEquals
-
-  /**
-   * Input parameter used to create an hour angle range. Parameter ranges
-   * are validated and minHours must be <= maxHours
-   */
-  final case class Create(minHours: BigDecimal, maxHours: BigDecimal) {
-    def create: ValidatedInput[HourAngleRange] =
-      (ValidatedInput.closedInterval("minHours", minHours, MinHour, MaxHour),
-       ValidatedInput.closedInterval("maxHours", maxHours, MinHour, MaxHour)
-      ).tupled.andThen { case (min, max) =>
-        apply(min, max).toValidNec(
-          InputError.fromMessage(s"Invalid HourAngleRange: 'minHours' must be <= 'maxHours'")
-        )
-      }
-  }
-
-  object Create {
-    implicit val DecoderCreateHourAngleRange: Decoder[Create] =
-      deriveDecoder[Create]
-
-    implicit val EqCreateHourAngleRange: Eq[Create] =
-      Eq.fromUniversalEquals
-
-    implicit val ValidatorCreateHourAngleRange: InputValidator[Create, HourAngleRange] =
-      InputValidator.by(_.create)
-  }
 }
 
 trait HourAngleRangeOptics {
@@ -216,11 +234,8 @@ trait HourAngleRangeOptics {
 
   lazy val fromOrderedDecimalHours: Prism[(DecimalHour, DecimalHour), HourAngleRange] =
     Prism[(DecimalHour, DecimalHour), HourAngleRange] { case (minHours, maxHours) =>
-      if (minHours.value <= maxHours.value) (new HourAngleRange(minHours, maxHours) {}).some
-      else none
-    } { a =>
-      (a.minHours, a.maxHours)
-    }
+      Option.when(minHours.value <= maxHours.value)(new HourAngleRange(minHours, maxHours) {})
+    } { a => (a.minHours, a.maxHours) }
 
   /** @group Optics */
   lazy val minHours: Getter[HourAngleRange, DecimalHour] =
@@ -229,4 +244,54 @@ trait HourAngleRangeOptics {
   /** @group Optics */
   lazy val maxHours: Getter[HourAngleRange, DecimalHour] =
     Getter(_.maxHours)
+}
+
+final case class HourAngleRangeInput(
+  minHours: Option[BigDecimal],
+  maxHours: Option[BigDecimal]
+) extends EditorInput[HourAngleRange] {
+
+  import HourAngleRange._
+
+  private def invalidRange(min: DecimalHour, max: DecimalHour): InputError =
+    InputError.fromMessage(
+      s"""Invalid HourAngleRange: "minHours" value ${min.value} must be <= "maxHours" value ${max.value}."""
+    )
+
+  override val create: ValidatedInput[HourAngleRange] = {
+    def checkRange(name: String, value: Option[BigDecimal]): ValidatedInput[Refined[BigDecimal, Closed[MinHour.type, MaxHour.type]]] =
+      value
+        .toValidNec(InputError.fromMessage(s""""$name" parameter of HourAngleRange must be defined on creation"""))
+        .andThen(v => ValidatedInput.closedInterval(name, v, MinHour, MaxHour))
+
+    (checkRange("min", minHours),
+     checkRange("max", maxHours)
+    ).tupled.andThen { case (min, max) =>
+      HourAngleRange(min, max).toValidNec(invalidRange(min,  max))
+    }
+
+  }
+
+  override val edit: StateT[EitherInput, HourAngleRange, Unit] =
+    for {
+      min0 <- StateT.liftF(minHours.traverse(n => ValidatedInput.closedInterval("minHours", n, MinHour, MaxHour)).toEither)
+      max0 <- StateT.liftF(maxHours.traverse(x => ValidatedInput.closedInterval("maxHours", x, MinHour, MaxHour)).toEither)
+      min1 <- StateT.inspect[EitherInput, HourAngleRange, DecimalHour](r => min0.getOrElse(r.minHours))
+      max1 <- StateT.inspect[EitherInput, HourAngleRange, DecimalHour](r => max0.getOrElse(r.maxHours))
+      _    <- StateT.setF(HourAngleRange(min1, max1).toRightNec(invalidRange(min1, max1)))
+    } yield ()
+
+}
+
+object HourAngleRangeInput {
+
+  implicit val DecoderHourAngleRangeInput: Decoder[HourAngleRangeInput] =
+    deriveDecoder[HourAngleRangeInput]
+
+  implicit val EqHourAngleRangeInput: Eq[HourAngleRangeInput] =
+    Eq.by { a => (
+      a.minHours,
+      a.maxHours
+    )}
+
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -82,7 +82,7 @@ object ObservationModel extends ObservationOptics {
     status:               Option[ObsStatus],
     activeStatus:         Option[ObsActiveStatus],
     targets:              Option[TargetEnvironmentModel.Create],
-    constraintSet:        Option[ConstraintSetModel.Create],
+    constraintSet:        Option[ConstraintSetInput],
     scienceRequirements:  Option[ScienceRequirementsModel.Create],
     scienceConfiguration: Option[ScienceConfigurationModel.Create],
     config:               Option[InstrumentConfigModel.Create]
@@ -165,7 +165,7 @@ object ObservationModel extends ObservationOptics {
     status:               Input[ObsStatus]                      = Input.ignore,
     activeStatus:         Input[ObsActiveStatus]                = Input.ignore,
     targets:              Option[TargetEnvironmentModel.Edit]   = None,
-    constraintSet:        Option[ConstraintSetModel.Edit]       = None,
+    constraintSet:        Option[ConstraintSetInput]            = None,
     scienceRequirements:  Option[ScienceRequirementsModel.Edit] = None,
     scienceConfiguration: Input[ScienceConfigurationModelEdit]  = Input.ignore
   ) {
@@ -197,7 +197,7 @@ object ObservationModel extends ObservationOptics {
                   targets.fold(empty[TargetEnvironmentModel])(_.editor)
                 )
         _    <- ObservationModel.constraintSet.transform(
-                  constraintSet.fold(empty[ConstraintSetModel])(_.editor)
+                  constraintSet.fold(empty[ConstraintSetModel])(_.edit)
                 )
         _    <- ObservationModel.scienceRequirements.transform(
                   scienceRequirements.fold(empty[ScienceRequirements])(_.editor)

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
@@ -8,7 +8,7 @@ import cats.effect.{Async, Ref}
 import cats.implicits._
 import lucuma.core.model.{Observation, Program, Target}
 import lucuma.odb.api.model.ObservationModel.{BulkEdit, Create, Edit, Group, ObservationEvent}
-import lucuma.odb.api.model.{ConstraintSetModel, EitherInput, Event, InputError, InstrumentConfigModel, ObservationModel, PlannedTimeSummaryModel, ScienceRequirements, ScienceRequirementsModel, ValidatedInput}
+import lucuma.odb.api.model.{ConstraintSetInput, ConstraintSetModel, EitherInput, Event, InputError, InstrumentConfigModel, ObservationModel, PlannedTimeSummaryModel, ScienceRequirements, ScienceRequirementsModel, ValidatedInput}
 import lucuma.odb.api.model.syntax.lens._
 import lucuma.odb.api.model.syntax.toplevel._
 import lucuma.odb.api.model.syntax.validatedinput._
@@ -84,7 +84,7 @@ sealed trait ObservationRepo[F[_]] extends TopLevelRepo[F, Observation.Id, Obser
   ): F[List[ObservationModel]]
 
   def bulkEditConstraintSet(
-    be: BulkEdit[ConstraintSetModel.Edit]
+    be: BulkEdit[ConstraintSetInput]
   ): F[List[ObservationModel]]
 
   def bulkEditScienceRequirements(
@@ -360,12 +360,12 @@ object ObservationRepo {
       }
 
       override def bulkEditConstraintSet(
-        be: BulkEdit[ConstraintSetModel.Edit]
+        be: BulkEdit[ConstraintSetInput]
       ): F[List[ObservationModel]] =
 
         bulkEdit(
           selectObservations(be.selectProgram, be.selectObservations),
-          ObservationModel.constraintSet.transform(be.edit.editor)
+          ObservationModel.constraintSet.transform(be.edit.edit)
         )
 
       override def bulkEditScienceRequirements(

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetMutation.scala
@@ -3,7 +3,7 @@
 
 package lucuma.odb.api.schema
 
-import lucuma.odb.api.model.{AirmassRange, ConstraintSetModel, ElevationRangeModel, HourAngleRange}
+import lucuma.odb.api.model.{AirmassRangeInput, ConstraintSetModel, ElevationRangeInput, HourAngleRangeInput}
 import lucuma.odb.api.schema.syntax.inputtype._
 import sangria.macros.derive._
 import sangria.marshalling.circe._
@@ -14,22 +14,26 @@ trait ConstraintSetMutation {
   import ConstraintSetSchema._
   import syntax.inputobjecttype._
 
-  implicit val InputObjectTypeAirmassRangeCreate: InputObjectType[AirmassRange.Create] =
-    deriveInputObjectType[AirmassRange.Create](
-      InputObjectTypeName("CreateAirmassRangeInput"),
-      InputObjectTypeDescription("Airmass range creation parameters")
+  implicit val InputObjectTypeAirmassRange: InputObjectType[AirmassRangeInput] =
+    deriveInputObjectType[AirmassRangeInput](
+      InputObjectTypeName("AirmassRangeInput"),
+      InputObjectTypeDescription("Airmass range creation and edit parameters")
     )
 
-  implicit val InputObjectTypeHourAngleRangeCreate: InputObjectType[HourAngleRange.Create] =
-    deriveInputObjectType[HourAngleRange.Create](
+  implicit val InputObjectTypeHourAngleRange: InputObjectType[HourAngleRangeInput] =
+    deriveInputObjectType[HourAngleRangeInput](
       InputObjectTypeName("CreateHourAngleRangeInput"),
       InputObjectTypeDescription("Hour angle range creation parameters")
     )
 
-  implicit val InputObjectTypeElevationRangeCreate: InputObjectType[ElevationRangeModel.Create] =
-    deriveInputObjectType[ElevationRangeModel.Create](
-      InputObjectTypeName("CreateElevationRangeInput"),
-      InputObjectTypeDescription("Elevation range creation parameters")
+  implicit val InputObjectTypeElevationRange: InputObjectType[ElevationRangeInput] =
+    InputObjectType[ElevationRangeInput](
+      "ElevationRangeInput",
+      "Elevation range creation and edit parameters.  Choose one of airmass or hour angle constraints.",
+      List(
+        InputObjectTypeAirmassRange.optionField("airmassRange"),
+        InputObjectTypeHourAngleRange.optionField("hourAngleRange")
+      )
     )
 
   implicit val InputObjectTypeConstraintSetCreate: InputObjectType[ConstraintSetModel.Create] =
@@ -55,7 +59,7 @@ trait ConstraintSetMutation {
       ReplaceInputField("skyBackground", EnumTypeSkyBackground.notNullableField("skyBackground")),
       ReplaceInputField("waterVapor", EnumTypeWaterVapor.notNullableField("waterVapor")),
       ReplaceInputField("elevationRange",
-                        InputObjectTypeElevationRangeCreate.notNullableField("elevationRange")
+                        InputObjectTypeElevationRange.notNullableField("elevationRange")
       )
     )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetMutation.scala
@@ -3,7 +3,7 @@
 
 package lucuma.odb.api.schema
 
-import lucuma.odb.api.model.{AirmassRangeInput, ConstraintSetModel, ElevationRangeInput, HourAngleRangeInput}
+import lucuma.odb.api.model.{AirmassRangeInput, ConstraintSetInput, ElevationRangeInput, HourAngleRangeInput}
 import lucuma.odb.api.schema.syntax.inputtype._
 import sangria.macros.derive._
 import sangria.marshalling.circe._
@@ -36,32 +36,25 @@ trait ConstraintSetMutation {
       )
     )
 
-  implicit val InputObjectTypeConstraintSetCreate: InputObjectType[ConstraintSetModel.Create] =
-    deriveInputObjectType[ConstraintSetModel.Create](
-      InputObjectTypeName("CreateConstraintSetInput"),
-      InputObjectTypeDescription("Constraint set creation parameters")
+  implicit val InputObjectTypeConstraintSet: InputObjectType[ConstraintSetInput] =
+    InputObjectType[ConstraintSetInput](
+      "ConstraintSetInput",
+      "Constraint set creation and editing parameters",
+      List(
+        EnumTypeImageQuality.createRequiredEditOptional("imageQuality", "ConstraintSet"),
+        EnumTypeCloudExtinction.createRequiredEditOptional("cloudExtinction", "ConstraintSet"),
+        EnumTypeSkyBackground.createRequiredEditOptional("skyBackground", "ConstraintSet"),
+        EnumTypeWaterVapor.createRequiredEditOptional("waterVapor", "ConstraintSet"),
+        InputObjectTypeElevationRange.createRequiredEditOptional("elevationRange", "ConstraintSet")
+      )
     )
 
-  val ArgumentConstraintSetCreate: Argument[ConstraintSetModel.Create] =
-    InputObjectTypeConstraintSetCreate.argument(
+  val ArgumentConstraintSetInput: Argument[ConstraintSetInput] =
+    InputObjectTypeConstraintSet.argument(
       "input",
       "Constraint set description"
     )
 
-  implicit val InputObjectTypeConstraintSetEdit: InputObjectType[ConstraintSetModel.Edit] =
-    deriveInputObjectType[ConstraintSetModel.Edit](
-      InputObjectTypeName("EditConstraintSetInput"),
-      InputObjectTypeDescription("Edit constraint set"),
-      ReplaceInputField("imageQuality", EnumTypeImageQuality.notNullableField("imageQuality")),
-      ReplaceInputField("cloudExtinction",
-                        EnumTypeCloudExtinction.notNullableField("cloudExtinction")
-      ),
-      ReplaceInputField("skyBackground", EnumTypeSkyBackground.notNullableField("skyBackground")),
-      ReplaceInputField("waterVapor", EnumTypeWaterVapor.notNullableField("waterVapor")),
-      ReplaceInputField("elevationRange",
-                        InputObjectTypeElevationRange.notNullableField("elevationRange")
-      )
-    )
 
 }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ConstraintSetSchema.scala
@@ -65,12 +65,26 @@ object ConstraintSetSchema {
         )
     )
 
-  def ElevationRangeModelType[F[_]]: OutputType[ElevationRangeModel] =
-    UnionType(
+  def ElevationRangeModelType[F[_]]: ObjectType[OdbRepo[F], ElevationRangeModel] =
+    ObjectType(
       name        = "ElevationRange",
-      description = Some("Either airmass range or elevation range"),
-      types       = List(AirMassRangeType[F], HourAngleRangeType[F])
-    ).mapValue[ElevationRangeModel](identity)
+      description = "Either airmass range or elevation range",
+      fieldsFn    = () =>
+        fields(
+          Field(
+            name        = "airmassRange",
+            fieldType   = OptionType(AirMassRangeType[F]),
+            description = Some("Airmass range if elevation range is an Airmass range"),
+            resolve     = c => ElevationRangeModel.airmassRange.getOption(c.value)
+          ),
+          Field(
+            name        = "hourAngleRange",
+            fieldType   = OptionType(HourAngleRangeType[F]),
+            description = Some("Hour angle range if elevation range is an Hour angle range"),
+            resolve     = c => ElevationRangeModel.hourAngleRange.getOption(c.value)
+          )
+        )
+    )
 
   def ConstraintSetType[F[_]]: ObjectType[OdbRepo[F], ConstraintSetModel] =
     ObjectType(
@@ -106,18 +120,6 @@ object ConstraintSetSchema {
             fieldType   = ElevationRangeModelType,
             description = Some("Either airmass range or elevation range"),
             resolve     = _.value.elevationRange
-          ),
-          Field(
-            name        = "airmassRange",
-            fieldType   = OptionType(AirMassRangeType[F]),
-            description = Some("Airmass range if elevation range is an Airmass range"),
-            resolve     = c => ElevationRangeModel.airmassRange.getOption(c.value.elevationRange)
-          ),
-          Field(
-            name        = "hourAngleRange",
-            fieldType   = OptionType(HourAngleRangeType[F]),
-            description = Some("Hour angle range if elevation range is an Hour angle range"),
-            resolve     = c => ElevationRangeModel.hourAngleRange.getOption(c.value.elevationRange)
           )
         )
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -3,7 +3,7 @@
 
 package lucuma.odb.api.schema
 
-import lucuma.odb.api.model.{ConstraintSetModel, ObservationModel, ScienceRequirementsModel}
+import lucuma.odb.api.model.{ConstraintSetInput, ObservationModel, ScienceRequirementsModel}
 import lucuma.odb.api.model.ObservationModel.BulkEdit
 import lucuma.odb.api.repo.OdbRepo
 import lucuma.odb.api.schema.syntax.inputtype._
@@ -17,7 +17,7 @@ import sangria.schema._
 
 trait ObservationMutation {
 
-  import ConstraintSetMutation.{InputObjectTypeConstraintSetCreate, InputObjectTypeConstraintSetEdit}
+  import ConstraintSetMutation.InputObjectTypeConstraintSet
   import context._
   import ScienceConfigurationMutation.{InputObjectTypeScienceConfigurationCreate, InputObjectTypeScienceConfigurationSetEdit}
   import ScienceRequirementsMutation.{InputObjectTypeScienceRequirementsCreate, InputObjectTypeScienceRequirementsEdit}
@@ -49,7 +49,7 @@ trait ObservationMutation {
       ReplaceInputField("status",               ObsStatusType.notNullableField("status")),
       ReplaceInputField("activeStatus",         ObsActiveStatusType.notNullableField("activeStatus")),
       ReplaceInputField("targets",              InputObjectTypeTargetEnvironmentEdit.notNullableField("targetEnvironment")),
-      ReplaceInputField("constraintSet",        InputObjectTypeConstraintSetEdit.notNullableField("constraintSet")),
+      ReplaceInputField("constraintSet",        InputObjectTypeConstraintSet.notNullableField("constraintSet")),
       ReplaceInputField("scienceRequirements",  InputObjectTypeScienceRequirementsEdit.nullableField("scienceRequirements")),
       ReplaceInputField("scienceConfiguration", InputObjectTypeScienceConfigurationSetEdit.nullableField("scienceConfiguration"))
     )
@@ -92,10 +92,10 @@ trait ObservationMutation {
       InputObjectTypeTargetEnvironmentEdit
     )
 
-  val ArgumentConstraintSetBulkEdit: Argument[BulkEdit[ConstraintSetModel.Edit]] =
-    bulkEditArgument[ConstraintSetModel.Edit](
+  val ArgumentConstraintSetBulkEdit: Argument[BulkEdit[ConstraintSetInput]] =
+    bulkEditArgument[ConstraintSetInput](
       "constraintSet",
-      InputObjectTypeConstraintSetEdit
+      InputObjectTypeConstraintSet
     )
 
   val ArgumentScienceRequirementsBulkEdit: Argument[BulkEdit[ScienceRequirementsModel.Edit]] =

--- a/modules/core/src/test/scala/lucuma/odb/api/model/ConstraintSetModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/ConstraintSetModelSuite.scala
@@ -24,8 +24,7 @@ final class ConstraintSetModelSuite extends DisciplineSuite {
   checkAll("ConstraintSet.elevationRange", LensTests(ConstraintSetModel.elevationRange))
   checkAll("ConstraintSet.airmass", OptionalTests(ConstraintSetModel.airmass))
   checkAll("ConstraintSet.hourAngle", OptionalTests(ConstraintSetModel.hourAngle))
-  checkAll("Eq[ConstraintSet.Create]", EqTests[ConstraintSetModel.Create].eqv)
-  checkAll("Eq[ConstraintSet.Edit]", EqTests[ConstraintSetModel.Edit].eqv)
+  checkAll("Eq[ConstraintSetInput]", EqTests[ConstraintSetInput].eqv)
 
   test("ConstraintSet.AirmassMin") {
     forAll { constraints: ConstraintSetModel =>

--- a/modules/core/src/test/scala/lucuma/odb/api/model/ElevationRangeModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/ElevationRangeModelSuite.scala
@@ -15,15 +15,15 @@ final class ElevationRangeModelSuite extends DisciplineSuite {
 
   // Laws
   checkAll("Eq[AirmassRange]", EqTests[AirmassRange].eqv)
-  checkAll("Eq[AirmassRange.Create]", EqTests[AirmassRange.Create].eqv)
+  checkAll("Eq[AirmassRangeInput]", EqTests[AirmassRangeInput].eqv)
   checkAll("AirmassRange.fromOrderedDecimalValues", PrismTests(AirmassRange.fromOrderedDecimalValues))
   checkAll("Eq[HourAngleRange]", EqTests[HourAngleRange].eqv)
-  checkAll("Eq[HourAngleRange.Create]", EqTests[HourAngleRange.Create].eqv)
+  checkAll("Eq[HourAngleRangeInput]", EqTests[HourAngleRangeInput].eqv)
   checkAll("HourAngleRange.fromDecimalHours", PrismTests(HourAngleRange.fromOrderedDecimalHours))
   checkAll("Eq[ElevationRangeModel]", EqTests[ElevationRangeModel].eqv)
   checkAll("ElevationRangeModel.airmassRange", PrismTests(ElevationRangeModel.airmassRange))
   checkAll("ElevationRangeModel.hourAngleRange", PrismTests(ElevationRangeModel.hourAngleRange))
-  checkAll("Eq[ElevationRangeModel.Create]", EqTests[ElevationRangeModel.Create].eqv)
+  checkAll("Eq[ElevationRangeInput]", EqTests[ElevationRangeInput].eqv)
 
   test("AirmassRange.min") {
     forAll { range: AirmassRange =>

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbConstraintSetModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbConstraintSetModel.scala
@@ -8,7 +8,6 @@ import clue.data.Input
 import eu.timepit.refined.scalacheck._
 import lucuma.core.enum._
 import lucuma.core.util.arb.{ ArbEnumerated, ArbGid }
-import lucuma.odb.api.model.{ ConstraintSetModel, ElevationRangeModel }
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 
@@ -53,7 +52,7 @@ trait ArbConstraintSetModel {
         ce   <- arbitrary[CloudExtinction]
         sb   <- arbitrary[SkyBackground]
         wv   <- arbitrary[WaterVapor]
-        erc  <- arbitrary[ElevationRangeModel.Create]
+        erc  <- arbitrary[ElevationRangeInput]
       } yield ConstraintSetModel.Create(iq, ce, sb, wv, erc)
     }
 
@@ -63,7 +62,7 @@ trait ArbConstraintSetModel {
        CloudExtinction,
        SkyBackground,
        WaterVapor,
-       ElevationRangeModel.Create
+       ElevationRangeInput
       )
     ].contramap(cs =>
       (cs.imageQuality,
@@ -81,7 +80,7 @@ trait ArbConstraintSetModel {
         c    <- arbitrary[Input[CloudExtinction]]
         sb   <- arbitrary[Input[SkyBackground]]
         wv   <- arbitrary[Input[WaterVapor]]
-        er   <- arbitrary[Input[ElevationRangeModel.Create]]
+        er   <- arbitrary[Input[ElevationRangeInput]]
       } yield ConstraintSetModel.Edit(iq, c, sb, wv, er)
     }
 
@@ -91,7 +90,7 @@ trait ArbConstraintSetModel {
        Input[CloudExtinction],
        Input[SkyBackground],
        Input[WaterVapor],
-       Input[ElevationRangeModel.Create]
+       Input[ElevationRangeInput]
       )
     ].contramap(cse =>
       (cse.imageQuality,

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbConstraintSetModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbConstraintSetModel.scala
@@ -7,14 +7,13 @@ package arb
 import clue.data.Input
 import eu.timepit.refined.scalacheck._
 import lucuma.core.enum._
-import lucuma.core.util.arb.{ ArbEnumerated, ArbGid }
+import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 
 trait ArbConstraintSetModel {
   import ArbElevationRange._
   import ArbEnumerated._
-  import ArbGid._
   import ArbInput._
 
   implicit val arbConstraintSet: Arbitrary[ConstraintSetModel] =
@@ -45,46 +44,18 @@ trait ArbConstraintSetModel {
       )
     )
 
-  implicit val arbConstraintSetCreate: Arbitrary[ConstraintSetModel.Create] =
-    Arbitrary {
-      for {
-        iq   <- arbitrary[ImageQuality]
-        ce   <- arbitrary[CloudExtinction]
-        sb   <- arbitrary[SkyBackground]
-        wv   <- arbitrary[WaterVapor]
-        erc  <- arbitrary[ElevationRangeInput]
-      } yield ConstraintSetModel.Create(iq, ce, sb, wv, erc)
-    }
-
-  implicit val cogConstraintSetCreate: Cogen[ConstraintSetModel.Create] =
-    Cogen[
-      (ImageQuality,
-       CloudExtinction,
-       SkyBackground,
-       WaterVapor,
-       ElevationRangeInput
-      )
-    ].contramap(cs =>
-      (cs.imageQuality,
-       cs.cloudExtinction,
-       cs.skyBackground,
-       cs.waterVapor,
-       cs.elevationRange
-      )
-    )
-
-  implicit val arbConstraintSetEdit: Arbitrary[ConstraintSetModel.Edit] =
+  implicit val arbConstraintSetInput: Arbitrary[ConstraintSetInput] =
     Arbitrary {
       for {
         iq   <- arbitrary[Input[ImageQuality]]
-        c    <- arbitrary[Input[CloudExtinction]]
+        ce   <- arbitrary[Input[CloudExtinction]]
         sb   <- arbitrary[Input[SkyBackground]]
         wv   <- arbitrary[Input[WaterVapor]]
-        er   <- arbitrary[Input[ElevationRangeInput]]
-      } yield ConstraintSetModel.Edit(iq, c, sb, wv, er)
+        erc  <- arbitrary[Input[ElevationRangeInput]]
+      } yield ConstraintSetInput(iq, ce, sb, wv, erc)
     }
 
-  implicit val cogConstraintSetEdit: Cogen[ConstraintSetModel.Edit] =
+  implicit val cogConstraintSetInput: Cogen[ConstraintSetInput] =
     Cogen[
       (Input[ImageQuality],
        Input[CloudExtinction],
@@ -92,12 +63,12 @@ trait ArbConstraintSetModel {
        Input[WaterVapor],
        Input[ElevationRangeInput]
       )
-    ].contramap(cse =>
-      (cse.imageQuality,
-       cse.cloudExtinction,
-       cse.skyBackground,
-       cse.waterVapor,
-       cse.elevationRange
+    ].contramap(cs =>
+      (cs.imageQuality,
+       cs.cloudExtinction,
+       cs.skyBackground,
+       cs.waterVapor,
+       cs.elevationRange
       )
     )
 }

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbElevationRange.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbElevationRange.scala
@@ -3,15 +3,17 @@
 
 package lucuma.odb.api.model.arb
 
+import clue.data.Input
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.scalacheck._
 import lucuma.core.util.arb.ArbEnumerated
-import lucuma.odb.api.model.{AirmassRange, ElevationRangeModel, HourAngleRange}
+import lucuma.odb.api.model.{AirmassRange, AirmassRangeInput, ElevationRangeInput, ElevationRangeModel, HourAngleRange, HourAngleRangeInput}
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 
 trait ArbElevationRange {
   import ArbEnumerated._
+  import ArbInput._
 
   implicit val arbDecimalValue: Arbitrary[AirmassRange.DecimalValue] =
     Arbitrary {
@@ -43,22 +45,22 @@ trait ArbElevationRange {
       (amr.min, amr.max)
     )
 
-  implicit val arbAirmassRangeCreate: Arbitrary[AirmassRange.Create] =
+  implicit val arbAirmassRangeInput: Arbitrary[AirmassRangeInput] =
     Arbitrary {
       for {
-        min        <- arbitrary[BigDecimal]
-        max        <- arbitrary[BigDecimal]
-        arc1        = AirmassRange.Create(min, max)
+        min        <- arbitrary[Option[BigDecimal]]
+        max        <- arbitrary[Option[BigDecimal]]
+        arc1        = AirmassRangeInput(min, max)
         // make at least some of them valid
-        minInRange <- arbitrary[AirmassRange.DecimalValue]
-        maxInRange <- arbitrary[AirmassRange.DecimalValue]
-        arc2        = AirmassRange.Create(minInRange.value, maxInRange.value)
+        minInRange <- arbitrary[Option[AirmassRange.DecimalValue]]
+        maxInRange <- arbitrary[Option[AirmassRange.DecimalValue]]
+        arc2        = AirmassRangeInput(minInRange.map(_.value), maxInRange.map(_.value))
         arc        <- Gen.oneOf(arc1, arc2)
       } yield arc
     }
 
-  implicit val cogAirmassRangeCreate: Cogen[AirmassRange.Create] =
-    Cogen[(BigDecimal, BigDecimal)].contramap(c => (c.min, c.max))
+  implicit val cogAirmassRangeInput: Cogen[AirmassRangeInput] =
+    Cogen[(Option[BigDecimal], Option[BigDecimal])].contramap(c => (c.min, c.max))
 
   implicit val arbHourAngleRange: Arbitrary[HourAngleRange] =
     Arbitrary {
@@ -75,22 +77,22 @@ trait ArbElevationRange {
       (har.minHours, har.maxHours)
     )
 
-  implicit val arbHourAngleRangeCreate: Arbitrary[HourAngleRange.Create] =
+  implicit val arbHourAngleRangeInput: Arbitrary[HourAngleRangeInput] =
     Arbitrary {
       for {
-        min        <- arbitrary[BigDecimal]
-        max        <- arbitrary[BigDecimal]
-        harc1       = HourAngleRange.Create(min, max)
+        min        <- arbitrary[Option[BigDecimal]]
+        max        <- arbitrary[Option[BigDecimal]]
+        harc1       = HourAngleRangeInput(min, max)
         // make at least some of them valid
-        minInRange <- arbitrary[HourAngleRange.DecimalHour]
-        maxInRange <- arbitrary[HourAngleRange.DecimalHour]
-        harc2       = HourAngleRange.Create(minInRange.value, maxInRange.value)
+        minInRange <- arbitrary[Option[HourAngleRange.DecimalHour]]
+        maxInRange <- arbitrary[Option[HourAngleRange.DecimalHour]]
+        harc2       = HourAngleRangeInput(minInRange.map(_.value), maxInRange.map(_.value))
         harc       <- Gen.oneOf(harc1, harc2)
       } yield harc
     }
 
-  implicit val cogHourAngleRangeCreate: Cogen[HourAngleRange.Create] =
-    Cogen[(BigDecimal, BigDecimal)].contramap(c => (c.minHours, c.maxHours))
+  implicit val cogHourAngleRangeInput: Cogen[HourAngleRangeInput] =
+    Cogen[(Option[BigDecimal], Option[BigDecimal])].contramap(c => (c.minHours, c.maxHours))
 
   implicit val arbElevationRange: Arbitrary[ElevationRangeModel] =
     Arbitrary {
@@ -107,16 +109,16 @@ trait ArbElevationRange {
       case hourAngle: HourAngleRange => Right(hourAngle)
     }
 
-  implicit val arbElevationRangeCreate: Arbitrary[ElevationRangeModel.Create] =
+  implicit val arbElevationRangeCreate: Arbitrary[ElevationRangeInput] =
     Arbitrary {
       for {
-        airmassRange   <- arbitrary[Option[AirmassRange.Create]]
-        hourAngleRange <- arbitrary[Option[HourAngleRange.Create]]
-      } yield ElevationRangeModel.Create(airmassRange, hourAngleRange)
+        airmassRange   <- arbitrary[Input[AirmassRangeInput]]
+        hourAngleRange <- arbitrary[Input[HourAngleRangeInput]]
+      } yield ElevationRangeInput(airmassRange, hourAngleRange)
     }
 
-  implicit val cogElevationRangeCreate: Cogen[ElevationRangeModel.Create] =
-    Cogen[(Option[AirmassRange.Create], Option[HourAngleRange.Create])].contramap { ermc =>
+  implicit val cogElevationRangeCreate: Cogen[ElevationRangeInput] =
+    Cogen[(Input[AirmassRangeInput], Input[HourAngleRangeInput])].contramap { ermc =>
       (ermc.airmassRange, ermc.hourAngleRange)
     }
 }

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
@@ -73,7 +73,7 @@ trait ArbObservationModel {
         st <- arbitrary[Option[ObsStatus]]
         as <- arbitrary[Option[ObsActiveStatus]]
         ts <- arbitrary[Option[TargetEnvironmentModel.Create]]
-        cs <- arbitrary[Option[ConstraintSetModel.Create]]
+        cs <- arbitrary[Option[ConstraintSetInput]]
       } yield ObservationModel.Create(
         id,
         pd,
@@ -96,7 +96,7 @@ trait ArbObservationModel {
       Option[ObsStatus],
       Option[ObsActiveStatus],
       Option[TargetEnvironmentModel.Create],
-      Option[ConstraintSetModel.Create]
+      Option[ConstraintSetInput]
     )].contramap { in => (
       in.observationId,
       in.programId,

--- a/modules/service/src/test/scala/MutationSuite.scala
+++ b/modules/service/src/test/scala/MutationSuite.scala
@@ -60,7 +60,7 @@ class MutationSuite extends OdbSuite {
             constraintSet {
               skyBackground
               elevationRange {
-                ... on AirMassRange {
+                airmassRange {
                   min
                   max
                 }


### PR DESCRIPTION
Updates the constraint set graph to be consistent with source profile.  Namely:

* Combines the create and edit inputs into a single input that works for either, checking arguments appropriately for each case
* Allows all parts of the tree to be edited independently.  You can update just the `min` airmass range for example.
* Makes the constraint set output shape match the input.  In other words, removes the `Union` in favor of optional `airmassRange` and `hourAngleRange` under `elevationRange`