### PR TITLE
liftState

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ConstraintSetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ConstraintSetModel.scala
@@ -11,6 +11,7 @@ import io.circe.Decoder
 import lucuma.core.enum._
 import lucuma.odb.api.model.syntax.input._
 import lucuma.odb.api.model.syntax.lens._
+import lucuma.odb.api.model.syntax.validatedinput._
 import monocle.{Fold, Lens, Optional}
 import monocle.macros.GenLens
 
@@ -124,16 +125,16 @@ final case class ConstraintSetInput(
        cloudExtinction.validateIsNotNull("cloudExtinction"),
        skyBackground.validateIsNotNull("skyBackground"),
        waterVapor.validateIsNotNull("waterVapor")
-      ).tupled.toEither
+      ).tupled
 
     for {
-      args <- StateT.liftF(validArgs)
+      args <- validArgs.liftState
       (i, c, s, w) = args
-        _ <- ConstraintSetModel.imageQuality    := i
-        _ <- ConstraintSetModel.cloudExtinction := c
-        _ <- ConstraintSetModel.skyBackground   := s
-        _ <- ConstraintSetModel.waterVapor      := w
-        _ <- ConstraintSetModel.elevationRange  :! elevationRange
+      _ <- ConstraintSetModel.imageQuality    := i
+      _ <- ConstraintSetModel.cloudExtinction := c
+      _ <- ConstraintSetModel.skyBackground   := s
+      _ <- ConstraintSetModel.waterVapor      := w
+      _ <- ConstraintSetModel.elevationRange  :! elevationRange
     } yield ()
   }
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -7,6 +7,7 @@ import lucuma.odb.api.model.Existence._
 import lucuma.odb.api.model.ScienceConfigurationModel.ScienceConfigurationModelEdit
 import lucuma.odb.api.model.syntax.input._
 import lucuma.odb.api.model.syntax.lens._
+import lucuma.odb.api.model.syntax.validatedinput._
 import lucuma.odb.api.model.targetModel.TargetEnvironmentModel
 import lucuma.core.`enum`.{ObsActiveStatus, ObsStatus}
 import lucuma.core.model.{Observation, Program}
@@ -175,7 +176,7 @@ object ObservationModel extends ObservationOptics {
         (existence   .validateIsNotNull("existence"),
          status      .validateIsNotNull("status"),
          activeStatus.validateIsNotNull("active")
-        ).tupled.toEither
+        ).tupled
 
       val sc: StateT[EitherInput, ObservationModel, Unit] =
         scienceConfiguration match {
@@ -187,22 +188,22 @@ object ObservationModel extends ObservationOptics {
       def empty[T]: StateT[EitherInput, T, Unit] = StateT.empty
 
       for {
-        args <- StateT.liftF(validArgs)
+        args <- validArgs.liftState
         (e, s, a) = args
-        _    <- ObservationModel.existence    := e
-        _    <- ObservationModel.name         := name.toOptionOption
-        _    <- ObservationModel.status       := s
-        _    <- ObservationModel.activeStatus := a
-        _    <- ObservationModel.targetEnvironment.transform(
-                  targets.fold(empty[TargetEnvironmentModel])(_.editor)
-                )
-        _    <- ObservationModel.constraintSet.transform(
-                  constraintSet.fold(empty[ConstraintSetModel])(_.edit)
-                )
-        _    <- ObservationModel.scienceRequirements.transform(
-                  scienceRequirements.fold(empty[ScienceRequirements])(_.editor)
-                )
-        _    <- sc
+        _ <- ObservationModel.existence    := e
+        _ <- ObservationModel.name         := name.toOptionOption
+        _ <- ObservationModel.status       := s
+        _ <- ObservationModel.activeStatus := a
+        _ <- ObservationModel.targetEnvironment.transform(
+               targets.fold(empty[TargetEnvironmentModel])(_.editor)
+             )
+        _ <- ObservationModel.constraintSet.transform(
+               constraintSet.fold(empty[ConstraintSetModel])(_.edit)
+             )
+        _ <- ObservationModel.scienceRequirements.transform(
+               scienceRequirements.fold(empty[ScienceRequirements])(_.editor)
+             )
+        _ <- sc
       } yield ()
     }
   }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ScienceConfigurationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ScienceConfigurationModel.scala
@@ -20,6 +20,7 @@ import lucuma.core.util.Display
 import lucuma.odb.api.model.syntax.input._
 import lucuma.odb.api.model.syntax.lens._
 import lucuma.odb.api.model.syntax.prism._
+import lucuma.odb.api.model.syntax.validatedinput._
 import monocle.{Focus, Lens, Prism}
 import monocle.macros.GenPrism
 
@@ -97,14 +98,14 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
         val validArgs =
           (disperser.validateIsNotNull("disperser"),
            slitWidth.validateNotNullable("slitWidth")(_.toAngle)
-          ).tupled.toEither
+          ).tupled
 
         for {
-          args <- StateT.liftF(validArgs)
+          args <- validArgs.liftState
           (disperser, slitWidth) = args
-          _    <- GmosNorthLongSlit.filter    := filter.toOptionOption
-          _    <- GmosNorthLongSlit.disperser := disperser
-          _    <- GmosNorthLongSlit.slitWidth := slitWidth
+          _ <- GmosNorthLongSlit.filter    := filter.toOptionOption
+          _ <- GmosNorthLongSlit.disperser := disperser
+          _ <- GmosNorthLongSlit.slitWidth := slitWidth
         } yield ()
       }
     }
@@ -183,14 +184,14 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
         val validArgs =
           (disperser.validateIsNotNull("disperser"),
            slitWidth.validateNotNullable("slitWidth")(_.toAngle)
-          ).tupled.toEither
+          ).tupled
 
         for {
-          args <- StateT.liftF(validArgs)
+          args <- validArgs.liftState
           (disperser, slitWidth) = args
-          _    <- GmosSouthLongSlit.filter    := filter.toOptionOption
-          _    <- GmosSouthLongSlit.disperser := disperser
-          _    <- GmosSouthLongSlit.slitWidth := slitWidth
+          _ <- GmosSouthLongSlit.filter    := filter.toOptionOption
+          _ <- GmosSouthLongSlit.disperser := disperser
+          _ <- GmosSouthLongSlit.slitWidth := slitWidth
         } yield ()
       }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/SpectroscopyRequirements.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/SpectroscopyRequirements.scala
@@ -17,6 +17,7 @@ import io.circe.generic.semiauto._
 import io.circe.refined._
 import lucuma.odb.api.model.syntax.input._
 import lucuma.odb.api.model.syntax.lens._
+import lucuma.odb.api.model.syntax.validatedinput._
 import lucuma.core.enum.FocalPlane
 import lucuma.core.enum.SpectroscopyCapabilities
 import lucuma.core.math.Angle
@@ -117,19 +118,19 @@ object SpectroscopyScienceRequirementsModel {
          signalToNoiseAt.validateNullable(_.toWavelength("signalToNoiseAt")),
          wavelengthCoverage.validateNullable(_.toWavelength("wavelengthCoverage")),
          focalPlaneAngle.validateNullable(_.toAngle)
-        ).tupled.toEither
+        ).tupled
 
       for {
-        args <- StateT.liftF(validArgs)
+        args <- validArgs.liftState
         (cw, signalToNoiseAt, wavelengthCoverage, focalPlaneAngle) = args
-          _ <- SpectroscopyScienceRequirements.wavelength         := cw
-          _ <- SpectroscopyScienceRequirements.resolution         := resolution.toOptionOption
-          _ <- SpectroscopyScienceRequirements.signalToNoise      := signalToNoise.toOptionOption
-          _ <- SpectroscopyScienceRequirements.signalToNoiseAt    := signalToNoiseAt
-          _ <- SpectroscopyScienceRequirements.wavelengthCoverage := wavelengthCoverage
-          _ <- SpectroscopyScienceRequirements.focalPlane         := focalPlane.toOptionOption
-          _ <- SpectroscopyScienceRequirements.focalPlaneAngle    := focalPlaneAngle
-          _ <- SpectroscopyScienceRequirements.capabilities       := capabilities.toOptionOption
+        _ <- SpectroscopyScienceRequirements.wavelength         := cw
+        _ <- SpectroscopyScienceRequirements.resolution         := resolution.toOptionOption
+        _ <- SpectroscopyScienceRequirements.signalToNoise      := signalToNoise.toOptionOption
+        _ <- SpectroscopyScienceRequirements.signalToNoiseAt    := signalToNoiseAt
+        _ <- SpectroscopyScienceRequirements.wavelengthCoverage := wavelengthCoverage
+        _ <- SpectroscopyScienceRequirements.focalPlane         := focalPlane.toOptionOption
+        _ <- SpectroscopyScienceRequirements.focalPlaneAngle    := focalPlaneAngle
+        _ <- SpectroscopyScienceRequirements.capabilities       := capabilities.toOptionOption
       } yield ()
     }
   }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/syntax/ValidatedInputOps.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/syntax/ValidatedInputOps.scala
@@ -4,6 +4,7 @@
 package lucuma.odb.api.model
 package syntax
 
+import cats.data.StateT
 import cats.{Applicative, ApplicativeError}
 import cats.syntax.functor._
 import cats.syntax.validated._
@@ -12,6 +13,9 @@ final class ValidatedInputOps[A](self: ValidatedInput[A]) {
 
   def liftTo[F[_]](implicit F: ApplicativeError[F, Throwable]): F[A] =
     self.leftMap(nec => InputError.Exception(nec)).liftTo[F]
+
+  def liftState[S]: StateT[EitherInput, S, A] =
+    StateT.liftF(self.toEither)
 
   def flatten[B](implicit ev: A <:< ValidatedInput[B]): ValidatedInput[B] =
     self.andThen(ev)

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/CatalogInfoInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/CatalogInfoInput.scala
@@ -16,6 +16,7 @@ import lucuma.core.`enum`.CatalogName
 import lucuma.core.model.CatalogInfo
 import lucuma.odb.api.model.syntax.input._
 import lucuma.odb.api.model.syntax.lens._
+import lucuma.odb.api.model.syntax.validatedinput._
 import lucuma.odb.api.model.{InputError, EditorInput, ValidatedInput}
 
 final case class CatalogInfoInput(
@@ -31,13 +32,12 @@ final case class CatalogInfoInput(
 
   override val edit: StateT[EitherNec[InputError, *], CatalogInfo, Unit] = {
     val validArgs =
-      (
-        name.validateIsNotNull("name"),
-        id.validateIsNotNull("id")
-      ).tupled.toEither
+      (name.validateIsNotNull("name"),
+       id.validateIsNotNull("id")
+      ).tupled
 
     for {
-      args <- StateT.liftF(validArgs)
+      args <- validArgs.liftState
       (n, i) = args
       _ <- CatalogInfo.catalog    := n
       _ <- CatalogInfo.id         := i

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SiderealInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SiderealInput.scala
@@ -18,6 +18,7 @@ import lucuma.odb.api.model.json.target._
 import lucuma.odb.api.model.syntax.input._
 import lucuma.odb.api.model.syntax.lens._
 import lucuma.odb.api.model.syntax.optional._
+import lucuma.odb.api.model.syntax.validatedinput._
 import lucuma.odb.api.model.targetModel.SourceProfileModel.SourceProfileInput
 import monocle.{Focus, Lens, Optional}
 
@@ -71,12 +72,12 @@ final case class SiderealInput(
        properMotion  .validateNullable(_.toProperMotion),
        radialVelocity.validateNullable(_.toRadialVelocity),
        parallax      .validateNullable(_.toParallax)
-      ).tupled.toEither
+      ).tupled
 
     import SiderealInput.optics
 
     for {
-      args <- StateT.liftF(validArgs)
+      args <- validArgs.liftState
       (r, d, e, pm, rv, px) = args
 
       _ <- optics.baseRa         := r

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
@@ -20,6 +20,7 @@ import lucuma.core.model.{Program, SourceProfile, Target}
 import lucuma.odb.api.model.{DatabaseState, EitherInput, Event, Existence, TopLevelModel, ValidatedInput}
 import lucuma.odb.api.model.syntax.input._
 import lucuma.odb.api.model.syntax.lens._
+import lucuma.odb.api.model.syntax.validatedinput._
 import lucuma.odb.api.model.targetModel.SourceProfileModel.SourceProfileInput
 import monocle.{Focus, Lens}
 
@@ -133,14 +134,13 @@ object TargetModel extends TargetModelOptics {
     val editor: StateT[EitherInput, TargetModel, Unit] = {
 
       val validArgs =
-        (
-          existence    .validateIsNotNull("existence"),
-          name         .validateIsNotNull("name"),
-          sourceProfile.validateIsNotNull("sourceProfile")
-        ).tupled.toEither
+        (existence    .validateIsNotNull("existence"),
+         name         .validateIsNotNull("name"),
+         sourceProfile.validateIsNotNull("sourceProfile")
+        ).tupled
 
       for {
-        args <- StateT.liftF(validArgs)
+        args <- validArgs.liftState
         (e, n, p) = args
         _ <- TargetModel.existence     := e
         _ <- TargetModel.name          := n


### PR DESCRIPTION
A minor cosmetic change to take a `ValidatedInput` into a `StateT`.  I don't use it on the individual arguments though, preferring a `(arg1.validate, arg2.validate).tupled.liftState` pattern so that both arguments get checked instead of stopping on the first failure.

