### PR TITLE
Science configuration

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -177,27 +177,16 @@ object ObservationModel extends ObservationOptics {
          activeStatus.validateIsNotNull("active")
         ).tupled
 
-//      def empty[T]: StateT[EitherInput, T, Unit] = StateT.empty
-
       for {
         args <- validArgs.liftState
         (e, s, a) = args
-        _ <- ObservationModel.existence    := e
-        _ <- ObservationModel.name         := name.toOptionOption
-        _ <- ObservationModel.status       := s
-        _ <- ObservationModel.activeStatus := a
+        _ <- ObservationModel.existence            := e
+        _ <- ObservationModel.name                 := name.toOptionOption
+        _ <- ObservationModel.status               := s
+        _ <- ObservationModel.activeStatus         := a
         _ <- ObservationModel.targetEnvironment    :< targets.map(_.editor)
-        //.transform(
-//               targets.fold(empty[TargetEnvironmentModel])(_.editor)
-//             )
-        _ <- ObservationModel.constraintSet        :! constraintSet  //.map(_.edit)
-        //.transform(
-//               constraintSet.fold(empty[ConstraintSetModel])(_.edit)
-//             )
+        _ <- ObservationModel.constraintSet        :! constraintSet
         _ <- ObservationModel.scienceRequirements  :< scienceRequirements.map(_.editor)
-          //.transform(
-//               scienceRequirements.fold(empty[ScienceRequirements])(_.editor)
-//             )
         _ <- ObservationModel.scienceConfiguration :? scienceConfiguration
       } yield ()
     }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ScienceConfigurationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ScienceConfigurationModel.scala
@@ -78,7 +78,7 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
     ) extends EditorInput[GmosNorthLongSlit] {
 
       override val create: ValidatedInput[GmosNorthLongSlit] =
-        (disperser.notMissing("filter"),
+        (disperser.notMissing("disperser"),
          slitWidth.notMissingAndThen("slitWidth")(_.toAngle)
         ).mapN { case (d, s) =>
           GmosNorthLongSlit(filter.toOption, d, s)
@@ -152,7 +152,7 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
     ) extends EditorInput[GmosSouthLongSlit] {
 
       override val create: ValidatedInput[GmosSouthLongSlit] =
-        (disperser.notMissing("filter"),
+        (disperser.notMissing("disperser"),
          slitWidth.notMissingAndThen("slitWidth")(_.toAngle)
         ).mapN { case (d, s) =>
           GmosSouthLongSlit(filter.toOption, d, s)

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -19,7 +19,7 @@ trait ObservationMutation {
 
   import ConstraintSetMutation.InputObjectTypeConstraintSet
   import context._
-  import ScienceConfigurationMutation.{InputObjectTypeScienceConfigurationCreate, InputObjectTypeScienceConfigurationSetEdit}
+  import ScienceConfigurationMutation.InputObjectTypeScienceConfig
   import ScienceRequirementsMutation.{InputObjectTypeScienceRequirementsCreate, InputObjectTypeScienceRequirementsEdit}
   import GeneralSchema.{EnumTypeExistence, NonEmptyStringType}
   import ObservationSchema.{ObsActiveStatusType, ObservationIdType, ObservationIdArgument, ObsStatusType, ObservationType}
@@ -51,7 +51,7 @@ trait ObservationMutation {
       ReplaceInputField("targets",              InputObjectTypeTargetEnvironmentEdit.notNullableField("targetEnvironment")),
       ReplaceInputField("constraintSet",        InputObjectTypeConstraintSet.notNullableField("constraintSet")),
       ReplaceInputField("scienceRequirements",  InputObjectTypeScienceRequirementsEdit.nullableField("scienceRequirements")),
-      ReplaceInputField("scienceConfiguration", InputObjectTypeScienceConfigurationSetEdit.nullableField("scienceConfiguration"))
+      ReplaceInputField("scienceConfiguration", InputObjectTypeScienceConfig.nullableField("scienceConfiguration"))
     )
 
   val ArgumentObservationEdit: Argument[ObservationModel.Edit] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationMutation.scala
@@ -3,8 +3,7 @@
 
 package lucuma.odb.api.schema
 
-import lucuma.odb.api.model.ScienceConfigurationModel
-import lucuma.odb.api.model.ScienceConfigurationModel.ScienceConfigurationModelEdit
+import lucuma.odb.api.model.{ScienceConfigurationInput, ScienceConfigurationModel}
 import sangria.macros.derive._
 import sangria.schema._
 
@@ -19,12 +18,6 @@ trait ScienceConfigurationMutation {
     deriveInputObjectType[SlitWidthInput](
       InputObjectTypeName("SlitWidthInput"),
       InputObjectTypeDescription("Slit width in appropriate units"),
-    )
-
-  implicit val InputObjectTypeScienceConfigurationCreate: InputObjectType[ScienceConfigurationModel.Create] =
-    deriveInputObjectType[ScienceConfigurationModel.Create](
-      InputObjectTypeName("CreateObservationConfigInput"),
-      InputObjectTypeDescription("Create observation configuration"),
     )
 
   implicit val InputObjectTypeGmosSouthLongSlit: InputObjectType[GmosSouthLongSlitInput] =
@@ -49,20 +42,14 @@ trait ScienceConfigurationMutation {
       )
     )
 
-  implicit val InputObjectTypeScienceConfigEdit: InputObjectType[ScienceConfigurationModel.Edit] =
-    deriveInputObjectType[ScienceConfigurationModel.Edit](
-      InputObjectTypeName("EditScienceConfiguration"),
-      InputObjectTypeDescription("Edit observation configuration"),
-      ReplaceInputField("gmosNorthLongSlit", InputObjectTypeGmosNorthLongSlit.notNullableField("gmosNorthLongSlit")),
-      ReplaceInputField("gmosSouthLongSlit", InputObjectTypeGmosSouthLongSlit.notNullableField("gmosSouthLongSlit")),
-    )
-
-  implicit val InputObjectTypeScienceConfigurationSetEdit: InputObjectType[ScienceConfigurationModelEdit] =
-    deriveInputObjectType[ScienceConfigurationModelEdit](
-      InputObjectTypeName("EditScienceConfigurationInput"),
-      InputObjectTypeDescription("Edit or set observation configuration"),
-      ReplaceInputField("set", InputObjectTypeScienceConfigurationCreate.notNullableField("set")),
-      ReplaceInputField("edit", InputObjectTypeScienceConfigEdit.notNullableField("edit")),
+  implicit val InputObjectTypeScienceConfig: InputObjectType[ScienceConfigurationInput] =
+    InputObjectType[ScienceConfigurationInput](
+      "ScienceConfigurationInput",
+      "Edit or create an observation's science configuration",
+      List(
+        InputObjectTypeGmosNorthLongSlit.notNullableField("gmosNorthLongSlit"),
+        InputObjectTypeGmosSouthLongSlit.notNullableField("gmosSouthLongSlit")
+      )
     )
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationMutation.scala
@@ -21,48 +21,40 @@ trait ScienceConfigurationMutation {
       InputObjectTypeDescription("Slit width in appropriate units"),
     )
 
-  implicit val InputObjectTypeCreateGmosNorthLongSlit: InputObjectType[CreateGmosNorthLongSlit] =
-    deriveInputObjectType[CreateGmosNorthLongSlit](
-      InputObjectTypeName("CreateGmosNorthLongSlit"),
-      InputObjectTypeDescription("Create a configuration for a GMOS North Long Slit observation")
-    )
-
-  implicit val InputObjectTypeCreateGmosSouthLongSlit: InputObjectType[CreateGmosSouthLongSlit] =
-    deriveInputObjectType[CreateGmosSouthLongSlit](
-      InputObjectTypeName("CreateGmosSouthLongSlit"),
-      InputObjectTypeDescription("Create a configuration for a GMOS South Long Slit observation")
-    )
-
   implicit val InputObjectTypeScienceConfigurationCreate: InputObjectType[ScienceConfigurationModel.Create] =
     deriveInputObjectType[ScienceConfigurationModel.Create](
       InputObjectTypeName("CreateObservationConfigInput"),
       InputObjectTypeDescription("Create observation configuration"),
     )
 
-  implicit val InputObjectTypeEditGmosSouthLongSlitEdit: InputObjectType[EditGmosSouthLongSlit] =
-    deriveInputObjectType[EditGmosSouthLongSlit](
-      InputObjectTypeName("EditGmosSouthLongSlit"),
-      InputObjectTypeDescription("Edit GMOS South Long Slit configuration"),
-      ReplaceInputField("filter", EnumTypeGmosSouthFilter.notNullableField("filter")),
-      ReplaceInputField("disperser", EnumTypeGmosSouthDisperser.notNullableField("disperser")),
-      ReplaceInputField("slitWidth", InputSlitWidthInput.notNullableField("slitWidth")),
+  implicit val InputObjectTypeGmosSouthLongSlit: InputObjectType[GmosSouthLongSlitInput] =
+    InputObjectType[GmosSouthLongSlitInput](
+      "EditGmosSouthLongSlit",
+      "Edit or create GMOS South Long Slit configuration",
+      List(
+        EnumTypeGmosSouthFilter.notNullableField("filter"),
+        EnumTypeGmosSouthDisperser.notNullableField("disperser"),
+        InputSlitWidthInput.notNullableField("slitWidth")
+      )
     )
 
-  implicit val InputObjectTypeEditGmosNorthLongSlitEdit: InputObjectType[EditGmosNorthLongSlit] =
-    deriveInputObjectType[EditGmosNorthLongSlit](
-      InputObjectTypeName("EditGmosNorthLongSlit"),
-      InputObjectTypeDescription("Edit GMOS North Long Slit configuration"),
-      ReplaceInputField("filter", EnumTypeGmosNorthFilter.notNullableField("filter")),
-      ReplaceInputField("disperser", EnumTypeGmosNorthDisperser.notNullableField("disperser")),
-      ReplaceInputField("slitWidth", InputSlitWidthInput.notNullableField("slitWidth")),
+  implicit val InputObjectTypeGmosNorthLongSlit: InputObjectType[GmosNorthLongSlitInput] =
+    InputObjectType[GmosNorthLongSlitInput](
+      "EditGmosNorthLongSlit",
+      "Edit or create GMOS North Long Slit configuration",
+      List(
+        EnumTypeGmosNorthFilter.notNullableField("filter"),
+        EnumTypeGmosNorthDisperser.notNullableField("disperser"),
+        InputSlitWidthInput.notNullableField("slitWidth")
+      )
     )
 
   implicit val InputObjectTypeScienceConfigEdit: InputObjectType[ScienceConfigurationModel.Edit] =
     deriveInputObjectType[ScienceConfigurationModel.Edit](
       InputObjectTypeName("EditScienceConfiguration"),
       InputObjectTypeDescription("Edit observation configuration"),
-      ReplaceInputField("gmosNorthLongSlit", InputObjectTypeEditGmosNorthLongSlitEdit.notNullableField("gmosNorthLongSlit")),
-      ReplaceInputField("gmosSouthLongSlit", InputObjectTypeEditGmosSouthLongSlitEdit.notNullableField("gmosSouthLongSlit")),
+      ReplaceInputField("gmosNorthLongSlit", InputObjectTypeGmosNorthLongSlit.notNullableField("gmosNorthLongSlit")),
+      ReplaceInputField("gmosSouthLongSlit", InputObjectTypeGmosSouthLongSlit.notNullableField("gmosSouthLongSlit")),
     )
 
   implicit val InputObjectTypeScienceConfigurationSetEdit: InputObjectType[ScienceConfigurationModelEdit] =


### PR DESCRIPTION
Converts the `ScienceConfiguration` to the same editor pattern used by `SourceProfile` and `ConstraintSet`:

* combines the create / edit inputs into a single input
* removes the `edit` and `create` "command" inputs in favor of checking the current state of the science configuration and applying the updates accordingly