### PR TITLE
Science Configuration and Target Environment

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -177,27 +177,16 @@ object ObservationModel extends ObservationOptics {
          activeStatus.validateIsNotNull("active")
         ).tupled
 
-//      def empty[T]: StateT[EitherInput, T, Unit] = StateT.empty
-
       for {
         args <- validArgs.liftState
         (e, s, a) = args
-        _ <- ObservationModel.existence    := e
-        _ <- ObservationModel.name         := name.toOptionOption
-        _ <- ObservationModel.status       := s
-        _ <- ObservationModel.activeStatus := a
+        _ <- ObservationModel.existence            := e
+        _ <- ObservationModel.name                 := name.toOptionOption
+        _ <- ObservationModel.status               := s
+        _ <- ObservationModel.activeStatus         := a
         _ <- ObservationModel.targetEnvironment    :< targets.map(_.editor)
-        //.transform(
-//               targets.fold(empty[TargetEnvironmentModel])(_.editor)
-//             )
-        _ <- ObservationModel.constraintSet        :! constraintSet  //.map(_.edit)
-        //.transform(
-//               constraintSet.fold(empty[ConstraintSetModel])(_.edit)
-//             )
+        _ <- ObservationModel.constraintSet        :! constraintSet
         _ <- ObservationModel.scienceRequirements  :< scienceRequirements.map(_.editor)
-          //.transform(
-//               scienceRequirements.fold(empty[ScienceRequirements])(_.editor)
-//             )
         _ <- ObservationModel.scienceConfiguration :? scienceConfiguration
       } yield ()
     }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ScienceConfigurationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ScienceConfigurationModel.scala
@@ -78,7 +78,7 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
     ) extends EditorInput[GmosNorthLongSlit] {
 
       override val create: ValidatedInput[GmosNorthLongSlit] =
-        (disperser.notMissing("filter"),
+        (disperser.notMissing("disperser"),
          slitWidth.notMissingAndThen("slitWidth")(_.toAngle)
         ).mapN { case (d, s) =>
           GmosNorthLongSlit(filter.toOption, d, s)
@@ -152,7 +152,7 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
     ) extends EditorInput[GmosSouthLongSlit] {
 
       override val create: ValidatedInput[GmosSouthLongSlit] =
-        (disperser.notMissing("filter"),
+        (disperser.notMissing("disperser"),
          slitWidth.notMissingAndThen("slitWidth")(_.toAngle)
         ).mapN { case (d, s) =>
           GmosSouthLongSlit(filter.toOption, d, s)

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetEnvironmentModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetEnvironmentModel.scala
@@ -85,7 +85,7 @@ final case class TargetEnvironmentInput(
     for {
       b <- explicitBase.validateNullable(_.toCoordinates).liftState
       _ <- TargetEnvironmentModel.explicitBase := b
-      _ <- TargetEnvironmentModel.asterism     := asterism.toOption.map(ts => SortedSet.from(ts)(catsKernelOrderingForOrder))
+      _ <- TargetEnvironmentModel.asterism     := asterism.toOption.map(SortedSet.from(_))
     } yield ()
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
@@ -184,7 +184,7 @@ object TargetRepo {
             .observations
             .values
             .filter(o => o.programId === pid && (includeDeleted || o.isPresent))
-            .map(_.targets.asterism)
+            .map(_.targetEnvironment.asterism)
             .reduceOption(_.union(_))
             .getOrElse(SortedSet.empty[Target.Id])
         }
@@ -200,7 +200,7 @@ object TargetRepo {
             tab
               .observations
               .get(oid)
-              .map(_.targets.asterism)
+              .map(_.targetEnvironment.asterism)
               .getOrElse(SortedSet.empty[Target.Id])
           }.reduceOption(_.union(_))
            .getOrElse(SortedSet.empty[Target.Id])
@@ -237,7 +237,7 @@ object TargetRepo {
             .observations
             .values
             .filter(o => o.programId === pid && (includeDeleted || o.isPresent))
-            .map(_.targets.asterism)
+            .map(_.targetEnvironment.asterism)
             .toList
             .distinct
             .map(_.map(tab.targets.apply).filter(t => includeDeleted || t.isPresent))
@@ -252,7 +252,7 @@ object TargetRepo {
       override def selectObservationTargetEnvironment(
         id: Observation.Id
       ): F[Option[TargetEnvironmentModel]] =
-        tablesRef.get.map(_.observations.get(id).map(_.targets))
+        tablesRef.get.map(_.observations.get(id).map(_.targetEnvironment))
 
       override def unsafeSelectObservationTargetEnvironment(
         id: Observation.Id

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -19,7 +19,7 @@ trait ObservationMutation {
 
   import ConstraintSetMutation.InputObjectTypeConstraintSet
   import context._
-  import ScienceConfigurationMutation.{InputObjectTypeScienceConfigurationCreate, InputObjectTypeScienceConfigurationSetEdit}
+  import ScienceConfigurationMutation.InputObjectTypeScienceConfig
   import ScienceRequirementsMutation.{InputObjectTypeScienceRequirementsCreate, InputObjectTypeScienceRequirementsEdit}
   import GeneralSchema.{EnumTypeExistence, NonEmptyStringType}
   import ObservationSchema.{ObsActiveStatusType, ObservationIdType, ObservationIdArgument, ObsStatusType, ObservationType}
@@ -51,7 +51,7 @@ trait ObservationMutation {
       ReplaceInputField("targets",              InputObjectTypeTargetEnvironmentEdit.notNullableField("targetEnvironment")),
       ReplaceInputField("constraintSet",        InputObjectTypeConstraintSet.notNullableField("constraintSet")),
       ReplaceInputField("scienceRequirements",  InputObjectTypeScienceRequirementsEdit.nullableField("scienceRequirements")),
-      ReplaceInputField("scienceConfiguration", InputObjectTypeScienceConfigurationSetEdit.nullableField("scienceConfiguration"))
+      ReplaceInputField("scienceConfiguration", InputObjectTypeScienceConfig.nullableField("scienceConfiguration"))
     )
 
   val ArgumentObservationEdit: Argument[ObservationModel.Edit] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -10,7 +10,7 @@ import lucuma.odb.api.schema.syntax.inputtype._
 import cats.MonadError
 import cats.effect.std.Dispatcher
 import io.circe.Decoder
-import lucuma.odb.api.model.targetModel.{EditAsterismInput, TargetEnvironmentModel}
+import lucuma.odb.api.model.targetModel.{EditAsterismInput, TargetEnvironmentInput}
 import sangria.macros.derive._
 import sangria.marshalling.circe._
 import sangria.schema._
@@ -24,7 +24,7 @@ trait ObservationMutation {
   import GeneralSchema.{EnumTypeExistence, NonEmptyStringType}
   import ObservationSchema.{ObsActiveStatusType, ObservationIdType, ObservationIdArgument, ObsStatusType, ObservationType}
   import ProgramSchema.ProgramIdType
-  import TargetMutation.{InputObjectTypeCreateTargetEnvironmentInput, InputObjectTypeEditAsterism, InputObjectTypeTargetEnvironmentEdit}
+  import TargetMutation.{InputObjectTypeEditAsterism, InputObjectTypeTargetEnvironment}
   import syntax.inputobjecttype._
 
   val InputObjectTypeObservationCreate: InputObjectType[ObservationModel.Create] =
@@ -48,7 +48,7 @@ trait ObservationMutation {
       ReplaceInputField("name",                 NonEmptyStringType.nullableField("name")),
       ReplaceInputField("status",               ObsStatusType.notNullableField("status")),
       ReplaceInputField("activeStatus",         ObsActiveStatusType.notNullableField("activeStatus")),
-      ReplaceInputField("targets",              InputObjectTypeTargetEnvironmentEdit.notNullableField("targetEnvironment")),
+      ReplaceInputField("targetEnvironment",    InputObjectTypeTargetEnvironment.notNullableField("targetEnvironment")),
       ReplaceInputField("constraintSet",        InputObjectTypeConstraintSet.notNullableField("constraintSet")),
       ReplaceInputField("scienceRequirements",  InputObjectTypeScienceRequirementsEdit.nullableField("scienceRequirements")),
       ReplaceInputField("scienceConfiguration", InputObjectTypeScienceConfig.nullableField("scienceConfiguration"))
@@ -86,10 +86,10 @@ trait ObservationMutation {
       ListInputType(InputObjectTypeEditAsterism)
     )
 
-  val ArgumentTargetEnvironmentBulkEdit: Argument[BulkEdit[TargetEnvironmentModel.Edit]] =
-    bulkEditArgument[TargetEnvironmentModel.Edit](
+  val ArgumentTargetEnvironmentBulkEdit: Argument[BulkEdit[TargetEnvironmentInput]] =
+    bulkEditArgument[TargetEnvironmentInput](
       "targetEnvironment",
-      InputObjectTypeTargetEnvironmentEdit
+      InputObjectTypeTargetEnvironment
     )
 
   val ArgumentConstraintSetBulkEdit: Argument[BulkEdit[ConstraintSetInput]] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
@@ -121,7 +121,7 @@ object ObservationSchema {
         ),
 
         Field(
-          name        = "targets",
+          name        = "targetEnvironment",
           fieldType   = TargetEnvironmentType[F],
           description = "The observation's target(s)".some,
           resolve     = c => c.target(_.unsafeSelectObservationTargetEnvironment(c.value.id))

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationMutation.scala
@@ -3,8 +3,7 @@
 
 package lucuma.odb.api.schema
 
-import lucuma.odb.api.model.ScienceConfigurationModel
-import lucuma.odb.api.model.ScienceConfigurationModel.ScienceConfigurationModelEdit
+import lucuma.odb.api.model.{ScienceConfigurationInput, ScienceConfigurationModel}
 import sangria.macros.derive._
 import sangria.schema._
 
@@ -19,12 +18,6 @@ trait ScienceConfigurationMutation {
     deriveInputObjectType[SlitWidthInput](
       InputObjectTypeName("SlitWidthInput"),
       InputObjectTypeDescription("Slit width in appropriate units"),
-    )
-
-  implicit val InputObjectTypeScienceConfigurationCreate: InputObjectType[ScienceConfigurationModel.Create] =
-    deriveInputObjectType[ScienceConfigurationModel.Create](
-      InputObjectTypeName("CreateObservationConfigInput"),
-      InputObjectTypeDescription("Create observation configuration"),
     )
 
   implicit val InputObjectTypeGmosSouthLongSlit: InputObjectType[GmosSouthLongSlitInput] =
@@ -49,20 +42,14 @@ trait ScienceConfigurationMutation {
       )
     )
 
-  implicit val InputObjectTypeScienceConfigEdit: InputObjectType[ScienceConfigurationModel.Edit] =
-    deriveInputObjectType[ScienceConfigurationModel.Edit](
-      InputObjectTypeName("EditScienceConfiguration"),
-      InputObjectTypeDescription("Edit observation configuration"),
-      ReplaceInputField("gmosNorthLongSlit", InputObjectTypeGmosNorthLongSlit.notNullableField("gmosNorthLongSlit")),
-      ReplaceInputField("gmosSouthLongSlit", InputObjectTypeGmosSouthLongSlit.notNullableField("gmosSouthLongSlit")),
-    )
-
-  implicit val InputObjectTypeScienceConfigurationSetEdit: InputObjectType[ScienceConfigurationModelEdit] =
-    deriveInputObjectType[ScienceConfigurationModelEdit](
-      InputObjectTypeName("EditScienceConfigurationInput"),
-      InputObjectTypeDescription("Edit or set observation configuration"),
-      ReplaceInputField("set", InputObjectTypeScienceConfigurationCreate.notNullableField("set")),
-      ReplaceInputField("edit", InputObjectTypeScienceConfigEdit.notNullableField("edit")),
+  implicit val InputObjectTypeScienceConfig: InputObjectType[ScienceConfigurationInput] =
+    InputObjectType[ScienceConfigurationInput](
+      "ScienceConfigurationInput",
+      "Edit or create an observation's science configuration",
+      List(
+        InputObjectTypeGmosNorthLongSlit.notNullableField("gmosNorthLongSlit"),
+        InputObjectTypeGmosSouthLongSlit.notNullableField("gmosSouthLongSlit")
+      )
     )
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationMutation.scala
@@ -21,48 +21,40 @@ trait ScienceConfigurationMutation {
       InputObjectTypeDescription("Slit width in appropriate units"),
     )
 
-  implicit val InputObjectTypeCreateGmosNorthLongSlit: InputObjectType[CreateGmosNorthLongSlit] =
-    deriveInputObjectType[CreateGmosNorthLongSlit](
-      InputObjectTypeName("CreateGmosNorthLongSlit"),
-      InputObjectTypeDescription("Create a configuration for a GMOS North Long Slit observation")
-    )
-
-  implicit val InputObjectTypeCreateGmosSouthLongSlit: InputObjectType[CreateGmosSouthLongSlit] =
-    deriveInputObjectType[CreateGmosSouthLongSlit](
-      InputObjectTypeName("CreateGmosSouthLongSlit"),
-      InputObjectTypeDescription("Create a configuration for a GMOS South Long Slit observation")
-    )
-
   implicit val InputObjectTypeScienceConfigurationCreate: InputObjectType[ScienceConfigurationModel.Create] =
     deriveInputObjectType[ScienceConfigurationModel.Create](
       InputObjectTypeName("CreateObservationConfigInput"),
       InputObjectTypeDescription("Create observation configuration"),
     )
 
-  implicit val InputObjectTypeEditGmosSouthLongSlitEdit: InputObjectType[EditGmosSouthLongSlit] =
-    deriveInputObjectType[EditGmosSouthLongSlit](
-      InputObjectTypeName("EditGmosSouthLongSlit"),
-      InputObjectTypeDescription("Edit GMOS South Long Slit configuration"),
-      ReplaceInputField("filter", EnumTypeGmosSouthFilter.notNullableField("filter")),
-      ReplaceInputField("disperser", EnumTypeGmosSouthDisperser.notNullableField("disperser")),
-      ReplaceInputField("slitWidth", InputSlitWidthInput.notNullableField("slitWidth")),
+  implicit val InputObjectTypeGmosSouthLongSlit: InputObjectType[GmosSouthLongSlitInput] =
+    InputObjectType[GmosSouthLongSlitInput](
+      "EditGmosSouthLongSlit",
+      "Edit or create GMOS South Long Slit configuration",
+      List(
+        EnumTypeGmosSouthFilter.notNullableField("filter"),
+        EnumTypeGmosSouthDisperser.notNullableField("disperser"),
+        InputSlitWidthInput.notNullableField("slitWidth")
+      )
     )
 
-  implicit val InputObjectTypeEditGmosNorthLongSlitEdit: InputObjectType[EditGmosNorthLongSlit] =
-    deriveInputObjectType[EditGmosNorthLongSlit](
-      InputObjectTypeName("EditGmosNorthLongSlit"),
-      InputObjectTypeDescription("Edit GMOS North Long Slit configuration"),
-      ReplaceInputField("filter", EnumTypeGmosNorthFilter.notNullableField("filter")),
-      ReplaceInputField("disperser", EnumTypeGmosNorthDisperser.notNullableField("disperser")),
-      ReplaceInputField("slitWidth", InputSlitWidthInput.notNullableField("slitWidth")),
+  implicit val InputObjectTypeGmosNorthLongSlit: InputObjectType[GmosNorthLongSlitInput] =
+    InputObjectType[GmosNorthLongSlitInput](
+      "EditGmosNorthLongSlit",
+      "Edit or create GMOS North Long Slit configuration",
+      List(
+        EnumTypeGmosNorthFilter.notNullableField("filter"),
+        EnumTypeGmosNorthDisperser.notNullableField("disperser"),
+        InputSlitWidthInput.notNullableField("slitWidth")
+      )
     )
 
   implicit val InputObjectTypeScienceConfigEdit: InputObjectType[ScienceConfigurationModel.Edit] =
     deriveInputObjectType[ScienceConfigurationModel.Edit](
       InputObjectTypeName("EditScienceConfiguration"),
       InputObjectTypeDescription("Edit observation configuration"),
-      ReplaceInputField("gmosNorthLongSlit", InputObjectTypeEditGmosNorthLongSlitEdit.notNullableField("gmosNorthLongSlit")),
-      ReplaceInputField("gmosSouthLongSlit", InputObjectTypeEditGmosSouthLongSlitEdit.notNullableField("gmosSouthLongSlit")),
+      ReplaceInputField("gmosNorthLongSlit", InputObjectTypeGmosNorthLongSlit.notNullableField("gmosNorthLongSlit")),
+      ReplaceInputField("gmosSouthLongSlit", InputObjectTypeGmosSouthLongSlit.notNullableField("gmosSouthLongSlit")),
     )
 
   implicit val InputObjectTypeScienceConfigurationSetEdit: InputObjectType[ScienceConfigurationModelEdit] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
@@ -9,7 +9,7 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.option._
 import lucuma.odb.api.model.{CoordinatesModel, DeclinationModel, ObservationModel, ParallaxModel, ProperMotionModel, RadialVelocityModel, RightAscensionModel}
-import lucuma.odb.api.model.targetModel.{CatalogInfoInput, EditAsterismInput, NonsiderealInput, SiderealInput, TargetEnvironmentModel, TargetModel}
+import lucuma.odb.api.model.targetModel.{CatalogInfoInput, EditAsterismInput, NonsiderealInput, SiderealInput, TargetEnvironmentInput, TargetModel}
 import lucuma.odb.api.repo.OdbRepo
 import lucuma.odb.api.schema.syntax.`enum`._
 import lucuma.core.model.Target
@@ -179,36 +179,15 @@ trait TargetMutation extends TargetScalars {
       "Parameters for editing an existing target. Nonsidereal edits are ignored for sidereal targets and vice versa."
     )
 
-  implicit val InputObjectTypeCreateTargetEnvironmentInput: InputObjectType[TargetEnvironmentModel.Create] =
-    deriveInputObjectType[TargetEnvironmentModel.Create](
-      InputObjectTypeName("CreateTargetEnvironmentInput"),
-      InputObjectTypeDescription("Target environment creation input parameters")
-    )
-
-  val ArgumentCreateTargetEnvironmentInput: Argument[TargetEnvironmentModel.Create] =
-    InputObjectTypeCreateTargetEnvironmentInput.argument(
-      "input",
-      "Parameters for creating a new target environment"
-    )
-
-  implicit val InputObjectTypeTargetEnvironmentEdit: InputObjectType[TargetEnvironmentModel.Edit] = {
-
-    // Not able to derive this for some reason, TBD.
-//    deriveInputObjectType[TargetEnvironmentModel.Edit](
-//      InputObjectTypeName("EditTargetEnvironmentInput"),
-//      InputObjectTypeDescription("Target environment editing parameters"),
-//      ReplaceInputField("explicitBase", InputObjectTypeCoordinates.nullableField("explicitBase"))
-//    )
-
-    InputObjectType[TargetEnvironmentModel.Edit](
-      "EditTargetEnvironmentInput",
-      "Target environment editing parameters",
+  implicit val InputObjectTypeTargetEnvironment: InputObjectType[TargetEnvironmentInput] =
+    InputObjectType[TargetEnvironmentInput](
+      "TargetEnvironmentInput",
+      "Target environment editing and creation parameters",
       List(
         InputObjectTypeCoordinates.nullableField("explicitBase"),
         InputField("asterism", OptionInputType(ListInputType(TargetIdType)))
       )
     )
-  }
 
   implicit val InputObjectTypeEditAsterism: InputObjectType[EditAsterismInput] =
     deriveInputObjectType[EditAsterismInput](

--- a/modules/core/src/test/scala/lucuma/odb/api/model/TargetModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/TargetModelSuite.scala
@@ -38,6 +38,6 @@ final class TargetModelSuite extends DisciplineSuite {
 
   checkAll("EditTargetInput", EqTests[EditAsterismInput].eqv)
 
-  checkAll("TargetEnvironmentModel.Create", EqTests[TargetEnvironmentModel.Create].eqv)
+  checkAll("TargetEnvironmentInput", EqTests[TargetEnvironmentInput].eqv)
 
 }

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
@@ -9,7 +9,7 @@ import lucuma.core.model.{Observation, Program}
 import lucuma.core.util.arb.{ArbEnumerated, ArbGid}
 import eu.timepit.refined.scalacheck.all._
 import eu.timepit.refined.types.all.NonEmptyString
-import lucuma.odb.api.model.targetModel.TargetEnvironmentModel
+import lucuma.odb.api.model.targetModel.{TargetEnvironmentInput, TargetEnvironmentModel}
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 
@@ -72,7 +72,7 @@ trait ArbObservationModel {
         nm <- arbitrary[Option[NonEmptyString]]
         st <- arbitrary[Option[ObsStatus]]
         as <- arbitrary[Option[ObsActiveStatus]]
-        ts <- arbitrary[Option[TargetEnvironmentModel.Create]]
+        ts <- arbitrary[Option[TargetEnvironmentInput]]
         cs <- arbitrary[Option[ConstraintSetInput]]
       } yield ObservationModel.Create(
         id,
@@ -95,7 +95,7 @@ trait ArbObservationModel {
       Option[String],
       Option[ObsStatus],
       Option[ObsActiveStatus],
-      Option[TargetEnvironmentModel.Create],
+      Option[TargetEnvironmentInput],
       Option[ConstraintSetInput]
     )].contramap { in => (
       in.observationId,
@@ -103,7 +103,7 @@ trait ArbObservationModel {
       in.name.map(_.value),
       in.status,
       in.activeStatus,
-      in.targets,
+      in.targetEnvironment,
       in.constraintSet
     )}
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbTargetModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbTargetModel.scala
@@ -189,18 +189,18 @@ trait ArbTargetModel {
       in.delete
     )}
 
-  implicit val arbCreateTargetEnvironmentInput: Arbitrary[TargetEnvironmentModel.Create] =
+  implicit val arbTargetEnvironmentInput: Arbitrary[TargetEnvironmentInput] =
     Arbitrary {
       for {
-        a <- arbitrary[Option[List[Target.Id]]]
-        e <- arbitrary[Option[CoordinatesModel.Input]]
-      } yield TargetEnvironmentModel.Create(a, e)
+        a <- arbitrary[Input[List[Target.Id]]]
+        e <- arbitrary[Input[CoordinatesModel.Input]]
+      } yield TargetEnvironmentInput(a, e)
     }
 
-  implicit val cogCreateTargetEnvironmentInput: Cogen[TargetEnvironmentModel.Create] =
+  implicit val cogTargetEnvironmentInput: Cogen[TargetEnvironmentInput] =
     Cogen[(
-      Option[List[Target.Id]],
-      Option[CoordinatesModel.Input]
+      Input[List[Target.Id]],
+      Input[CoordinatesModel.Input]
     )].contramap { in => (
       in.asterism,
       in.explicitBase

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -360,8 +360,8 @@ object Init {
       name                 = target.map(_.name) orElse NonEmptyString.from("Observation").toOption,
       status               = ObsStatus.New.some,
       activeStatus         = ObsActiveStatus.Active.some,
-      targets              = target.fold(none[TargetEnvironmentModel.Create]) { sidereal =>
-        TargetEnvironmentModel.Create(List(sidereal.id).some, None).some
+      targetEnvironment    = target.fold(none[TargetEnvironmentInput]) { sidereal =>
+        TargetEnvironmentInput.asterism(sidereal.id).some
       },
       constraintSet        = None,
       scienceRequirements  = ScienceRequirementsModel.Create.Default.some,

--- a/modules/service/src/test/scala/test/TestInit.scala
+++ b/modules/service/src/test/scala/test/TestInit.scala
@@ -14,7 +14,7 @@ import lucuma.core.model.Program
 import lucuma.core.optics.syntax.all._
 import lucuma.odb.api.model.OffsetModel.ComponentInput
 import lucuma.odb.api.model._
-import lucuma.odb.api.model.targetModel.{TargetEnvironmentModel, TargetModel}
+import lucuma.odb.api.model.targetModel.{TargetEnvironmentInput, TargetModel}
 import lucuma.odb.api.repo.OdbRepo
 
 import scala.concurrent.duration._
@@ -405,7 +405,7 @@ object TestInit {
       name                 = targets.headOption.map(_.name) orElse NonEmptyString.from("Observation").toOption,
       status               = ObsStatus.New.some,
       activeStatus         = ObsActiveStatus.Active.some,
-      targets              = TargetEnvironmentModel.Create(targets.map(_.id).some, None).some,
+      targetEnvironment    = TargetEnvironmentInput.asterism(targets.map(_.id)).some,
       constraintSet        = None,
       scienceRequirements  = ScienceRequirementsModel.Create.Default.some,
       scienceConfiguration = None,
@@ -446,7 +446,7 @@ object TestInit {
       _  <- repo.observation.bulkEditTargetEnvironment(
               ObservationModel.BulkEdit.observations(
                 List(o.id),
-                TargetEnvironmentModel.Edit.explicitBase(
+                TargetEnvironmentInput.explicitBase(
                   CoordinatesModel.Input(
                       RightAscensionModel.Input.fromDegrees(159.2583),
                       DeclinationModel.Input.fromDegrees(-27.5650)

--- a/modules/service/src/test/scala/test/targets/AsterismMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/AsterismMutationSuite.scala
@@ -27,7 +27,7 @@ class AsterismMutationSuite extends OdbSuite {
       mutation ReplaceTargets($listEdit: BulkEditAsterismInput!) {
         updateAsterism(input: $listEdit) {
           id
-          targets {
+          targetEnvironment {
             asterism {
               name
             }
@@ -40,7 +40,7 @@ class AsterismMutationSuite extends OdbSuite {
         "updateAsterism": [
           {
             "id": "o-3",
-            "targets": {
+            "targetEnvironment": {
               "asterism": [
                 {
                   "name": "NGC 5949"
@@ -50,7 +50,7 @@ class AsterismMutationSuite extends OdbSuite {
           },
           {
             "id": "o-4",
-            "targets": {
+            "targetEnvironment": {
               "asterism": [
                 {
                   "name": "NGC 5949"

--- a/modules/service/src/test/scala/test/targets/TargetEnvironmentMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetEnvironmentMutationSuite.scala
@@ -26,7 +26,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
       mutation UpdateTargetEnvironment($envEdit: BulkEditTargetEnvironmentInput!) {
         updateTargetEnvironment(input: $envEdit) {
           id
-          targets {
+          targetEnvironment {
             asterism {
               name
             }
@@ -39,7 +39,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
         "updateTargetEnvironment": [
           {
             "id": "o-3",
-            "targets": {
+            "targetEnvironment": {
               "asterism": [
                 {
                   "name": "NGC 5949"
@@ -68,7 +68,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
       mutation UpdateTargetEnvironment($envEdit: BulkEditTargetEnvironmentInput!) {
         updateTargetEnvironment(input: $envEdit) {
           id
-          targets {
+          targetEnvironment {
             asterism {
               name
             }
@@ -96,7 +96,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
       mutation UpdateTargetEnvironment($envEdit: BulkEditTargetEnvironmentInput!) {
         updateTargetEnvironment(input: $envEdit) {
           id
-          targets {
+          targetEnvironment {
             explicitBase {
               ra { hms }
               dec { dms }
@@ -110,7 +110,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
         "updateTargetEnvironment": [
           {
             "id": "o-3",
-            "targets": {
+            "targetEnvironment": {
               "explicitBase": {
                 "ra": {
                   "hms": "01:00:00.000000"


### PR DESCRIPTION
Makes the science configuration and target environment consistent with source profile and constraint set editing:

* One input for creation and editing with appropriate argument checking
* Removes explicit "edit" and "create" commands for science configuration
* Use "targetEnvironment" everywhere instead of a mix of "targetEnvironment" and "targets"