### PR TITLE
Convert science requirements

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -83,7 +83,7 @@ object ObservationModel extends ObservationOptics {
     activeStatus:         Option[ObsActiveStatus],
     targetEnvironment:    Option[TargetEnvironmentInput],
     constraintSet:        Option[ConstraintSetInput],
-    scienceRequirements:  Option[ScienceRequirementsModel.Create],
+    scienceRequirements:  Option[ScienceRequirementsInput],
     scienceConfiguration: Option[ScienceConfigurationInput],
     config:               Option[InstrumentConfigModel.Create]
   ) {
@@ -160,14 +160,14 @@ object ObservationModel extends ObservationOptics {
 
   final case class Edit(
     observationId:        Observation.Id,
-    existence:            Input[Existence]                      = Input.ignore,
-    name:                 Input[NonEmptyString]                 = Input.ignore,
-    status:               Input[ObsStatus]                      = Input.ignore,
-    activeStatus:         Input[ObsActiveStatus]                = Input.ignore,
-    targetEnvironment:    Input[TargetEnvironmentInput]         = Input.ignore,
-    constraintSet:        Input[ConstraintSetInput]             = Input.ignore,
-    scienceRequirements:  Option[ScienceRequirementsModel.Edit] = None,
-    scienceConfiguration: Input[ScienceConfigurationInput]      = Input.ignore
+    existence:            Input[Existence]                 = Input.ignore,
+    name:                 Input[NonEmptyString]            = Input.ignore,
+    status:               Input[ObsStatus]                 = Input.ignore,
+    activeStatus:         Input[ObsActiveStatus]           = Input.ignore,
+    targetEnvironment:    Input[TargetEnvironmentInput]    = Input.ignore,
+    constraintSet:        Input[ConstraintSetInput]        = Input.ignore,
+    scienceRequirements:  Input[ScienceRequirementsInput]  = Input.ignore,
+    scienceConfiguration: Input[ScienceConfigurationInput] = Input.ignore
   ) {
 
     val edit: StateT[EitherInput, ObservationModel, Unit] = {
@@ -186,7 +186,7 @@ object ObservationModel extends ObservationOptics {
         _ <- ObservationModel.activeStatus         := a
         _ <- ObservationModel.targetEnvironment    :! targetEnvironment
         _ <- ObservationModel.constraintSet        :! constraintSet
-        _ <- ObservationModel.scienceRequirements  :< scienceRequirements.map(_.editor)
+        _ <- ObservationModel.scienceRequirements  :! scienceRequirements
         _ <- ObservationModel.scienceConfiguration :? scienceConfiguration
       } yield ()
     }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ScienceRequirements.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ScienceRequirements.scala
@@ -17,33 +17,36 @@ import monocle.Lens
 import monocle.Focus
 
 final case class ScienceRequirements(
-  mode:                     ScienceMode,
-  spectroscopyRequirements: SpectroscopyScienceRequirements
+  mode:         ScienceMode,
+  spectroscopy: SpectroscopyScienceRequirements
 )
 
 object ScienceRequirements extends ScienceRequirementsOptics {
   val Default: ScienceRequirements =
-    ScienceRequirements(ScienceMode.Spectroscopy, SpectroscopyScienceRequirements.Default)
+    ScienceRequirements(
+      ScienceMode.Spectroscopy,
+      SpectroscopyScienceRequirements.Default
+    )
 
   implicit val eqScienceRequirements: Eq[ScienceRequirements] =
-    Eq.by(x => (x.mode, x.spectroscopyRequirements))
+    Eq.by(a => (a.mode, a.spectroscopy))
 }
 
 final case class ScienceRequirementsInput(
-  mode:                     Input[ScienceMode],
-  spectroscopyRequirements: Input[SpectroscopyScienceRequirementsInput]
+  mode:         Input[ScienceMode]                          = Input.ignore,
+  spectroscopy: Input[SpectroscopyScienceRequirementsInput] = Input.ignore
 ) extends EditorInput[ScienceRequirements] {
 
   override val create: ValidatedInput[ScienceRequirements] =
     (mode.notMissing("mode"),
-     spectroscopyRequirements.notMissingAndThen("spectroscopyRequirements")(_.create)
+     spectroscopy.notMissingAndThen("spectroscopy")(_.create)
     ).mapN { (m, s) => ScienceRequirements(m, s) }
 
   override val edit: StateT[EitherInput, ScienceRequirements, Unit] =
     for {
       m <- mode.validateIsNotNull("mode").liftState
-      _ <- ScienceRequirements.mode                     := m
-      _ <- ScienceRequirements.spectroscopyRequirements :! spectroscopyRequirements
+      _ <- ScienceRequirements.mode         := m
+      _ <- ScienceRequirements.spectroscopy :! spectroscopy
     } yield ()
 
 }
@@ -60,17 +63,14 @@ object ScienceRequirementsInput {
     deriveConfiguredDecoder
 
   implicit val EqScienceRequirementsInput: Eq[ScienceRequirementsInput] =
-    Eq.by { a => (
-      a.mode,
-      a.spectroscopyRequirements
-    )}
+    Eq.by(a => (a.mode, a.spectroscopy))
 }
 
 trait ScienceRequirementsOptics {
   val mode: Lens[ScienceRequirements, ScienceMode] =
     Focus[ScienceRequirements](_.mode)
 
-  val spectroscopyRequirements: Lens[ScienceRequirements, SpectroscopyScienceRequirements] =
-    Focus[ScienceRequirements](_.spectroscopyRequirements)
+  val spectroscopy: Lens[ScienceRequirements, SpectroscopyScienceRequirements] =
+    Focus[ScienceRequirements](_.spectroscopy)
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ScienceRequirements.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ScienceRequirements.scala
@@ -6,6 +6,7 @@ package lucuma.odb.api.model
 import cats.Eq
 import cats.data.StateT
 import cats.syntax.apply._
+import cats.syntax.traverse._
 import clue.data.Input
 import clue.data.syntax._
 import io.circe.Decoder
@@ -39,7 +40,7 @@ final case class ScienceRequirementsInput(
 
   override val create: ValidatedInput[ScienceRequirements] =
     (mode.notMissing("mode"),
-     spectroscopy.notMissingAndThen("spectroscopy")(_.create)
+     spectroscopy.toOption.traverse(_.create).map(_.getOrElse(SpectroscopyScienceRequirements.Default))
     ).mapN { (m, s) => ScienceRequirements(m, s) }
 
   override val edit: StateT[EitherInput, ScienceRequirements, Unit] =

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
@@ -8,7 +8,7 @@ import cats.effect.{Async, Ref}
 import cats.implicits._
 import lucuma.core.model.{Observation, Program, Target}
 import lucuma.odb.api.model.ObservationModel.{BulkEdit, Create, Edit, Group, ObservationEvent}
-import lucuma.odb.api.model.{ConstraintSetInput, ConstraintSetModel, EitherInput, Event, InputError, InstrumentConfigModel, ObservationModel, PlannedTimeSummaryModel, ScienceRequirements, ScienceRequirementsModel, ValidatedInput}
+import lucuma.odb.api.model.{ConstraintSetInput, ConstraintSetModel, EitherInput, Event, InputError, InstrumentConfigModel, ObservationModel, PlannedTimeSummaryModel, ScienceRequirements, ScienceRequirementsInput, ValidatedInput}
 import lucuma.odb.api.model.syntax.lens._
 import lucuma.odb.api.model.syntax.toplevel._
 import lucuma.odb.api.model.syntax.validatedinput._
@@ -88,7 +88,7 @@ sealed trait ObservationRepo[F[_]] extends TopLevelRepo[F, Observation.Id, Obser
   ): F[List[ObservationModel]]
 
   def bulkEditScienceRequirements(
-    be: BulkEdit[ScienceRequirementsModel.Edit]
+    be: BulkEdit[ScienceRequirementsInput]
   ): F[List[ObservationModel]]
 
 }
@@ -369,12 +369,12 @@ object ObservationRepo {
         )
 
       override def bulkEditScienceRequirements(
-        be: BulkEdit[ScienceRequirementsModel.Edit]
+        be: BulkEdit[ScienceRequirementsInput]
       ): F[List[ObservationModel]] =
 
         bulkEdit(
           selectObservations(be.selectProgram, be.selectObservations),
-          ObservationModel.scienceRequirements.transform(be.edit.editor)
+          ObservationModel.scienceRequirements.transform(be.edit.edit)
         )
 
     }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -50,7 +50,7 @@ trait ObservationMutation {
       ReplaceInputField("activeStatus",         ObsActiveStatusType.notNullableField("activeStatus")),
       ReplaceInputField("targetEnvironment",    InputObjectTypeTargetEnvironment.notNullableField("targetEnvironment")),
       ReplaceInputField("constraintSet",        InputObjectTypeConstraintSet.notNullableField("constraintSet")),
-      ReplaceInputField("scienceRequirements",  InputObjectTypeScienceRequirements.nullableField("scienceRequirements")),
+      ReplaceInputField("scienceRequirements",  InputObjectTypeScienceRequirements.notNullableField("scienceRequirements")),
       ReplaceInputField("scienceConfiguration", InputObjectTypeScienceConfig.nullableField("scienceConfiguration"))
     )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -3,7 +3,7 @@
 
 package lucuma.odb.api.schema
 
-import lucuma.odb.api.model.{ConstraintSetInput, ObservationModel, ScienceRequirementsModel}
+import lucuma.odb.api.model.{ConstraintSetInput, ObservationModel, ScienceRequirementsInput}
 import lucuma.odb.api.model.ObservationModel.BulkEdit
 import lucuma.odb.api.repo.OdbRepo
 import lucuma.odb.api.schema.syntax.inputtype._
@@ -20,7 +20,7 @@ trait ObservationMutation {
   import ConstraintSetMutation.InputObjectTypeConstraintSet
   import context._
   import ScienceConfigurationMutation.InputObjectTypeScienceConfig
-  import ScienceRequirementsMutation.{InputObjectTypeScienceRequirementsCreate, InputObjectTypeScienceRequirementsEdit}
+  import ScienceRequirementsMutation.InputObjectTypeScienceRequirements
   import GeneralSchema.{EnumTypeExistence, NonEmptyStringType}
   import ObservationSchema.{ObsActiveStatusType, ObservationIdType, ObservationIdArgument, ObsStatusType, ObservationType}
   import ProgramSchema.ProgramIdType
@@ -50,7 +50,7 @@ trait ObservationMutation {
       ReplaceInputField("activeStatus",         ObsActiveStatusType.notNullableField("activeStatus")),
       ReplaceInputField("targetEnvironment",    InputObjectTypeTargetEnvironment.notNullableField("targetEnvironment")),
       ReplaceInputField("constraintSet",        InputObjectTypeConstraintSet.notNullableField("constraintSet")),
-      ReplaceInputField("scienceRequirements",  InputObjectTypeScienceRequirementsEdit.nullableField("scienceRequirements")),
+      ReplaceInputField("scienceRequirements",  InputObjectTypeScienceRequirements.nullableField("scienceRequirements")),
       ReplaceInputField("scienceConfiguration", InputObjectTypeScienceConfig.nullableField("scienceConfiguration"))
     )
 
@@ -98,10 +98,10 @@ trait ObservationMutation {
       InputObjectTypeConstraintSet
     )
 
-  val ArgumentScienceRequirementsBulkEdit: Argument[BulkEdit[ScienceRequirementsModel.Edit]] =
-    bulkEditArgument[ScienceRequirementsModel.Edit](
+  val ArgumentScienceRequirementsBulkEdit: Argument[BulkEdit[ScienceRequirementsInput]] =
+    bulkEditArgument[ScienceRequirementsInput](
       "scienceRequirements",
-      InputObjectTypeScienceRequirementsEdit
+      InputObjectTypeScienceRequirements
     )
 
   def create[F[_]: Dispatcher](implicit ev: MonadError[F, Throwable]): Field[OdbRepo[F], Unit] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceRequirementsMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceRequirementsMutation.scala
@@ -3,11 +3,8 @@
 
 package lucuma.odb.api.schema
 
-import lucuma.odb.api.model.ScienceRequirementsModel
-
-import sangria.macros.derive._
+import lucuma.odb.api.model.{ScienceRequirementsInput, SpectroscopyScienceRequirementsInput}
 import sangria.schema._
-import lucuma.odb.api.model.SpectroscopyScienceRequirementsModel
 
 trait ScienceRequirementsMutation {
 
@@ -16,38 +13,30 @@ trait ScienceRequirementsMutation {
   import RefinedSchema._
   import syntax.inputtype._
 
-  implicit val InputObjectTypeSpectroscopyRequirements: InputObjectType[SpectroscopyScienceRequirementsModel.Create] =
-    deriveInputObjectType[SpectroscopyScienceRequirementsModel.Create](
-      InputObjectTypeName("SpectroscopyScienceRequirementsInput"),
-      InputObjectTypeDescription("Spectroscopy science requirements create params")
+  implicit val InputObjectTypeSpectroscopyScienceRequirements: InputObjectType[SpectroscopyScienceRequirementsInput] =
+    InputObjectType[SpectroscopyScienceRequirementsInput](
+      "SpectroscopyScienceRequirementsInput",
+      "Edit or create spectroscopy science requirements",
+      List(
+        InputWavelength.nullableField("wavelength"),
+        InputObjectPosInt.nullableField("resolution"),
+        InputObjectPosBigDecimal.nullableField("signalToNoise"),
+        InputWavelength.nullableField("signalToNoiseAt"),
+        InputWavelength.nullableField("wavelengthCoverage"),
+        EnumTypeFocalPlane.nullableField("focalPlane"),
+        InputFocalPlaneAngleInput.nullableField("focalPlaneAngle"),
+        EnumTypeSpectroscopyCapabilities.nullableField("capabilities")
+      )
     )
 
-  implicit val InputObjectTypeScienceRequirementsCreate: InputObjectType[ScienceRequirementsModel.Create] =
-    deriveInputObjectType[ScienceRequirementsModel.Create](
-      InputObjectTypeName("ScienceRequirementsInput"),
-      InputObjectTypeDescription("Science requirement input params")
-    )
-
-  implicit val InputObjectTypeScienceRequirementsEdit: InputObjectType[ScienceRequirementsModel.Edit] =
-    deriveInputObjectType[ScienceRequirementsModel.Edit](
-      InputObjectTypeName("EditScienceRequirementsInput"),
-      InputObjectTypeDescription("Edit science requirements"),
-      ReplaceInputField("mode", EnumTypeScienceMode.notNullableField("mode")),
-      ReplaceInputField("spectroscopyRequirements", InputObjectTypeSpectroscopyRequirements.notNullableField("spectroscopyRequirements")),
-    )
-
-  implicit val InputObjectTypeSpectroscopyEdit: InputObjectType[SpectroscopyScienceRequirementsModel.Edit] =
-    deriveInputObjectType[SpectroscopyScienceRequirementsModel.Edit](
-      InputObjectTypeName("SpectroscopyScienceRequirementsEdit"),
-      InputObjectTypeDescription("Edit spectroscopy science requirements"),
-      ReplaceInputField("wavelength", InputWavelength.notNullableField("wavelength")),
-      ReplaceInputField("resolution", InputObjectPosInt.notNullableField("resolution")),
-      ReplaceInputField("signalToNoise", InputObjectPosBigDecimal.notNullableField("signalToNoise")),
-      ReplaceInputField("signalToNoiseAt", InputWavelength.notNullableField("signalToNoiseAt")),
-      ReplaceInputField("wavelengthCoverage", InputWavelength.notNullableField("wavelengthCoverage")),
-      ReplaceInputField("focalPlane", EnumTypeFocalPlane.notNullableField("focalPlane")),
-      ReplaceInputField("focalPlaneAngle", InputFocalPlaneAngleInput.notNullableField("focalPlaneAngle")),
-      ReplaceInputField("capabilities", EnumTypeSpectroscopyCapabilities.notNullableField("capabilities")),
+  implicit val InputObjectTypeScienceRequirements: InputObjectType[ScienceRequirementsInput] =
+    InputObjectType[ScienceRequirementsInput](
+      "ScienceRequirementsInput",
+      "Edit science requirements",
+      List(
+        EnumTypeScienceMode.notNullableField("mode"),
+        InputObjectTypeSpectroscopyScienceRequirements.notNullableField("spectroscopyRequirements")
+      )
     )
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceRequirementsMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceRequirementsMutation.scala
@@ -35,7 +35,7 @@ trait ScienceRequirementsMutation {
       "Edit science requirements",
       List(
         EnumTypeScienceMode.notNullableField("mode"),
-        InputObjectTypeSpectroscopyScienceRequirements.notNullableField("spectroscopyRequirements")
+        InputObjectTypeSpectroscopyScienceRequirements.notNullableField("spectroscopy")
       )
     )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceRequirementsSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceRequirementsSchema.scala
@@ -144,10 +144,10 @@ object ScienceRequirementsSchema {
           ),
 
           Field(
-            name        = "spectroscopyRequirements",
+            name        = "spectroscopy",
             fieldType   = SpectroscopyRequirementsType[F],
             description = Some("Spectroscopy requirements"),
-            resolve     = _.value.spectroscopyRequirements
+            resolve     = _.value.spectroscopy
           ),
         )
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceRequirementsSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceRequirementsSchema.scala
@@ -7,12 +7,9 @@ import lucuma.core.math.Angle
 import lucuma.core.enum.FocalPlane
 import lucuma.core.enum.SpectroscopyCapabilities
 import lucuma.core.enum.ScienceMode
-import lucuma.odb.api.model.SpectroscopyScienceRequirements
-import lucuma.odb.api.model.SpectroscopyScienceRequirementsModel
-import lucuma.odb.api.model.ScienceRequirements
+import lucuma.odb.api.model.{FocalPlaneAngleInput, ScienceRequirements, SpectroscopyScienceRequirements}
 import lucuma.odb.api.repo.OdbRepo
 import lucuma.odb.api.schema.syntax.all._
-
 import sangria.schema._
 import sangria.macros.derive._
 
@@ -29,14 +26,14 @@ object ScienceRequirementsSchema {
   implicit val EnumTypeSpectroscopyCapabilities: EnumType[SpectroscopyCapabilities] =
     EnumType.fromEnumerated("SpectroscopyCapabilities", "Spectroscopy capabilities Nod&Shuffle/Polarimetry/Corongraphy")
 
-  implicit val EnumSpectroscopyModelAnglUnits: EnumType[SpectroscopyScienceRequirementsModel.Units] =
-    EnumType.fromEnumerated[SpectroscopyScienceRequirementsModel.Units](
+  implicit val EnumSpectroscopyModelAngleUnits: EnumType[FocalPlaneAngleInput.Units] =
+    EnumType.fromEnumerated[FocalPlaneAngleInput.Units](
       "FocalPlaneAngleUnits",
       "Focal plane angle units"
     )
 
-  implicit val InputFocalPlaneAngleInput: InputType[SpectroscopyScienceRequirementsModel.FocalPlaneAngleInput] =
-    deriveInputObjectType[SpectroscopyScienceRequirementsModel.FocalPlaneAngleInput](
+  implicit val InputFocalPlaneAngleInput: InputType[FocalPlaneAngleInput] =
+    deriveInputObjectType[FocalPlaneAngleInput](
       InputObjectTypeName("FocalPlaneAngleInput"),
       InputObjectTypeDescription("Focal plane angle source angle in appropriate units"),
     )

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbScienceRequirements.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbScienceRequirements.scala
@@ -76,7 +76,7 @@ trait ArbScienceRequirements {
       SpectroscopyScienceRequirements
     )].contramap { sc => (
       sc.mode,
-      sc.spectroscopyRequirements
+      sc.spectroscopy
     )}
 }
 

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -364,7 +364,7 @@ object Init {
         TargetEnvironmentInput.asterism(sidereal.id).some
       },
       constraintSet        = None,
-      scienceRequirements  = ScienceRequirementsModel.Create.Default.some,
+      scienceRequirements  = ScienceRequirementsInput.Default.some,
       scienceConfiguration = None,
       config               =
         InstrumentConfigModel.Create.gmosSouth(

--- a/modules/service/src/test/scala/QuerySuite.scala
+++ b/modules/service/src/test/scala/QuerySuite.scala
@@ -199,7 +199,7 @@ class QuerySuite extends OdbSuite {
           nodes {
             scienceRequirements {
               mode
-              spectroscopyRequirements {
+              spectroscopy {
                 wavelength { nanometers }
               }
             }
@@ -221,7 +221,7 @@ class QuerySuite extends OdbSuite {
             {
               "scienceRequirements" : {
                 "mode" : "SPECTROSCOPY",
-                "spectroscopyRequirements" : {
+                "spectroscopy" : {
                   "wavelength" : null
                 }
               },

--- a/modules/service/src/test/scala/test/TestInit.scala
+++ b/modules/service/src/test/scala/test/TestInit.scala
@@ -407,7 +407,7 @@ object TestInit {
       activeStatus         = ObsActiveStatus.Active.some,
       targetEnvironment    = TargetEnvironmentInput.asterism(targets.map(_.id)).some,
       constraintSet        = None,
-      scienceRequirements  = ScienceRequirementsModel.Create.Default.some,
+      scienceRequirements  = ScienceRequirementsInput.Default.some,
       scienceConfiguration = None,
       config               =
         InstrumentConfigModel.Create.gmosSouth(


### PR DESCRIPTION
Makes `ScienceRequirements` resemble `SourceProfile`, `ConstraintSet`, and `ScienceConfiguration`:

* Combines create and edit inputs
* Renames `scienceRequirements` / `spectroscopyRequirements` to `scienceRequirements` / `spectroscopy`