### PR TITLE
ITC result cache

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
@@ -159,7 +159,7 @@ object ObservationSchema {
           resolve     = c => c.unsafeToFuture {
             for {
               ts <- c.value.targetEnvironment.asterism.toList.traverse(tid => c.ctx.odbRepo.target.unsafeSelectTarget(tid))
-              rs <- ts.traverse(t => c.ctx.itcClient.query[F](c.value, t.target))
+              rs <- ts.traverse(t => c.ctx.itcClient.query(c.value, t.target))
 
               results   = rs.flatMap(_.toList).traverse(_.itc.toEither)
               maxResult = results.map(_.maxByOption(s => (s.exposureTime.getSeconds, s.exposureTime.getNano)))

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/OdbCtx.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/OdbCtx.scala
@@ -13,7 +13,7 @@ import lucuma.odb.api.repo.OdbRepo
  */
 trait OdbCtx[F[_]] {
 
-  def itcClient:  ItcClient
+  def itcClient:  ItcClient[F]
 
   def odbRepo: OdbRepo[F]
 
@@ -22,13 +22,13 @@ trait OdbCtx[F[_]] {
 object OdbCtx {
 
   def create[F[_]](
-    itc: ItcClient,
+    itc: ItcClient[F],
     repo: OdbRepo[F]
   ): OdbCtx[F] =
 
     new OdbCtx[F] {
 
-      override def itcClient: ItcClient =
+      override def itcClient: ItcClient[F] =
         itc
 
       override def odbRepo: OdbRepo[F] =

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Config.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Config.scala
@@ -68,7 +68,7 @@ object Config {
   def fromCiris[F[_]]: ConfigValue[F, Config] =
     (
       (envOrProp[F]("ODB_PORT") or envOrProp[F]("PORT") or ConfigValue.default("8080")).as[Int],
-      (envOrProp[F]("ITC_URI") or ConfigValue.default("https://itc-staging.herokuapp.com/itc")).as[Uri]
+      (envOrProp[F]("ITC_URI") or ConfigValue.default("https://itc-production.herokuapp.com/itc")).as[Uri]
     ).parMapN(Config.apply)
 
 // TODO: SSO

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Main.scala
@@ -92,9 +92,10 @@ object Main extends IOApp {
     for {
       cfg  <- Config.fromCiris.load(Async[IO])
       log  <- Slf4jLogger.create[IO]
-      odb  <- OdbRepo.create[IO]
-      ctx   = OdbCtx.create[IO](ItcClient(cfg.itc)(Async[IO], log), odb)
-      _    <- Init.initialize(odb)
+      itc  <- ItcClient.create(cfg.itc)(Async[IO], log)
+      rpo  <- OdbRepo.create[IO]
+      _    <- Init.initialize(rpo)
+      ctx   = OdbCtx.create[IO](itc, rpo)
       _    <- stream(ctx, cfg)(log, Async[IO]).compile.drain
     } yield ExitCode.Success
 }

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Main.scala
@@ -93,7 +93,7 @@ object Main extends IOApp {
       cfg  <- Config.fromCiris.load(Async[IO])
       log  <- Slf4jLogger.create[IO]
       odb  <- OdbRepo.create[IO]
-      ctx   = OdbCtx.create(ItcClient(cfg.itc), odb)
+      ctx   = OdbCtx.create[IO](ItcClient(cfg.itc)(Async[IO], log), odb)
       _    <- Init.initialize(odb)
       _    <- stream(ctx, cfg)(log, Async[IO]).compile.drain
     } yield ExitCode.Success

--- a/modules/service/src/test/scala/OdbSuite.scala
+++ b/modules/service/src/test/scala/OdbSuite.scala
@@ -57,7 +57,7 @@ trait OdbSuite extends CatsEffectSuite {
   private val httpApp: Resource[IO, WebSocketBuilder2[IO] => HttpApp[IO]] =
     Resource.eval(OdbRepo.create[IO].flatTap(TestInit.initialize(_)))
       .flatMap { repo =>
-        val ctx = OdbCtx.create(ItcClient( uri"https://itc-staging.herokuapp.com/itc"), repo)
+        val ctx = OdbCtx.create(ItcClient[IO]( uri"https://itc-staging.herokuapp.com/itc"), repo)
         Main.httpApp(ctx) //, ssoClient))  // TODO: SSO
       }
 

--- a/modules/service/src/test/scala/OdbSuite.scala
+++ b/modules/service/src/test/scala/OdbSuite.scala
@@ -54,12 +54,17 @@ trait OdbSuite extends CatsEffectSuite {
 //      def collect[B](f: PartialFunction[User,B]): SsoClient[IO,B] = ???
 //    }
 
-  private val httpApp: Resource[IO, WebSocketBuilder2[IO] => HttpApp[IO]] =
-    Resource.eval(OdbRepo.create[IO].flatTap(TestInit.initialize(_)))
-      .flatMap { repo =>
-        val ctx = OdbCtx.create(ItcClient[IO]( uri"https://itc-staging.herokuapp.com/itc"), repo)
+  private val httpApp: Resource[IO, WebSocketBuilder2[IO] => HttpApp[IO]] = {
+    val setupContext: IO[OdbCtx[IO]] =
+      for {
+        itc <- ItcClient.create[IO](uri"https://itc-staging.herokuapp.com/itc")
+        rpo <- OdbRepo.create[IO].flatTap(TestInit.initialize(_))
+      } yield OdbCtx.create(itc, rpo)
+
+    Resource.eval(setupContext).flatMap { ctx =>
         Main.httpApp(ctx) //, ssoClient))  // TODO: SSO
-      }
+    }
+  }
 
   private val server: Resource[IO, Server] =
     // Resource.make(IO.println("  • Server starting..."))(_ => IO.println("  • Server stopped.")) *>


### PR DESCRIPTION
Updates the ITC client to use a simple forever `Map` cache of results.  I think this is good enough for the throwaway API service, especially since it is restarted daily.  There is a `useCache` argument (`true` by default) that can be used to skip the cache lookup.

Switches to the production ITC because I need to update the client for the updated ITC API.