### PR TITLE
Add TargetEnvironmentMutationSuite to the ignore list

### DIFF
--- a/modules/service/src/main/resources/logback.xml
+++ b/modules/service/src/main/resources/logback.xml
@@ -14,6 +14,7 @@
   <logger name="test.MutationSuite" level="OFF" />
   <logger name="test.targets.ScienceTargetMutationSuite" level="OFF" />
   <logger name="test.targets.ScienceTargetsMutationSuite" level="OFF" />
+  <logger name="test.targets.TargetEnvironmentMutationSuite" level="OFF" />
   <logger name="test.targets.TargetRenameMutationSuite" level="OFF" />
 
   <root level="WARN">


### PR DESCRIPTION
When the test cases run, a scary stack trace is logged for `TargetEnvironmentMutationSuite`.  This is expected but misleading so it's turned off here.