### PR TITLE
Update ItcSpectroscopyInput

### DIFF
--- a/modules/service/src/main/resources/logback.xml
+++ b/modules/service/src/main/resources/logback.xml
@@ -17,6 +17,8 @@
   <logger name="test.targets.TargetEnvironmentMutationSuite" level="OFF" />
   <logger name="test.targets.TargetRenameMutationSuite" level="OFF" />
 
+  <logger name="lucuma.odb.api.service.Main" level="INFO"/>
+
   <root level="WARN">
     <appender-ref ref="STDOUT" />
   </root>

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Config.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Config.scala
@@ -68,7 +68,7 @@ object Config {
   def fromCiris[F[_]]: ConfigValue[F, Config] =
     (
       (envOrProp[F]("ODB_PORT") or envOrProp[F]("PORT") or ConfigValue.default("8080")).as[Int],
-      (envOrProp[F]("ITC_URI") or ConfigValue.default("https://itc-production.herokuapp.com/itc")).as[Uri]
+      (envOrProp[F]("ITC_URI") or ConfigValue.default("https://itc-staging.herokuapp.com/itc")).as[Uri]
     ).parMapN(Config.apply)
 
 // TODO: SSO

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -49,7 +49,7 @@ object Init {
     "point": {
       "bandNormalized": {
         "sed": {
-          "stellarLibrary": "O5_V"
+          "galaxy": "SPIRAL"
         },
         "brightnesses": [
           {


### PR DESCRIPTION
* Updates `ItcSpectroscopyInput` to match the current API.  Defines a bunch of encoders that might be better placed in `core` I don't know.
* Switches back to itc-staging by default
* Switches init back to spiral galaxy SED since the server should be able to swallow it now