### PR TITLE
generalize lens and optional ops

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/VisitRecords.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/VisitRecords.scala
@@ -76,11 +76,11 @@ object VisitRecords {
     }(GmosSouth(_))
 
   def visits(oid: Observation.Id): StateT[EitherInput, Database, Option[ListMap[Visit.Id, VisitRecord[_, _]]]] =
-    Database.visitRecordsAt(oid).st.map { _.map(_.visits) }
+    Database.visitRecordsAt(oid).st[EitherInput].map { _.map(_.visits) }
 
   def visitAt(oid: Observation.Id, visitId: Visit.Id): StateT[EitherInput, Database, VisitRecord[_, _]] =
     for {
-      v <- Database.visitRecordsAt(oid).st
+      v <- Database.visitRecordsAt(oid).st[EitherInput]
       r <- StateT.liftF(
         v.flatMap(_.visits.get(visitId)).toRightNec(
           InputError.fromMessage(s"Unknown visit for observation $oid, visit $visitId")

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ExecutionEventRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ExecutionEventRepo.scala
@@ -437,7 +437,7 @@ object ExecutionEventRepo {
         def record(in: ValidatedInput[VisitRecord[S, D]]): StateT[EitherInput, Database, VisitRecord[S, D]] =
           for {
             vr <- StateT.liftF(in.toEither)
-            _  <- Database.visitRecordsAt(visit.observationId).mod_ { ovr =>
+            _  <- Database.visitRecordsAt(visit.observationId).mod_[EitherInput] { ovr =>
               prism.reverseGet(ovr.fold(ListMap(visitId -> vr)) { vrs =>
                 prism.getOption(vrs).fold(ListMap(visitId -> vr))(_.updated(visitId, vr))
               }).some
@@ -462,7 +462,7 @@ object ExecutionEventRepo {
             sr  <- StateT.liftF(in.toEither)
             _   <- Database.visitRecordAt(step.observationId, step.visitId, prism)
                     .andThen(VisitRecord.steps[S, D].asOptional)
-                    .mod_(_.updated(stepId, sr))
+                    .mod_[EitherInput](_.updated(stepId, sr))
           } yield sr
 
         for {


### PR DESCRIPTION
Small hack to `tmp-api` `LensOps` and `OptionalOps` syntax to generalize the `F` context wrapper for most methods.  The symbolic names are fixed at `EitherInput` since that's the usual context and I wanted to avoid having to explicitly specify it like `:=[EitherInput]`.