### PR TITLE
Observation subtitle (aka "detail")

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -33,7 +33,7 @@ final case class ObservationModel(
   id:                   Observation.Id,
   existence:            Existence,
   programId:            Program.Id,
-  name:                 Option[NonEmptyString],
+  subtitle:             Option[NonEmptyString],
   status:               ObsStatus,
   activeStatus:         ObsActiveStatus,
   targetEnvironment:    TargetEnvironmentModel,
@@ -60,7 +60,7 @@ object ObservationModel extends ObservationOptics {
       o.id,
       o.existence,
       o.programId,
-      o.name,
+      o.subtitle,
       o.status,
       o.activeStatus,
       o.targetEnvironment,
@@ -75,7 +75,7 @@ object ObservationModel extends ObservationOptics {
   final case class Create(
     observationId:        Option[Observation.Id],
     programId:            Program.Id,
-    name:                 Option[NonEmptyString],
+    subtitle:             Option[NonEmptyString],
     status:               Option[ObsStatus],
     activeStatus:         Option[ObsActiveStatus],
     targetEnvironment:    Option[TargetEnvironmentInput],
@@ -101,7 +101,7 @@ object ObservationModel extends ObservationOptics {
               id                   = i,
               existence            = Present,
               programId            = programId,
-              name                 = name,
+              subtitle             = subtitle,
               status               = status.getOrElse(ObsStatus.New),
               activeStatus         = activeStatus.getOrElse(ObsActiveStatus.Active),
               targetEnvironment    = tʹ,
@@ -125,7 +125,7 @@ object ObservationModel extends ObservationOptics {
       Create(
         observationId        = None,
         programId            = programId,
-        name                 = None,
+        subtitle             = None,
         status               = None,
         activeStatus         = None,
         targetEnvironment    = None,
@@ -142,7 +142,7 @@ object ObservationModel extends ObservationOptics {
       Eq.by { a => (
         a.observationId,
         a.programId,
-        a.name,
+        a.subtitle,
         a.status,
         a.activeStatus,
         a.targetEnvironment,
@@ -157,7 +157,7 @@ object ObservationModel extends ObservationOptics {
   final case class Edit(
     observationId:        Observation.Id,
     existence:            Input[Existence]                 = Input.ignore,
-    name:                 Input[NonEmptyString]            = Input.ignore,
+    subtitle:             Input[NonEmptyString]            = Input.ignore,
     status:               Input[ObsStatus]                 = Input.ignore,
     activeStatus:         Input[ObsActiveStatus]           = Input.ignore,
     targetEnvironment:    Input[TargetEnvironmentInput]    = Input.ignore,
@@ -177,7 +177,7 @@ object ObservationModel extends ObservationOptics {
         args <- validArgs.liftState
         (e, s, a) = args
         _ <- ObservationModel.existence            := e
-        _ <- ObservationModel.name                 := name.toOptionOption
+        _ <- ObservationModel.subtitle             := subtitle.toOptionOption
         _ <- ObservationModel.status               := s
         _ <- ObservationModel.activeStatus         := a
         _ <- ObservationModel.targetEnvironment    :! targetEnvironment
@@ -201,7 +201,7 @@ object ObservationModel extends ObservationOptics {
       Eq.by { a => (
         a.observationId,
         a.existence,
-        a.name,
+        a.subtitle,
         a.status,
         a.activeStatus,
         a.targetEnvironment,
@@ -294,8 +294,8 @@ trait ObservationOptics { self: ObservationModel.type =>
   val existence: Lens[ObservationModel, Existence] =
     Focus[ObservationModel](_.existence)
 
-  val name: Lens[ObservationModel, Option[NonEmptyString]] =
-    Focus[ObservationModel](_.name)
+  val subtitle: Lens[ObservationModel, Option[NonEmptyString]] =
+    Focus[ObservationModel](_.subtitle)
 
   val status: Lens[ObservationModel, ObsStatus] =
     Focus[ObservationModel](_.status)

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -46,7 +46,7 @@ trait ObservationMutation {
       InputObjectTypeName("EditObservationInput"),
       InputObjectTypeDescription("Edit observation"),
       ReplaceInputField("existence",            EnumTypeExistence.notNullableField("existence")),
-      ReplaceInputField("name",                 NonEmptyStringType.nullableField("name")),
+      ReplaceInputField("subtitle",             NonEmptyStringType.nullableField("subtitle")),
       ReplaceInputField("status",               ObsStatusType.notNullableField("status")),
       ReplaceInputField("activeStatus",         ObsActiveStatusType.notNullableField("activeStatus")),
       ReplaceInputField("targetEnvironment",    InputObjectTypeTargetEnvironment.notNullableField("targetEnvironment")),

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
@@ -59,7 +59,7 @@ trait ArbObservationModel {
       in.id,
       in.existence,
       in.programId,
-      in.name.map(_.value),
+      in.subtitle.map(_.value),
       in.status,
       in.activeStatus,
       in.constraintSet,
@@ -102,7 +102,7 @@ trait ArbObservationModel {
     )].contramap { in => (
       in.observationId,
       in.programId,
-      in.name.map(_.value),
+      in.subtitle.map(_.value),
       in.status,
       in.activeStatus,
       in.targetEnvironment,

--- a/modules/core/src/test/scala/lucuma/odb/api/repo/ObservationRepoSpec.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/repo/ObservationRepoSpec.scala
@@ -89,9 +89,9 @@ final class ObservationRepoSpec extends ScalaCheckSuite with OdbRepoTest {
 
     forAll { (t: Database) =>
       val (_, obs) = runEditTest(t) { o =>
-        ObservationModel.Edit(o.id, name = Input(NonEmptyString.unsafeFrom("Biff")))
+        ObservationModel.Edit(o.id, subtitle = Input(NonEmptyString.unsafeFrom("Biff")))
       }
-      assert(obs.name.contains(NonEmptyString.unsafeFrom("Biff")))
+      assert(obs.subtitle.contains(NonEmptyString.unsafeFrom("Biff")))
     }
 
   }
@@ -99,7 +99,7 @@ final class ObservationRepoSpec extends ScalaCheckSuite with OdbRepoTest {
   property("simple non-edit") {
     forAll { (t: Database) =>
       val (before, after) = runEditTest(t) { o =>
-        ObservationModel.Edit(o.id, name = o.name.fold(Input.ignore[NonEmptyString])(n => Input(n)))
+        ObservationModel.Edit(o.id, subtitle = o.subtitle.fold(Input.ignore[NonEmptyString])(n => Input(n)))
       }
       assertEquals(after, before)
     }

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -362,7 +362,7 @@ object Init {
     ObservationModel.Create(
       observationId        = None,
       programId            = pid,
-      name                 = target.map(_.name) orElse NonEmptyString.from("Observation").toOption,
+      subtitle                 = target.map(_.name) orElse NonEmptyString.from("Observation").toOption,
       status               = ObsStatus.New.some,
       activeStatus         = ObsActiveStatus.Active.some,
       targetEnvironment    = target.fold(none[TargetEnvironmentInput]) { sidereal =>

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -362,7 +362,7 @@ object Init {
     ObservationModel.Create(
       observationId        = None,
       programId            = pid,
-      subtitle                 = target.map(_.name) orElse NonEmptyString.from("Observation").toOption,
+      subtitle             = None,
       status               = ObsStatus.New.some,
       activeStatus         = ObsActiveStatus.Active.some,
       targetEnvironment    = target.fold(none[TargetEnvironmentInput]) { sidereal =>

--- a/modules/service/src/test/scala/ObservationEditSubscriptionSuite.scala
+++ b/modules/service/src/test/scala/ObservationEditSubscriptionSuite.scala
@@ -12,7 +12,7 @@ class ObservationEditSubscriptionSuite extends OdbSuite {
   val query: String = """
     subscription ObservationEdit {
       observationEdit(programId: "p-2") {
-        value { id name }
+        value { id subtitle }
       }
     }
   """
@@ -34,7 +34,7 @@ class ObservationEditSubscriptionSuite extends OdbSuite {
       {
         "editObservation": {
           "observationId": "o-2",
-          "name": $newName
+          "subtitle": $newName
         }
       }
     """
@@ -50,7 +50,7 @@ class ObservationEditSubscriptionSuite extends OdbSuite {
         "observationEdit" : {
           "value" : {
             "id" : "o-2",
-            "name" : $newName
+            "subtitle" : $newName
           }
         }
       }

--- a/modules/service/src/test/scala/OdbSuite.scala
+++ b/modules/service/src/test/scala/OdbSuite.scala
@@ -191,7 +191,7 @@ trait OdbSuite extends CatsEffectSuite {
                 _   <- log.debug("*** ----- about to start stream fiber")
                 fib <- sub.stream.compile.toList.start
                 _   <- log.debug("*** ----- pausing a bit")
-                _   <- IO.sleep(200.millis)
+                _   <- IO.sleep(500.millis)
                 _   <- log.debug("*** ----- running mutations")
                 _   <- mutations.fold(_.traverse_ { case (query, vars) =>
                          val req = conn.request(Operation(query))

--- a/modules/service/src/test/scala/QuerySuite.scala
+++ b/modules/service/src/test/scala/QuerySuite.scala
@@ -131,7 +131,7 @@ class QuerySuite extends OdbSuite {
             observations(first: 10) {
               nodes {
                 id
-                name
+                title
               }
             }
           }
@@ -161,27 +161,27 @@ class QuerySuite extends OdbSuite {
                 "nodes" : [
                   {
                     "id" : "o-2",
-                    "name" : "NGC 5949"
+                    "title" : "o-2: NGC 5949"
                   },
                   {
                     "id" : "o-3",
-                    "name" : "NGC 3312"
+                    "title" : "o-3: NGC 3312"
                   },
                   {
                     "id" : "o-4",
-                    "name" : "NGC 3312"
+                    "title" : "o-4: NGC 3312"
                   },
                   {
                     "id" : "o-5",
-                    "name" : "NGC 3312"
+                    "title" : "o-5: NGC 3312"
                   },
                   {
                     "id" : "o-6",
-                    "name" : "NGC 5949"
+                    "title" : "o-6: NGC 5949, NGC 3269, NGC 3312"
                   },
                   {
                     "id" : "o-7",
-                    "name" : "Observation"
+                    "title" : "o-7"
                   }
                 ]
               }
@@ -207,7 +207,7 @@ class QuerySuite extends OdbSuite {
             observations(first: 10) {
               nodes {
                 id
-                name
+                title
               }
             }
           }
@@ -237,27 +237,27 @@ class QuerySuite extends OdbSuite {
                 "nodes" : [
                   {
                     "id" : "o-2",
-                    "name" : "NGC 5949"
+                    "title" : "o-2: NGC 5949"
                   },
                   {
                     "id" : "o-3",
-                    "name" : "NGC 3312"
+                    "title" : "o-3: NGC 3312"
                   },
                   {
                     "id" : "o-4",
-                    "name" : "NGC 3312"
+                    "title" : "o-4: NGC 3312"
                   },
                   {
                     "id" : "o-5",
-                    "name" : "NGC 3312"
+                    "title" : "o-5: NGC 3312"
                   },
                   {
                     "id" : "o-6",
-                    "name" : "NGC 5949"
+                    "title" : "o-6: NGC 5949, NGC 3269, NGC 3312"
                   },
                   {
                     "id" : "o-7",
-                    "name" : "Observation"
+                    "title" : "o-7"
                   }
                 ]
               }

--- a/modules/service/src/test/scala/test/TestInit.scala
+++ b/modules/service/src/test/scala/test/TestInit.scala
@@ -402,7 +402,7 @@ object TestInit {
     ObservationModel.Create(
       observationId        = None,
       programId            = pid,
-      name                 = targets.headOption.map(_.name) orElse NonEmptyString.from("Observation").toOption,
+      subtitle                 = targets.headOption.map(_.name) orElse NonEmptyString.from("Observation").toOption,
       status               = ObsStatus.New.some,
       activeStatus         = ObsActiveStatus.Active.some,
       targetEnvironment    = TargetEnvironmentInput.asterism(targets.map(_.id)).some,

--- a/modules/service/src/test/scala/test/TestInit.scala
+++ b/modules/service/src/test/scala/test/TestInit.scala
@@ -402,7 +402,7 @@ object TestInit {
     ObservationModel.Create(
       observationId        = None,
       programId            = pid,
-      subtitle                 = targets.headOption.map(_.name) orElse NonEmptyString.from("Observation").toOption,
+      subtitle             = None,
       status               = ObsStatus.New.some,
       activeStatus         = ObsActiveStatus.Active.some,
       targetEnvironment    = TargetEnvironmentInput.asterism(targets.map(_.id)).some,


### PR DESCRIPTION
Following the discussion in [Shortcut](https://app.shortcut.com/lucuma/story/1209/add-user-supplied-observation-details#activity-1221), this PR renames the currently unused observation `name` field to `subtitle`.

It also adds a generated `title` field to the observation output that matches the value currently shown in Explore.  I don't expect Explore to actually use the `title` field but this makes it available for API users.