### PR TITLE
Remove extra stepType field

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/schema/StepSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/StepSchema.scala
@@ -89,13 +89,6 @@ object StepSchema {
         ),
 
         Field(
-          name        = "stepType",
-          fieldType   = EnumTypeStepType,
-          description = Some("Step type"),
-          resolve     = _.value.config.stepType
-        ),
-
-        Field(
           name        = "stepConfig",
           fieldType   = StepConfigType[F],
           description = Some("The sequence step itself"),


### PR DESCRIPTION
On request, this PR removes the `stepType` field from `GmosNorthStep` and `GmosSouthStep`.  It is still available in `stepConfig.stepType`.