### PR TITLE
Remove extra setupTime field

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ManualConfigSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ManualConfigSchema.scala
@@ -15,7 +15,6 @@ object ManualConfigSchema {
   import InstrumentSchema.EnumTypeInstrument
   import PlannedTimeSchema.PlannedTimeType
   import SequenceSchema.SequenceType
-  import TimeSchema.DurationType
 
   def ManualConfigType[F[_]]: InterfaceType[OdbCtx[F], ExecutionModel] =
     InterfaceType[OdbCtx[F], ExecutionModel](
@@ -35,13 +34,6 @@ object ManualConfigSchema {
           fieldType   = PlannedTimeType,
           description = Some("Planned time for this configuration"),
           resolve     = c => PlannedTime.estimate(c.value)
-        ),
-
-        Field(
-          name        = "setupTime",
-          fieldType   = DurationType,
-          description = Some("Estimated setup time"),
-          resolve     = c => PlannedTime.estimate(c.value).setup.value
         )
 
       )


### PR DESCRIPTION
As @rpiaggio pointed out, you can get the `setupTime` from the `plannedTime` so this is redundant at best.