### PR TITLE
Rename GMOS grating

### DIFF
--- a/modules/core/src/main/scala/lucuma/gen/gmos/GmosNorthSequenceState.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/GmosNorthSequenceState.scala
@@ -26,11 +26,11 @@ private[gmos] trait GmosNorthSequenceState extends SequenceState[NorthDynamic] {
         GmosAmpGain.Low,
         GmosAmpReadMode.Fast
       ),
-      dtax    = GmosDtax.Zero,
-      roi     = GmosRoi.FullFrame,
+      dtax          = GmosDtax.Zero,
+      roi           = GmosRoi.FullFrame,
       gratingConfig = None,
-      filter  = None,
-      fpu     = None
+      filter        = None,
+      fpu           = None
     )
 
 }

--- a/modules/core/src/main/scala/lucuma/gen/gmos/GmosNorthSequenceState.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/GmosNorthSequenceState.scala
@@ -28,7 +28,7 @@ private[gmos] trait GmosNorthSequenceState extends SequenceState[NorthDynamic] {
       ),
       dtax    = GmosDtax.Zero,
       roi     = GmosRoi.FullFrame,
-      grating = None,
+      gratingConfig = None,
       filter  = None,
       fpu     = None
     )

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosNorthLongSlit.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosNorthLongSlit.scala
@@ -186,7 +186,7 @@ object GmosNorthLongSlit {
           _  <- NorthDynamic.exposure := exposureTime.value
           _  <- NorthDynamic.filter   := filter.some
           _  <- NorthDynamic.fpu      := none[Either[CustomMask, GmosNorthFpu]]
-          _  <- NorthDynamic.grating  := none[GratingConfig[GmosNorthDisperser]]
+          _  <- NorthDynamic.gratingConfig  := none[GratingConfig[GmosNorthDisperser]]
           _  <- NorthDynamic.xBin     := GmosXBinning.Two
           _  <- NorthDynamic.yBin     := GmosYBinning.Two
           _  <- NorthDynamic.roi      := GmosRoi.Ccd2
@@ -262,7 +262,7 @@ object GmosNorthLongSlit {
           _  <- NorthDynamic.exposure := exposureTime.value
           _  <- NorthDynamic.xBin     := mode.fpu.xbin(sourceProfile, imageQuality, sampling)
           _  <- NorthDynamic.yBin     := GmosYBinning.Two
-          _  <- NorthDynamic.grating  := GratingConfig(mode.disperser, GmosDisperserOrder.One, λ).some
+          _  <- NorthDynamic.gratingConfig  := GratingConfig(mode.disperser, GmosDisperserOrder.One, λ).some
           _  <- NorthDynamic.filter   := mode.filter
           _  <- NorthDynamic.fpu      := mode.fpu.asRight.some
           s0 <- scienceStep(0.arcsec, 0.arcsec)

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosNorthLongSlit.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosNorthLongSlit.scala
@@ -24,7 +24,7 @@ import lucuma.core.optics.syntax.lens._
 import lucuma.core.optics.syntax.optional._
 import lucuma.gen.gmos.longslit.syntax.all._
 import lucuma.itc.client.{ItcClient, ItcResult}
-import lucuma.odb.api.model.GmosModel.{CustomMask, Grating, NorthDynamic, NorthStatic}
+import lucuma.odb.api.model.GmosModel.{CustomMask, GratingConfig, NorthDynamic, NorthStatic}
 import lucuma.odb.api.model.{ObservationModel, ScienceConfigurationModel, Sequence, StepConfig}
 import lucuma.odb.api.repo.OdbRepo
 import spire.std.int._
@@ -186,7 +186,7 @@ object GmosNorthLongSlit {
           _  <- NorthDynamic.exposure := exposureTime.value
           _  <- NorthDynamic.filter   := filter.some
           _  <- NorthDynamic.fpu      := none[Either[CustomMask, GmosNorthFpu]]
-          _  <- NorthDynamic.grating  := none[Grating[GmosNorthDisperser]]
+          _  <- NorthDynamic.grating  := none[GratingConfig[GmosNorthDisperser]]
           _  <- NorthDynamic.xBin     := GmosXBinning.Two
           _  <- NorthDynamic.yBin     := GmosYBinning.Two
           _  <- NorthDynamic.roi      := GmosRoi.Ccd2
@@ -262,7 +262,7 @@ object GmosNorthLongSlit {
           _  <- NorthDynamic.exposure := exposureTime.value
           _  <- NorthDynamic.xBin     := mode.fpu.xbin(sourceProfile, imageQuality, sampling)
           _  <- NorthDynamic.yBin     := GmosYBinning.Two
-          _  <- NorthDynamic.grating  := Grating(mode.disperser, GmosDisperserOrder.One, λ).some
+          _  <- NorthDynamic.grating  := GratingConfig(mode.disperser, GmosDisperserOrder.One, λ).some
           _  <- NorthDynamic.filter   := mode.filter
           _  <- NorthDynamic.fpu      := mode.fpu.asRight.some
           s0 <- scienceStep(0.arcsec, 0.arcsec)

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosNorthLongSlit.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosNorthLongSlit.scala
@@ -183,13 +183,13 @@ object GmosNorthLongSlit {
 
       eval {
         for {
-          _  <- NorthDynamic.exposure := exposureTime.value
-          _  <- NorthDynamic.filter   := filter.some
-          _  <- NorthDynamic.fpu      := none[Either[CustomMask, GmosNorthFpu]]
-          _  <- NorthDynamic.gratingConfig  := none[GratingConfig[GmosNorthDisperser]]
-          _  <- NorthDynamic.xBin     := GmosXBinning.Two
-          _  <- NorthDynamic.yBin     := GmosYBinning.Two
-          _  <- NorthDynamic.roi      := GmosRoi.Ccd2
+          _  <- NorthDynamic.exposure      := exposureTime.value
+          _  <- NorthDynamic.filter        := filter.some
+          _  <- NorthDynamic.fpu           := none[Either[CustomMask, GmosNorthFpu]]
+          _  <- NorthDynamic.gratingConfig := none[GratingConfig[GmosNorthDisperser]]
+          _  <- NorthDynamic.xBin          := GmosXBinning.Two
+          _  <- NorthDynamic.yBin          := GmosYBinning.Two
+          _  <- NorthDynamic.roi           := GmosRoi.Ccd2
           s0 <- scienceStep(0.arcsec, 0.arcsec)
 
           _  <- NorthDynamic.exposure := 20.seconds
@@ -259,12 +259,12 @@ object GmosNorthLongSlit {
 
       eval {
         for {
-          _  <- NorthDynamic.exposure := exposureTime.value
-          _  <- NorthDynamic.xBin     := mode.fpu.xbin(sourceProfile, imageQuality, sampling)
-          _  <- NorthDynamic.yBin     := GmosYBinning.Two
-          _  <- NorthDynamic.gratingConfig  := GratingConfig(mode.disperser, GmosDisperserOrder.One, λ).some
-          _  <- NorthDynamic.filter   := mode.filter
-          _  <- NorthDynamic.fpu      := mode.fpu.asRight.some
+          _  <- NorthDynamic.exposure      := exposureTime.value
+          _  <- NorthDynamic.xBin          := mode.fpu.xbin(sourceProfile, imageQuality, sampling)
+          _  <- NorthDynamic.yBin          := GmosYBinning.Two
+          _  <- NorthDynamic.gratingConfig := GratingConfig(mode.disperser, GmosDisperserOrder.One, λ).some
+          _  <- NorthDynamic.filter        := mode.filter
+          _  <- NorthDynamic.fpu           := mode.fpu.asRight.some
           s0 <- scienceStep(0.arcsec, 0.arcsec)
           f0 <- flatStep
 

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosNorthLongSlit.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosNorthLongSlit.scala
@@ -262,13 +262,13 @@ object GmosNorthLongSlit {
           _  <- NorthDynamic.exposure      := exposureTime.value
           _  <- NorthDynamic.xBin          := mode.fpu.xbin(sourceProfile, imageQuality, sampling)
           _  <- NorthDynamic.yBin          := GmosYBinning.Two
-          _  <- NorthDynamic.gratingConfig := GratingConfig(mode.disperser, GmosDisperserOrder.One, λ).some
+          _  <- NorthDynamic.gratingConfig := GratingConfig(mode.grating, GmosDisperserOrder.One, λ).some
           _  <- NorthDynamic.filter        := mode.filter
           _  <- NorthDynamic.fpu           := mode.fpu.asRight.some
           s0 <- scienceStep(0.arcsec, 0.arcsec)
           f0 <- flatStep
 
-          _  <- NorthDynamic.wavelength := sum(λ, mode.disperser.Δλ)
+          _  <- NorthDynamic.wavelength := sum(λ, mode.grating.Δλ)
           s1 <- scienceStep(0.arcsec, 15.arcsec)
           f1 <- flatStep
         } yield ScienceSteps(s0, f0, s1, f1)

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/syntax/GmosNorthDisperserOps.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/syntax/GmosNorthDisperserOps.scala
@@ -15,9 +15,9 @@ final class GmosNorthDisperserOps(val self: GmosNorthDisperser) {
 
 }
 
-trait ToGmosNorthDisperserOps {
-  implicit def toGmosNorthDisperserOps(disperser: GmosNorthDisperser): GmosNorthDisperserOps =
-    new GmosNorthDisperserOps(disperser)
+trait ToGmosNorthGratingOps {
+  implicit def toGmosNorthGratingOps(grating: GmosNorthDisperser): GmosNorthDisperserOps =
+    new GmosNorthDisperserOps(grating)
 }
 
-object gmosNorthDisperser extends ToGmosNorthDisperserOps
+object gmosNorthGrating extends ToGmosNorthGratingOps

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/syntax/GmosSouthGratingOps.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/syntax/GmosSouthGratingOps.scala
@@ -8,16 +8,16 @@ import eu.timepit.refined.types.all.PosInt
 import lucuma.core.`enum`.GmosSouthDisperser
 import lucuma.core.math.units.Nanometer
 
-final class GmosSouthDisperserOps(val self: GmosSouthDisperser) {
+final class GmosSouthGratingOps(val self: GmosSouthDisperser) {
 
   val Δλ: Quantity[PosInt, Nanometer] =
     GmosSouthLongslitMath.Δλ(self.dispersion)
 
 }
 
-trait ToGmosSouthDisperserOps {
-  implicit def toGmosSouthDisperserOps(disperser: GmosSouthDisperser): GmosSouthDisperserOps =
-    new GmosSouthDisperserOps(disperser)
+trait ToGmosSouthGratingOps {
+  implicit def toGmosSouthGratingOps(grating: GmosSouthDisperser): GmosSouthGratingOps =
+    new GmosSouthGratingOps(grating)
 }
 
-object gmosSouthDisperser extends ToGmosSouthDisperserOps
+object gmosSouthGrating extends ToGmosSouthGratingOps

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/syntax/package.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/syntax/package.scala
@@ -5,10 +5,10 @@ package lucuma.gen.gmos.longslit
 
 package object syntax {
 
-  object all extends ToGmosNorthDisperserOps
+  object all extends ToGmosNorthGratingOps
                 with ToGmosNorthFilterCompanionOps
                 with ToGmosNorthFpuOps
-                with ToGmosSouthDisperserOps
+                with ToGmosSouthGratingOps
                 with ToGmosSouthFilterCompanionOps
                 with ToGmosSouthFpuOps
 

--- a/modules/core/src/main/scala/lucuma/itc/client/ItcSpectroscopyInput.scala
+++ b/modules/core/src/main/scala/lucuma/itc/client/ItcSpectroscopyInput.scala
@@ -215,22 +215,22 @@ object ItcSpectroscopyInput {
       )
 
   implicit val EncoderScienceConfigurationModel: Encoder[ScienceConfigurationModel] = {
-    case ScienceConfigurationModel.Modes.GmosNorthLongSlit(filter, disperser, fpu, _) =>
+    case ScienceConfigurationModel.Modes.GmosNorthLongSlit(filter, grating, fpu, _) =>
       Json.obj(
         "gmosN" ->
           Json.fromFields(
             List(
-              "disperser"  -> screaming(disperser),
+              "disperser"  -> screaming(grating),
               "fpu"        -> screaming(fpu)
             ) ++ filter.map(screaming(_)).tupleLeft("filter").toList
           )
       )
-    case ScienceConfigurationModel.Modes.GmosSouthLongSlit(filter, disperser, fpu, _) =>
+    case ScienceConfigurationModel.Modes.GmosSouthLongSlit(filter, grating, fpu, _) =>
       Json.obj(
         "gmosS" ->
           Json.fromFields(
             List(
-              "disperser"  -> screaming(disperser),
+              "disperser"  -> screaming(grating),
               "fpu"        -> screaming(fpu)
             ) ++ filter.map(screaming(_)).tupleLeft("filter").toList
           )

--- a/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
@@ -408,57 +408,57 @@ object GmosModel {
   }
 
 
-  final case class Grating[D](
-    disperser:  D,
+  final case class GratingConfig[D](
+    grating:    D,
     order:      GmosDisperserOrder,
     wavelength: Wavelength
   )
 
-  object Grating extends GratingOptics {
+  object GratingConfig extends GratingConfigOptics {
 
-    implicit def EqGmosGrating[D: Eq]: Eq[Grating[D]] =
+    implicit def EqGmosGrating[D: Eq]: Eq[GratingConfig[D]] =
       Eq.by { a => (
-        a.disperser,
+        a.grating,
         a.order,
         a.wavelength
       )}
 
   }
 
-  sealed trait GratingOptics { self: Grating.type =>
+  sealed trait GratingConfigOptics { self: GratingConfig.type =>
 
-    def disperser[D]: Lens[Grating[D], D] =
-      Focus[Grating[D]](_.disperser)
+    def disperser[D]: Lens[GratingConfig[D], D] =
+      Focus[GratingConfig[D]](_.grating)
 
-    def order[D]: Lens[Grating[D], GmosDisperserOrder] =
-      Focus[Grating[D]](_.order)
+    def order[D]: Lens[GratingConfig[D], GmosDisperserOrder] =
+      Focus[GratingConfig[D]](_.order)
 
-    def wavelength[D]: Lens[Grating[D], Wavelength] =
-      Focus[Grating[D]](_.wavelength)
+    def wavelength[D]: Lens[GratingConfig[D], Wavelength] =
+      Focus[GratingConfig[D]](_.wavelength)
 
   }
 
-  final case class CreateGrating[D](
-    disperser:  D,
+  final case class CreateGratingConfig[D](
+    grating:    D,
     order:      GmosDisperserOrder,
     wavelength: WavelengthModel.Input
   ) {
 
-    val create: ValidatedInput[Grating[D]] =
-      wavelength.toWavelength("wavelength").map(Grating(disperser, order, _))
+    val create: ValidatedInput[GratingConfig[D]] =
+      wavelength.toWavelength("wavelength").map(GratingConfig(grating, order, _))
 
   }
 
-  object CreateGrating {
-    def wavelength[D]: Lens[CreateGrating[D], WavelengthModel.Input] =
-      GenLens[CreateGrating[D]](_.wavelength)
+  object CreateGratingConfig {
+    def wavelength[D]: Lens[CreateGratingConfig[D], WavelengthModel.Input] =
+      GenLens[CreateGratingConfig[D]](_.wavelength)
 
-    implicit def DecoderCreateGrating[D: Decoder]: Decoder[CreateGrating[D]] =
-      deriveDecoder[CreateGrating[D]]
+    implicit def DecoderCreateGrating[D: Decoder]: Decoder[CreateGratingConfig[D]] =
+      deriveDecoder[CreateGratingConfig[D]]
 
-    implicit def EqCreateGrating[D: Eq]: Eq[CreateGrating[D]] =
+    implicit def EqCreateGratingConfig[D: Eq]: Eq[CreateGratingConfig[D]] =
       Eq.by { a => (
-        a.disperser,
+        a.grating,
         a.order,
         a.wavelength
       )}
@@ -470,7 +470,7 @@ object GmosModel {
     def readout:  CcdReadout
     def dtax:     GmosDtax
     def roi:      GmosRoi
-    def grating:  Option[Grating[D]]
+    def grating:  Option[GratingConfig[D]]
     def filter:   Option[L]
     def fpu:      Option[Either[CustomMask, U]]
   }
@@ -480,7 +480,7 @@ object GmosModel {
     readout:  CcdReadout,
     dtax:     GmosDtax,
     roi:      GmosRoi,
-    grating:  Option[Grating[GmosNorthDisperser]],
+    grating:  Option[GratingConfig[GmosNorthDisperser]],
     filter:   Option[GmosNorthFilter],
     fpu:      Option[Either[CustomMask, GmosNorthFpu]]
   ) extends Dynamic[GmosNorthDisperser, GmosNorthFilter, GmosNorthFpu]
@@ -520,14 +520,14 @@ object GmosModel {
     val roi: Lens[NorthDynamic, GmosRoi] =
       Focus[NorthDynamic](_.roi)
 
-    val grating: Lens[NorthDynamic, Option[Grating[GmosNorthDisperser]]] =
+    val grating: Lens[NorthDynamic, Option[GratingConfig[GmosNorthDisperser]]] =
       Focus[NorthDynamic](_.grating)
 
     val wavelength: Optional[NorthDynamic, Wavelength] =
       Optional[NorthDynamic, Wavelength](
         _.grating.map(_.wavelength)
       )(
-        λ => grating.modify(_.map(Grating.wavelength.replace(λ)))
+        λ => grating.modify(_.map(GratingConfig.wavelength.replace(λ)))
       )
 
     val filter: Lens[NorthDynamic, Option[GmosNorthFilter]] =
@@ -543,7 +543,7 @@ object GmosModel {
     readout:  CcdReadout,
     dtax:     GmosDtax,
     roi:      GmosRoi,
-    grating:  Option[Grating[GmosSouthDisperser]],
+    grating:  Option[GratingConfig[GmosSouthDisperser]],
     filter:   Option[GmosSouthFilter],
     fpu:      Option[Either[CustomMask, GmosSouthFpu]]
   ) extends Dynamic[GmosSouthDisperser, GmosSouthFilter, GmosSouthFpu]
@@ -577,7 +577,7 @@ object GmosModel {
     val roi: Lens[SouthDynamic, GmosRoi] =
       Focus[SouthDynamic](_.roi)
 
-    val grating: Lens[SouthDynamic, Option[Grating[GmosSouthDisperser]]] =
+    val grating: Lens[SouthDynamic, Option[GratingConfig[GmosSouthDisperser]]] =
       Focus[SouthDynamic](_.grating)
 
     val filter: Lens[SouthDynamic, Option[GmosSouthFilter]] =
@@ -594,7 +594,7 @@ object GmosModel {
     def readout:  CreateCcdReadout
     def dtax:     GmosDtax
     def roi:      GmosRoi
-    def grating:  Option[CreateGrating[D]]
+    def grating:  Option[CreateGratingConfig[D]]
     def filter:   Option[L]
     def fpu:      Option[CreateFpu[U]]
 
@@ -605,7 +605,7 @@ object GmosModel {
     readout:  CreateCcdReadout                          = CreateCcdReadout(),
     dtax:     GmosDtax                                  = GmosDtax.Zero,
     roi:      GmosRoi                                   = GmosRoi.FullFrame,
-    grating:  Option[CreateGrating[GmosNorthDisperser]] = None,
+    grating:  Option[CreateGratingConfig[GmosNorthDisperser]] = None,
     filter:   Option[GmosNorthFilter]                   = None,
     fpu:      Option[CreateFpu[GmosNorthFpu]]           = None
   ) extends CreateDynamic[GmosNorthDisperser, GmosNorthFilter, GmosNorthFpu] {
@@ -649,7 +649,7 @@ object GmosModel {
     readout:  CreateCcdReadout                          = CreateCcdReadout(),
     dtax:     GmosDtax                                  = GmosDtax.Zero,
     roi:      GmosRoi                                   = GmosRoi.FullFrame,
-    grating:  Option[CreateGrating[GmosSouthDisperser]] = None,
+    grating:  Option[CreateGratingConfig[GmosSouthDisperser]] = None,
     filter:   Option[GmosSouthFilter]                   = None,
     fpu:      Option[CreateFpu[GmosSouthFpu]]           = None
   ) extends CreateDynamic[GmosSouthDisperser, GmosSouthFilter, GmosSouthFpu] {
@@ -674,7 +674,7 @@ object GmosModel {
     val roi: Lens[CreateSouthDynamic, GmosRoi] =
       GenLens[CreateSouthDynamic](_.roi)
 
-    val grating: Lens[CreateSouthDynamic, Option[CreateGrating[GmosSouthDisperser]]] =
+    val grating: Lens[CreateSouthDynamic, Option[CreateGratingConfig[GmosSouthDisperser]]] =
       GenLens[CreateSouthDynamic](_.grating)
 
     val filter: Lens[CreateSouthDynamic, Option[GmosSouthFilter]] =
@@ -702,11 +702,11 @@ object GmosModel {
 
     object instrument {
 
-      val grating: Optional[CreateSouthDynamic, CreateGrating[GmosSouthDisperser]] =
+      val grating: Optional[CreateSouthDynamic, CreateGratingConfig[GmosSouthDisperser]] =
         CreateSouthDynamic.grating.some
 
       val wavelength: Optional[CreateSouthDynamic, WavelengthModel.Input] =
-        grating.andThen(CreateGrating.wavelength[GmosSouthDisperser])
+        grating.andThen(CreateGratingConfig.wavelength[GmosSouthDisperser])
 
     }
 
@@ -723,11 +723,11 @@ object GmosModel {
       val q: Optional[StepConfig.CreateStepConfig[CreateSouthDynamic], OffsetModel.ComponentInput] =
         StepConfig.CreateStepConfig.q[CreateSouthDynamic]
 
-      val grating: Optional[StepConfig.CreateStepConfig[CreateSouthDynamic], CreateGrating[GmosSouthDisperser]] =
+      val grating: Optional[StepConfig.CreateStepConfig[CreateSouthDynamic], CreateGratingConfig[GmosSouthDisperser]] =
         instrumentConfig.andThen(instrument.grating)
 
       val wavelength: Optional[StepConfig.CreateStepConfig[CreateSouthDynamic], WavelengthModel.Input] =
-        grating.andThen(CreateGrating.wavelength[GmosSouthDisperser])
+        grating.andThen(CreateGratingConfig.wavelength[GmosSouthDisperser])
 
     }
   }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
@@ -427,7 +427,7 @@ object GmosModel {
 
   sealed trait GratingConfigOptics { self: GratingConfig.type =>
 
-    def disperser[D]: Lens[GratingConfig[D], D] =
+    def grating[D]: Lens[GratingConfig[D], D] =
       Focus[GratingConfig[D]](_.grating)
 
     def order[D]: Lens[GratingConfig[D], GmosDisperserOrder] =

--- a/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
@@ -466,23 +466,23 @@ object GmosModel {
   }
 
   sealed trait Dynamic[D, L, U] {
-    def exposure: FiniteDuration
-    def readout:  CcdReadout
-    def dtax:     GmosDtax
-    def roi:      GmosRoi
-    def grating:  Option[GratingConfig[D]]
-    def filter:   Option[L]
-    def fpu:      Option[Either[CustomMask, U]]
+    def exposure:      FiniteDuration
+    def readout:       CcdReadout
+    def dtax:          GmosDtax
+    def roi:           GmosRoi
+    def gratingConfig: Option[GratingConfig[D]]
+    def filter:        Option[L]
+    def fpu:           Option[Either[CustomMask, U]]
   }
 
   final case class NorthDynamic (
-    exposure: FiniteDuration,
-    readout:  CcdReadout,
-    dtax:     GmosDtax,
-    roi:      GmosRoi,
-    grating:  Option[GratingConfig[GmosNorthDisperser]],
-    filter:   Option[GmosNorthFilter],
-    fpu:      Option[Either[CustomMask, GmosNorthFpu]]
+    exposure:      FiniteDuration,
+    readout:       CcdReadout,
+    dtax:          GmosDtax,
+    roi:           GmosRoi,
+    gratingConfig: Option[GratingConfig[GmosNorthDisperser]],
+    filter:        Option[GmosNorthFilter],
+    fpu:           Option[Either[CustomMask, GmosNorthFpu]]
   ) extends Dynamic[GmosNorthDisperser, GmosNorthFilter, GmosNorthFpu]
 
   object NorthDynamic extends NorthDynamicOptics {
@@ -493,7 +493,7 @@ object GmosModel {
         a.readout,
         a.dtax,
         a.roi,
-        a.grating,
+        a.gratingConfig,
         a.filter,
         a.fpu
       )}
@@ -520,14 +520,14 @@ object GmosModel {
     val roi: Lens[NorthDynamic, GmosRoi] =
       Focus[NorthDynamic](_.roi)
 
-    val grating: Lens[NorthDynamic, Option[GratingConfig[GmosNorthDisperser]]] =
-      Focus[NorthDynamic](_.grating)
+    val gratingConfig: Lens[NorthDynamic, Option[GratingConfig[GmosNorthDisperser]]] =
+      Focus[NorthDynamic](_.gratingConfig)
 
     val wavelength: Optional[NorthDynamic, Wavelength] =
       Optional[NorthDynamic, Wavelength](
-        _.grating.map(_.wavelength)
+        _.gratingConfig.map(_.wavelength)
       )(
-        λ => grating.modify(_.map(GratingConfig.wavelength.replace(λ)))
+        λ => gratingConfig.modify(_.map(GratingConfig.wavelength.replace(λ)))
       )
 
     val filter: Lens[NorthDynamic, Option[GmosNorthFilter]] =
@@ -539,13 +539,13 @@ object GmosModel {
   }
 
   final case class SouthDynamic (
-    exposure: FiniteDuration,
-    readout:  CcdReadout,
-    dtax:     GmosDtax,
-    roi:      GmosRoi,
-    grating:  Option[GratingConfig[GmosSouthDisperser]],
-    filter:   Option[GmosSouthFilter],
-    fpu:      Option[Either[CustomMask, GmosSouthFpu]]
+    exposure:      FiniteDuration,
+    readout:       CcdReadout,
+    dtax:          GmosDtax,
+    roi:           GmosRoi,
+    gratingConfig: Option[GratingConfig[GmosSouthDisperser]],
+    filter:        Option[GmosSouthFilter],
+    fpu:           Option[Either[CustomMask, GmosSouthFpu]]
   ) extends Dynamic[GmosSouthDisperser, GmosSouthFilter, GmosSouthFpu]
 
   object SouthDynamic extends SouthDynamicOptics {
@@ -556,7 +556,7 @@ object GmosModel {
         a.readout,
         a.dtax,
         a.roi,
-        a.grating,
+        a.gratingConfig,
         a.filter,
         a.fpu
       )}
@@ -577,8 +577,8 @@ object GmosModel {
     val roi: Lens[SouthDynamic, GmosRoi] =
       Focus[SouthDynamic](_.roi)
 
-    val grating: Lens[SouthDynamic, Option[GratingConfig[GmosSouthDisperser]]] =
-      Focus[SouthDynamic](_.grating)
+    val gratingConfig: Lens[SouthDynamic, Option[GratingConfig[GmosSouthDisperser]]] =
+      Focus[SouthDynamic](_.gratingConfig)
 
     val filter: Lens[SouthDynamic, Option[GmosSouthFilter]] =
       Focus[SouthDynamic](_.filter)
@@ -590,31 +590,31 @@ object GmosModel {
 
   sealed trait CreateDynamic[D, L, U] {
 
-    def exposure: FiniteDurationModel.Input
-    def readout:  CreateCcdReadout
-    def dtax:     GmosDtax
-    def roi:      GmosRoi
-    def grating:  Option[CreateGratingConfig[D]]
-    def filter:   Option[L]
-    def fpu:      Option[CreateFpu[U]]
+    def exposure:      FiniteDurationModel.Input
+    def readout:       CreateCcdReadout
+    def dtax:          GmosDtax
+    def roi:           GmosRoi
+    def gratingConfig: Option[CreateGratingConfig[D]]
+    def filter:        Option[L]
+    def fpu:           Option[CreateFpu[U]]
 
   }
 
   final case class CreateNorthDynamic(
-    exposure: FiniteDurationModel.Input,
-    readout:  CreateCcdReadout                          = CreateCcdReadout(),
-    dtax:     GmosDtax                                  = GmosDtax.Zero,
-    roi:      GmosRoi                                   = GmosRoi.FullFrame,
-    grating:  Option[CreateGratingConfig[GmosNorthDisperser]] = None,
-    filter:   Option[GmosNorthFilter]                   = None,
-    fpu:      Option[CreateFpu[GmosNorthFpu]]           = None
+    exposure:      FiniteDurationModel.Input,
+    readout:       CreateCcdReadout                                = CreateCcdReadout(),
+    dtax:          GmosDtax                                        = GmosDtax.Zero,
+    roi:           GmosRoi                                         = GmosRoi.FullFrame,
+    gratingConfig: Option[CreateGratingConfig[GmosNorthDisperser]] = None,
+    filter:        Option[GmosNorthFilter]                         = None,
+    fpu:           Option[CreateFpu[GmosNorthFpu]]                 = None
   ) extends CreateDynamic[GmosNorthDisperser, GmosNorthFilter, GmosNorthFpu] {
 
     val create: ValidatedInput[NorthDynamic] =
       (
         exposure.toFiniteDuration("exposure"),
         readout.create,
-        grating.traverse(_.create),
+        gratingConfig.traverse(_.create),
         fpu.traverse(_.create)
       ).mapN { (e, r, g, u) => NorthDynamic(e, r, dtax, roi, g, filter, u) }
 
@@ -631,7 +631,7 @@ object GmosModel {
         a.readout,
         a.dtax,
         a.roi,
-        a.grating,
+        a.gratingConfig,
         a.filter,
         a.fpu
       )}
@@ -645,20 +645,20 @@ object GmosModel {
     Decoder[CreateCustomMask].either(Decoder[GmosSouthFpu])
 
   final case class CreateSouthDynamic(
-    exposure: FiniteDurationModel.Input,
-    readout:  CreateCcdReadout                          = CreateCcdReadout(),
-    dtax:     GmosDtax                                  = GmosDtax.Zero,
-    roi:      GmosRoi                                   = GmosRoi.FullFrame,
-    grating:  Option[CreateGratingConfig[GmosSouthDisperser]] = None,
-    filter:   Option[GmosSouthFilter]                   = None,
-    fpu:      Option[CreateFpu[GmosSouthFpu]]           = None
+    exposure:      FiniteDurationModel.Input,
+    readout:       CreateCcdReadout                                = CreateCcdReadout(),
+    dtax:          GmosDtax                                        = GmosDtax.Zero,
+    roi:           GmosRoi                                         = GmosRoi.FullFrame,
+    gratingConfig: Option[CreateGratingConfig[GmosSouthDisperser]] = None,
+    filter:        Option[GmosSouthFilter]                         = None,
+    fpu:           Option[CreateFpu[GmosSouthFpu]]                 = None
   ) extends CreateDynamic[GmosSouthDisperser, GmosSouthFilter, GmosSouthFpu] {
 
     val create: ValidatedInput[SouthDynamic] =
       (
         exposure.toFiniteDuration("exposure"),
         readout.create,
-        grating.traverse(_.create),
+        gratingConfig.traverse(_.create),
         fpu.traverse(_.create)
       ).mapN { (e, r, g, u) => SouthDynamic(e, r, dtax, roi, g, filter, u) }
 
@@ -674,8 +674,8 @@ object GmosModel {
     val roi: Lens[CreateSouthDynamic, GmosRoi] =
       GenLens[CreateSouthDynamic](_.roi)
 
-    val grating: Lens[CreateSouthDynamic, Option[CreateGratingConfig[GmosSouthDisperser]]] =
-      GenLens[CreateSouthDynamic](_.grating)
+    val gratingConfig: Lens[CreateSouthDynamic, Option[CreateGratingConfig[GmosSouthDisperser]]] =
+      GenLens[CreateSouthDynamic](_.gratingConfig)
 
     val filter: Lens[CreateSouthDynamic, Option[GmosSouthFilter]] =
       GenLens[CreateSouthDynamic](_.filter)
@@ -689,7 +689,7 @@ object GmosModel {
         a.readout,
         a.dtax,
         a.roi,
-        a.grating,
+        a.gratingConfig,
         a.filter,
         a.fpu
       )}
@@ -702,11 +702,11 @@ object GmosModel {
 
     object instrument {
 
-      val grating: Optional[CreateSouthDynamic, CreateGratingConfig[GmosSouthDisperser]] =
-        CreateSouthDynamic.grating.some
+      val gratingConfig: Optional[CreateSouthDynamic, CreateGratingConfig[GmosSouthDisperser]] =
+        CreateSouthDynamic.gratingConfig.some
 
       val wavelength: Optional[CreateSouthDynamic, WavelengthModel.Input] =
-        grating.andThen(CreateGratingConfig.wavelength[GmosSouthDisperser])
+        gratingConfig.andThen(CreateGratingConfig.wavelength[GmosSouthDisperser])
 
     }
 
@@ -723,11 +723,11 @@ object GmosModel {
       val q: Optional[StepConfig.CreateStepConfig[CreateSouthDynamic], OffsetModel.ComponentInput] =
         StepConfig.CreateStepConfig.q[CreateSouthDynamic]
 
-      val grating: Optional[StepConfig.CreateStepConfig[CreateSouthDynamic], CreateGratingConfig[GmosSouthDisperser]] =
-        instrumentConfig.andThen(instrument.grating)
+      val gratingConfig: Optional[StepConfig.CreateStepConfig[CreateSouthDynamic], CreateGratingConfig[GmosSouthDisperser]] =
+        instrumentConfig.andThen(instrument.gratingConfig)
 
       val wavelength: Optional[StepConfig.CreateStepConfig[CreateSouthDynamic], WavelengthModel.Input] =
-        grating.andThen(CreateGratingConfig.wavelength[GmosSouthDisperser])
+        gratingConfig.andThen(CreateGratingConfig.wavelength[GmosSouthDisperser])
 
     }
   }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ScienceConfigurationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ScienceConfigurationModel.scala
@@ -47,7 +47,7 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
 
     final case class GmosNorthLongSlit(
       filter:    Option[GmosNorthFilter],
-      disperser: GmosNorthDisperser,
+      grating:   GmosNorthDisperser,
       fpu:       GmosNorthFpu,
       slitWidth: Angle
     ) extends ScienceConfigurationModel {
@@ -62,8 +62,8 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
       val filter: Lens[GmosNorthLongSlit, Option[GmosNorthFilter]] =
         Focus[GmosNorthLongSlit](_.filter)
 
-      val disperser: Lens[GmosNorthLongSlit, GmosNorthDisperser] =
-        Focus[GmosNorthLongSlit](_.disperser)
+      val grating: Lens[GmosNorthLongSlit, GmosNorthDisperser] =
+        Focus[GmosNorthLongSlit](_.grating)
 
       val fpu: Lens[GmosNorthLongSlit, GmosNorthFpu] =
         Focus[GmosNorthLongSlit](_.fpu)
@@ -72,18 +72,18 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
         Focus[GmosNorthLongSlit](_.slitWidth)
 
       implicit val EqGmosNorth: Eq[GmosNorthLongSlit] =
-        Eq.by(a => (a.filter, a.disperser, a.slitWidth))
+        Eq.by(a => (a.filter, a.grating, a.slitWidth))
     }
 
     final case class GmosNorthLongSlitInput(
       filter:    Input[GmosNorthFilter]    = Input.ignore,
-      disperser: Input[GmosNorthDisperser] = Input.ignore,
+      grating:   Input[GmosNorthDisperser] = Input.ignore,
       fpu:       Input[GmosNorthFpu]       = Input.ignore,
       slitWidth: Input[SlitWidthInput]     = Input.ignore
     ) extends EditorInput[GmosNorthLongSlit] {
 
       override val create: ValidatedInput[GmosNorthLongSlit] =
-        (disperser.notMissing("disperser"),
+        (grating.notMissing("grating"),
          fpu.notMissing("fpu"),
          slitWidth.notMissingAndThen("slitWidth")(_.toAngle)
         ).mapN { case (d, u, s) =>
@@ -92,16 +92,16 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
 
       override val edit: StateT[EitherInput, GmosNorthLongSlit, Unit] = {
         val validArgs =
-          (disperser.validateIsNotNull("disperser"),
+          (grating.validateIsNotNull("grating"),
            fpu.validateIsNotNull("fpu"),
            slitWidth.validateNotNullable("slitWidth")(_.toAngle)
           ).tupled
 
         for {
           args <- validArgs.liftState
-          (disperser, fpu, slitWidth) = args
+          (grating, fpu, slitWidth) = args
           _ <- GmosNorthLongSlit.filter    := filter.toOptionOption
-          _ <- GmosNorthLongSlit.disperser := disperser
+          _ <- GmosNorthLongSlit.grating   := grating
           _ <- GmosNorthLongSlit.fpu       := fpu
           _ <- GmosNorthLongSlit.slitWidth := slitWidth
         } yield ()
@@ -120,7 +120,7 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
       implicit val EqEditGmosNorthLongSlit: Eq[GmosNorthLongSlitInput] =
         Eq.by { a => (
           a.filter,
-          a.disperser,
+          a.grating,
           a.fpu,
           a.slitWidth
         )}
@@ -129,7 +129,7 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
 
     final case class GmosSouthLongSlit(
       filter:    Option[GmosSouthFilter],
-      disperser: GmosSouthDisperser,
+      grating:   GmosSouthDisperser,
       fpu:       GmosSouthFpu,
       slitWidth: Angle
     ) extends ScienceConfigurationModel {
@@ -144,8 +144,8 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
       val filter: Lens[GmosSouthLongSlit, Option[GmosSouthFilter]] =
         Focus[GmosSouthLongSlit](_.filter)
 
-      val disperser: Lens[GmosSouthLongSlit, GmosSouthDisperser] =
-        Focus[GmosSouthLongSlit](_.disperser)
+      val grating: Lens[GmosSouthLongSlit, GmosSouthDisperser] =
+        Focus[GmosSouthLongSlit](_.grating)
 
       val fpu: Lens[GmosSouthLongSlit, GmosSouthFpu] =
         Focus[GmosSouthLongSlit](_.fpu)
@@ -154,19 +154,19 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
         Focus[GmosSouthLongSlit](_.slitWidth)
 
       implicit val EqGmosSouth: Eq[GmosSouthLongSlit] =
-        Eq.by(a => (a.filter, a.disperser, a.slitWidth))
+        Eq.by(a => (a.filter, a.grating, a.slitWidth))
 
     }
 
     final case class GmosSouthLongSlitInput(
       filter:    Input[GmosSouthFilter]    = Input.ignore,
-      disperser: Input[GmosSouthDisperser] = Input.ignore,
+      grating:   Input[GmosSouthDisperser] = Input.ignore,
       fpu:       Input[GmosSouthFpu]       = Input.ignore,
       slitWidth: Input[SlitWidthInput]     = Input.ignore
     ) extends EditorInput[GmosSouthLongSlit] {
 
       override val create: ValidatedInput[GmosSouthLongSlit] =
-        (disperser.notMissing("disperser"),
+        (grating.notMissing("grating"),
          fpu.notMissing("fpu"),
          slitWidth.notMissingAndThen("slitWidth")(_.toAngle)
         ).mapN { case (d, u, s) =>
@@ -175,16 +175,16 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
 
       def edit: StateT[EitherInput, GmosSouthLongSlit, Unit] = {
         val validArgs =
-          (disperser.validateIsNotNull("disperser"),
+          (grating.validateIsNotNull("grating"),
            fpu.validateIsNotNull("fpu"),
            slitWidth.validateNotNullable("slitWidth")(_.toAngle)
           ).tupled
 
         for {
           args <- validArgs.liftState
-          (disperser, fpu, slitWidth) = args
+          (grating, fpu, slitWidth) = args
           _ <- GmosSouthLongSlit.filter    := filter.toOptionOption
-          _ <- GmosSouthLongSlit.disperser := disperser
+          _ <- GmosSouthLongSlit.grating   := grating
           _ <- GmosSouthLongSlit.fpu       := fpu
           _ <- GmosSouthLongSlit.slitWidth := slitWidth
         } yield ()
@@ -203,7 +203,7 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
       implicit val EqEditGmosSouthLongSlit: Eq[GmosSouthLongSlitInput] =
         Eq.by { a => (
           a.filter,
-          a.disperser,
+          a.grating,
           a.fpu,
           a.slitWidth
         )}

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/GmosSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/GmosSchema.scala
@@ -495,10 +495,10 @@ object GmosSchema {
         ),
 
         Field(
-          name        = "grating",
+          name        = "gratingConfig",
           fieldType   = OptionType(GmosGratingConfigType[D](site)),
           description = Some(s"${gmos(site).longName} grating"),
-          resolve     = _.value.grating
+          resolve     = _.value.gratingConfig
         ),
 
         Field(
@@ -531,13 +531,13 @@ object GmosSchema {
       s"${gmos(site).tag.capitalize}DynamicInput",
       s"${gmos(site).longName} instrument configuration input",
       List(
-        InputField("exposure", InputObjectTypeDuration,            "Exposure time"),
-        InputField("readout",  InputObjectTypeGmosCcdReadoutInput, "GMOS CCD readout"),
-        InputField("dtax",     EnumTypeGmosDtax,                   "GMOS detector x offset"),
-        InputField("roi",      EnumTypeGmosRoi,                    "GMOS region of interest"),
-        InputField("grating",  OptionInputType(InputObjectTypeGratingConfigInput[D](site)), s"${gmos(site).longName} grating"),
-        InputField("filter",   OptionInputType(implicitly[EnumType[L]]),              s"${gmos(site).longName} filter"),
-        InputField("fpu",      OptionInputType(InputObjectFpuInput[U](site)),         s"${gmos(site).longName} FPU")
+        InputField("exposure",      InputObjectTypeDuration,            "Exposure time"),
+        InputField("readout",       InputObjectTypeGmosCcdReadoutInput, "GMOS CCD readout"),
+        InputField("dtax",          EnumTypeGmosDtax,                   "GMOS detector x offset"),
+        InputField("roi",           EnumTypeGmosRoi,                    "GMOS region of interest"),
+        InputField("gratingConfig", OptionInputType(InputObjectTypeGratingConfigInput[D](site)), s"${gmos(site).longName} grating"),
+        InputField("filter",        OptionInputType(implicitly[EnumType[L]]),              s"${gmos(site).longName} filter"),
+        InputField("fpu",           OptionInputType(InputObjectFpuInput[U](site)),         s"${gmos(site).longName} FPU")
       )
     )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/GmosSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/GmosSchema.scala
@@ -56,10 +56,10 @@ object GmosSchema {
       "GmosSouth Detector type"
     )
 
-  implicit val EnumTypeGmosDisperserOrder: EnumType[GmosDisperserOrder] =
+  implicit val EnumTypeGmosGratingOrder: EnumType[GmosDisperserOrder] =
     EnumType.fromEnumerated(
-      "GmosDisperserOrder",
-      "GMOS disperser order"
+      "GmosGratingOrder",
+      "GMOS grating order"
     )
 
   implicit val EnumTypeGmosDtax: EnumType[GmosDtax] =
@@ -74,10 +74,10 @@ object GmosSchema {
       "Electronic offsetting"
     )
 
-  implicit val EnumTypeGmosNorthDisperser: EnumType[GmosNorthDisperser] =
+  implicit val EnumTypeGmosNorthGrating: EnumType[GmosNorthDisperser] =
     EnumType.fromEnumerated(
-      "GmosNorthDisperser",
-      "GMOS North Disperser"
+      "GmosNorthGrating",
+      "GMOS North Grating"
     )
 
   implicit val EnumTypeGmosNorthFilter: EnumType[GmosNorthFilter] =
@@ -104,12 +104,12 @@ object GmosSchema {
       "GMOS Region Of Interest"
     )
 
-  implicit val EnumTypeGmosSouthDisperser: EnumType[GmosSouthDisperser] =
+  implicit val EnumTypeGmosSouthGrating: EnumType[GmosSouthDisperser] =
     // GmosSouthDisperser.all is haunted.  B600_G5323 is inexplicably null in the list.
     // Fixed with marking it `lazy` in core but for now ....
     EnumType.fromEnumerated[GmosSouthDisperser](
-      "GmosSouthDisperser",
-      "GMOS South Disperser"
+      "GmosSouthGrating",
+      "GMOS South Grating"
     )(Enumerated.of(
       GmosSouthDisperser.B1200_G5321,
       GmosSouthDisperser.R831_G5322,
@@ -339,25 +339,25 @@ object GmosSchema {
       )
     )
 
-  def GmosGratingType[D: EnumType](
+  def GmosGratingConfigType[D: EnumType](
     site: Site
-  ): ObjectType[Any, GmosModel.Grating[D]] =
+  ): ObjectType[Any, GmosModel.GratingConfig[D]] =
     ObjectType(
-      name        = s"${gmos(site).tag}Grating",
-      description = s"${gmos(site).longName} Grating",
+      name        = s"${gmos(site).tag}GratingConfig",
+      description = s"${gmos(site).longName} Grating Configuration",
       fieldsFn    = () => fields(
 
         Field(
-          name        = "disperser",
+          name        = "grating",
           fieldType   = implicitly[EnumType[D]],
-          description = Some(s"${gmos(site).longName} Disperser"),
-          resolve     = _.value.disperser
+          description = Some(s"${gmos(site).longName} Grating"),
+          resolve     = _.value.grating
         ),
 
         Field(
           name        = "order",
-          fieldType   = EnumTypeGmosDisperserOrder,
-          description = Some(s"GMOS disperser order"),
+          fieldType   = EnumTypeGmosGratingOrder,
+          description = Some(s"GMOS grating order"),
           resolve     = _.value.order
         ),
 
@@ -371,16 +371,16 @@ object GmosSchema {
       )
     )
 
-  def InputObjectTypeGratingInput[D: EnumType](
+  def InputObjectTypeGratingConfigInput[D: EnumType](
     site: Site,
-  ): InputObjectType[GmosModel.CreateGrating[D]] =
+  ): InputObjectType[GmosModel.CreateGratingConfig[D]] =
 
-    InputObjectType[GmosModel.CreateGrating[D]](
-      s"${gmos(site).tag}GratingInput",
+    InputObjectType[GmosModel.CreateGratingConfig[D]](
+      s"${gmos(site).tag}GratingConfigInput",
       s"${gmos(site).longName} grating input parameters",
       List(
-        InputField("disperser", implicitly[EnumType[D]], s"Gmos${gmos(site).tag} disperser"),
-        InputField("order", EnumTypeGmosDisperserOrder, "GMOS disperser order"),
+        InputField("grating", implicitly[EnumType[D]], s"Gmos${gmos(site).tag} grating"),
+        InputField("order", EnumTypeGmosGratingOrder, "GMOS grating order"),
         InputField("wavelength", InputWavelength, "Grating wavelength")
       )
     )
@@ -496,7 +496,7 @@ object GmosSchema {
 
         Field(
           name        = "grating",
-          fieldType   = OptionType(GmosGratingType[D](site)),
+          fieldType   = OptionType(GmosGratingConfigType[D](site)),
           description = Some(s"${gmos(site).longName} grating"),
           resolve     = _.value.grating
         ),
@@ -535,7 +535,7 @@ object GmosSchema {
         InputField("readout",  InputObjectTypeGmosCcdReadoutInput, "GMOS CCD readout"),
         InputField("dtax",     EnumTypeGmosDtax,                   "GMOS detector x offset"),
         InputField("roi",      EnumTypeGmosRoi,                    "GMOS region of interest"),
-        InputField("grating",  OptionInputType(InputObjectTypeGratingInput[D](site)), s"${gmos(site).longName} grating"),
+        InputField("grating",  OptionInputType(InputObjectTypeGratingConfigInput[D](site)), s"${gmos(site).longName} grating"),
         InputField("filter",   OptionInputType(implicitly[EnumType[L]]),              s"${gmos(site).longName} filter"),
         InputField("fpu",      OptionInputType(InputObjectFpuInput[U](site)),         s"${gmos(site).longName} FPU")
       )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationMutation.scala
@@ -26,7 +26,7 @@ trait ScienceConfigurationMutation {
       "Edit or create GMOS South Long Slit configuration",
       List(
         EnumTypeGmosSouthFilter.notNullableField("filter"),
-        EnumTypeGmosSouthDisperser.notNullableField("disperser"),
+        EnumTypeGmosSouthGrating.notNullableField("disperser"),
         EnumTypeGmosSouthFpu.notNullableField("fpu"),
         InputSlitWidthInput.notNullableField("slitWidth")
       )
@@ -38,7 +38,7 @@ trait ScienceConfigurationMutation {
       "Edit or create GMOS North Long Slit configuration",
       List(
         EnumTypeGmosNorthFilter.notNullableField("filter"),
-        EnumTypeGmosNorthDisperser.notNullableField("disperser"),
+        EnumTypeGmosNorthGrating.notNullableField("disperser"),
         EnumTypeGmosNorthFpu.notNullableField("fpu"),
         InputSlitWidthInput.notNullableField("slitWidth")
       )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationMutation.scala
@@ -26,7 +26,7 @@ trait ScienceConfigurationMutation {
       "Edit or create GMOS South Long Slit configuration",
       List(
         EnumTypeGmosSouthFilter.notNullableField("filter"),
-        EnumTypeGmosSouthGrating.notNullableField("disperser"),
+        EnumTypeGmosSouthGrating.notNullableField("grating"),
         EnumTypeGmosSouthFpu.notNullableField("fpu"),
         InputSlitWidthInput.notNullableField("slitWidth")
       )
@@ -38,7 +38,7 @@ trait ScienceConfigurationMutation {
       "Edit or create GMOS North Long Slit configuration",
       List(
         EnumTypeGmosNorthFilter.notNullableField("filter"),
-        EnumTypeGmosNorthGrating.notNullableField("disperser"),
+        EnumTypeGmosNorthGrating.notNullableField("grating"),
         EnumTypeGmosNorthFpu.notNullableField("fpu"),
         InputSlitWidthInput.notNullableField("slitWidth")
       )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationSchema.scala
@@ -115,10 +115,10 @@ object ScienceConfigurationSchema {
         ),
 
         Field(
-          name        = "disperser",
+          name        = "grating",
           fieldType   = EnumTypeGmosNorthGrating,
-          description = Some("GMOS North Disperser"),
-          resolve     = _.value.disperser
+          description = Some("GMOS North Grating"),
+          resolve     = _.value.grating
         ),
 
         Field(
@@ -151,10 +151,10 @@ object ScienceConfigurationSchema {
         ),
 
         Field(
-          name        = "disperser",
+          name        = "grating",
           fieldType   = EnumTypeGmosSouthGrating,
-          description = Some("GMOS South Disperser"),
-          resolve     = _.value.disperser
+          description = Some("GMOS South Grating"),
+          resolve     = _.value.grating
         ),
 
         Field(

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationSchema.scala
@@ -116,7 +116,7 @@ object ScienceConfigurationSchema {
 
         Field(
           name        = "disperser",
-          fieldType   = EnumTypeGmosNorthDisperser,
+          fieldType   = EnumTypeGmosNorthGrating,
           description = Some("GMOS North Disperser"),
           resolve     = _.value.disperser
         ),
@@ -152,7 +152,7 @@ object ScienceConfigurationSchema {
 
         Field(
           name        = "disperser",
-          fieldType   = EnumTypeGmosSouthDisperser,
+          fieldType   = EnumTypeGmosSouthGrating,
           description = Some("GMOS South Disperser"),
           resolve     = _.value.disperser
         ),

--- a/modules/core/src/test/scala/lucuma/odb/api/model/GmosModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/GmosModelSuite.scala
@@ -38,8 +38,8 @@ final class GmosModelSuite extends DisciplineSuite {
   checkAll("GmosModel.CustomMask",                  EqTests[GmosModel.CustomMask].eqv)
   checkAll("GmosModel.CreateCustomMask",            EqTests[GmosModel.CreateCustomMask].eqv)
 
-  checkAll("GmosModel.Grating",                     EqTests[GmosModel.Grating[GmosNorthDisperser]].eqv)
-  checkAll("GmosModel.CreateGrating",               EqTests[GmosModel.CreateGrating[GmosNorthDisperser]].eqv)
+  checkAll("GmosModel.Grating",                     EqTests[GmosModel.GratingConfig[GmosNorthDisperser]].eqv)
+  checkAll("GmosModel.CreateGrating",               EqTests[GmosModel.CreateGratingConfig[GmosNorthDisperser]].eqv)
 
   checkAll("GmosModel.NorthDynamic",                EqTests[GmosModel.NorthDynamic].eqv)
   checkAll("GmosModel.CreateNorthDynamic",          EqTests[GmosModel.CreateNorthDynamic].eqv)

--- a/modules/core/src/test/scala/lucuma/odb/api/model/GmosModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/GmosModelSuite.scala
@@ -50,7 +50,7 @@ final class GmosModelSuite extends DisciplineSuite {
   checkAll("GmosModel.CreateSouthDynamic.step.exposure",   OptionalTests(GmosModel.CreateSouthDynamic.step.exposure))
   checkAll("GmosModel.CreateSouthDynamic.step.p",          OptionalTests(GmosModel.CreateSouthDynamic.step.p))
   checkAll("GmosModel.CreateSouthDynamic.step.q",          OptionalTests(GmosModel.CreateSouthDynamic.step.q))
-  checkAll("GmosModel.CreateSouthDynamic.step.grating",    OptionalTests(GmosModel.CreateSouthDynamic.step.grating))
+  checkAll("GmosModel.CreateSouthDynamic.step.grating",    OptionalTests(GmosModel.CreateSouthDynamic.step.gratingConfig))
   checkAll("GmosModel.CreateSouthDynamic.step.wavelength", OptionalTests(GmosModel.CreateSouthDynamic.step.wavelength))
 
 }

--- a/modules/core/src/test/scala/lucuma/odb/api/model/GmosModelSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/GmosModelSuite.scala
@@ -38,8 +38,8 @@ final class GmosModelSuite extends DisciplineSuite {
   checkAll("GmosModel.CustomMask",                  EqTests[GmosModel.CustomMask].eqv)
   checkAll("GmosModel.CreateCustomMask",            EqTests[GmosModel.CreateCustomMask].eqv)
 
-  checkAll("GmosModel.Grating",                     EqTests[GmosModel.GratingConfig[GmosNorthDisperser]].eqv)
-  checkAll("GmosModel.CreateGrating",               EqTests[GmosModel.CreateGratingConfig[GmosNorthDisperser]].eqv)
+  checkAll("GmosModel.GratingConfig",               EqTests[GmosModel.GratingConfig[GmosNorthDisperser]].eqv)
+  checkAll("GmosModel.CreateGratingConfig",         EqTests[GmosModel.CreateGratingConfig[GmosNorthDisperser]].eqv)
 
   checkAll("GmosModel.NorthDynamic",                EqTests[GmosModel.NorthDynamic].eqv)
   checkAll("GmosModel.CreateNorthDynamic",          EqTests[GmosModel.CreateNorthDynamic].eqv)

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbGmosModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbGmosModel.scala
@@ -385,7 +385,7 @@ trait ArbGmosModel {
         in.readout,
         in.dtax,
         in.roi,
-        in.grating,
+        in.gratingConfig,
         in.filter,
         in.fpu
       )
@@ -419,7 +419,7 @@ trait ArbGmosModel {
         in.readout,
         in.dtax,
         in.roi,
-        in.grating,
+        in.gratingConfig,
         in.filter,
         in.fpu
       )
@@ -453,7 +453,7 @@ trait ArbGmosModel {
         in.readout,
         in.dtax,
         in.roi,
-        in.grating,
+        in.gratingConfig,
         in.filter,
         in.fpu
       )
@@ -487,7 +487,7 @@ trait ArbGmosModel {
         in.readout,
         in.dtax,
         in.roi,
-        in.grating,
+        in.gratingConfig,
         in.filter,
         in.fpu
       )

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbGmosModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbGmosModel.scala
@@ -293,45 +293,45 @@ trait ArbGmosModel {
       )
     }
 
-  implicit def arbGrating[D: Arbitrary]: Arbitrary[GmosModel.Grating[D]] =
+  implicit def arbGrating[D: Arbitrary]: Arbitrary[GmosModel.GratingConfig[D]] =
     Arbitrary {
       for {
         d <- arbitrary[D]
         o <- arbitrary[GmosDisperserOrder]
         w <- arbitrary[Wavelength]
-      } yield GmosModel.Grating(d, o, w)
+      } yield GmosModel.GratingConfig(d, o, w)
     }
 
-  implicit def cogGrating[D: Cogen]: Cogen[GmosModel.Grating[D]] =
+  implicit def cogGrating[D: Cogen]: Cogen[GmosModel.GratingConfig[D]] =
     Cogen[(
       D,
       GmosDisperserOrder,
       Wavelength
     )].contramap { in =>
       (
-        in.disperser,
+        in.grating,
         in.order,
         in.wavelength
       )
     }
 
-  implicit def arbCreateGrating[D: Arbitrary]: Arbitrary[GmosModel.CreateGrating[D]] =
+  implicit def arbCreateGrating[D: Arbitrary]: Arbitrary[GmosModel.CreateGratingConfig[D]] =
     Arbitrary {
       for {
         d <- arbitrary[D]
         o <- arbitrary[GmosDisperserOrder]
         w <- arbitrary[WavelengthModel.Input]
-      } yield GmosModel.CreateGrating(d, o, w)
+      } yield GmosModel.CreateGratingConfig(d, o, w)
     }
 
-  implicit def cogCreateGrating[D: Cogen]: Cogen[GmosModel.CreateGrating[D]] =
+  implicit def cogCreateGrating[D: Cogen]: Cogen[GmosModel.CreateGratingConfig[D]] =
     Cogen[(
       D,
       GmosDisperserOrder,
       WavelengthModel.Input
     )].contramap { in =>
       (
-        in.disperser,
+        in.grating,
         in.order,
         in.wavelength
       )
@@ -364,7 +364,7 @@ trait ArbGmosModel {
         c <- arbitrary[GmosModel.CcdReadout]
         x <- arbitrary[GmosDtax]
         r <- arbitrary[GmosRoi]
-        g <- arbitrary[Option[GmosModel.Grating[GmosNorthDisperser]]]
+        g <- arbitrary[Option[GmosModel.GratingConfig[GmosNorthDisperser]]]
         f <- arbitrary[Option[GmosNorthFilter]]
         u <- arbitrary[Option[Either[GmosModel.CustomMask, GmosNorthFpu]]]
       } yield GmosModel.NorthDynamic(e, c, x, r, g, f, u)
@@ -376,7 +376,7 @@ trait ArbGmosModel {
       GmosModel.CcdReadout,
       GmosDtax,
       GmosRoi,
-      Option[GmosModel.Grating[GmosNorthDisperser]],
+      Option[GmosModel.GratingConfig[GmosNorthDisperser]],
       Option[GmosNorthFilter],
       Option[Either[GmosModel.CustomMask, GmosNorthFpu]]
     )].contramap { in =>
@@ -398,7 +398,7 @@ trait ArbGmosModel {
         c <- arbitrary[GmosModel.CreateCcdReadout]
         x <- arbitrary[GmosDtax]
         r <- arbitrary[GmosRoi]
-        g <- arbitrary[Option[GmosModel.CreateGrating[GmosNorthDisperser]]]
+        g <- arbitrary[Option[GmosModel.CreateGratingConfig[GmosNorthDisperser]]]
         f <- arbitrary[Option[GmosNorthFilter]]
         u <- arbitrary[Option[GmosModel.CreateFpu[GmosNorthFpu]]]
       } yield GmosModel.CreateNorthDynamic(e, c, x, r, g, f, u)
@@ -410,7 +410,7 @@ trait ArbGmosModel {
       GmosModel.CreateCcdReadout,
       GmosDtax,
       GmosRoi,
-      Option[GmosModel.CreateGrating[GmosNorthDisperser]],
+      Option[GmosModel.CreateGratingConfig[GmosNorthDisperser]],
       Option[GmosNorthFilter],
       Option[GmosModel.CreateFpu[GmosNorthFpu]]
     )].contramap { in =>
@@ -432,7 +432,7 @@ trait ArbGmosModel {
         c <- arbitrary[GmosModel.CcdReadout]
         x <- arbitrary[GmosDtax]
         r <- arbitrary[GmosRoi]
-        g <- arbitrary[Option[GmosModel.Grating[GmosSouthDisperser]]]
+        g <- arbitrary[Option[GmosModel.GratingConfig[GmosSouthDisperser]]]
         f <- arbitrary[Option[GmosSouthFilter]]
         u <- arbitrary[Option[Either[GmosModel.CustomMask, GmosSouthFpu]]]
       } yield GmosModel.SouthDynamic(e, c, x, r, g, f, u)
@@ -444,7 +444,7 @@ trait ArbGmosModel {
       GmosModel.CcdReadout,
       GmosDtax,
       GmosRoi,
-      Option[GmosModel.Grating[GmosSouthDisperser]],
+      Option[GmosModel.GratingConfig[GmosSouthDisperser]],
       Option[GmosSouthFilter],
       Option[Either[GmosModel.CustomMask, GmosSouthFpu]]
     )].contramap { in =>
@@ -466,7 +466,7 @@ trait ArbGmosModel {
         c <- arbitrary[GmosModel.CreateCcdReadout]
         x <- arbitrary[GmosDtax]
         r <- arbitrary[GmosRoi]
-        g <- arbitrary[Option[GmosModel.CreateGrating[GmosSouthDisperser]]]
+        g <- arbitrary[Option[GmosModel.CreateGratingConfig[GmosSouthDisperser]]]
         f <- arbitrary[Option[GmosSouthFilter]]
         u <- arbitrary[Option[GmosModel.CreateFpu[GmosSouthFpu]]]
       } yield GmosModel.CreateSouthDynamic(e, c, x, r, g, f, u)
@@ -478,7 +478,7 @@ trait ArbGmosModel {
       GmosModel.CreateCcdReadout,
       GmosDtax,
       GmosRoi,
-      Option[GmosModel.CreateGrating[GmosSouthDisperser]],
+      Option[GmosModel.CreateGratingConfig[GmosSouthDisperser]],
       Option[GmosSouthFilter],
       Option[GmosModel.CreateFpu[GmosSouthFpu]]
     )].contramap { in =>

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbScienceConfigurationModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbScienceConfigurationModel.scala
@@ -38,7 +38,7 @@ trait ArbScienceConfigurationModel {
       Angle
     )].contramap { in => (
       in.filter,
-      in.disperser,
+      in.grating,
       in.fpu,
       in.slitWidth
     )}

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -236,7 +236,7 @@ object Init {
   import GmosModel.{CreateCcdReadout, CreateSouthDynamic}
   import StepConfig.CreateStepConfig
 
-  import CreateSouthDynamic.{exposure, filter, fpu, grating, readout, roi, step}
+  import CreateSouthDynamic.{exposure, filter, fpu, gratingConfig, readout, roi, step}
   import CreateCcdReadout.{ampRead, xBin, yBin}
 
   private def edit[A](start: A)(state: State[A, _]): A =
@@ -303,7 +303,7 @@ object Init {
         _ <- readout.andThen(xBin)    := GmosXBinning.Two
         _ <- readout.andThen(yBin)    := GmosYBinning.Two
         _ <- roi                      := GmosRoi.CentralSpectrum
-        _ <- grating                  := GmosModel.CreateGratingConfig[GmosSouthDisperser](GmosSouthDisperser.B600_G5323, GmosDisperserOrder.One, WavelengthModel.Input.fromNanometers(520.0)).some
+        _ <- gratingConfig                  := GmosModel.CreateGratingConfig[GmosSouthDisperser](GmosSouthDisperser.B600_G5323, GmosDisperserOrder.One, WavelengthModel.Input.fromNanometers(520.0)).some
         _ <- filter                   := Option.empty[GmosSouthFilter]
         _ <- fpu                      := CreateFpu.builtin[GmosSouthFpu](GmosSouthFpu.LongSlit_1_00).some
       } yield ()

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -380,7 +380,7 @@ object Init {
       scienceConfiguration =
         ScienceConfigurationInput(
           gmosSouthLongSlit = GmosSouthLongSlitInput(
-            disperser = GmosSouthDisperser.B600_G5323.assign,
+            grating = GmosSouthDisperser.B600_G5323.assign,
             fpu       = GmosSouthFpu.LongSlit_1_00.assign,
             slitWidth = SlitWidthInput.arcseconds(1.0).assign
           ).assign
@@ -429,7 +429,7 @@ object Init {
       scienceConfiguration =
         ScienceConfigurationInput(
           gmosNorthLongSlit = GmosNorthLongSlitInput(
-            disperser = GmosNorthDisperser.B600_G5307.assign,
+            grating = GmosNorthDisperser.B600_G5307.assign,
             fpu       = GmosNorthFpu.LongSlit_1_00.assign,
             slitWidth = SlitWidthInput.arcseconds(1.0).assign
           ).assign

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -303,7 +303,7 @@ object Init {
         _ <- readout.andThen(xBin)    := GmosXBinning.Two
         _ <- readout.andThen(yBin)    := GmosYBinning.Two
         _ <- roi                      := GmosRoi.CentralSpectrum
-        _ <- grating                  := GmosModel.CreateGrating[GmosSouthDisperser](GmosSouthDisperser.B600_G5323, GmosDisperserOrder.One, WavelengthModel.Input.fromNanometers(520.0)).some
+        _ <- grating                  := GmosModel.CreateGratingConfig[GmosSouthDisperser](GmosSouthDisperser.B600_G5323, GmosDisperserOrder.One, WavelengthModel.Input.fromNanometers(520.0)).some
         _ <- filter                   := Option.empty[GmosSouthFilter]
         _ <- fpu                      := CreateFpu.builtin[GmosSouthFpu](GmosSouthFpu.LongSlit_1_00).some
       } yield ()

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -303,7 +303,7 @@ object Init {
         _ <- readout.andThen(xBin)    := GmosXBinning.Two
         _ <- readout.andThen(yBin)    := GmosYBinning.Two
         _ <- roi                      := GmosRoi.CentralSpectrum
-        _ <- gratingConfig                  := GmosModel.CreateGratingConfig[GmosSouthDisperser](GmosSouthDisperser.B600_G5323, GmosDisperserOrder.One, WavelengthModel.Input.fromNanometers(520.0)).some
+        _ <- gratingConfig            := GmosModel.CreateGratingConfig[GmosSouthDisperser](GmosSouthDisperser.B600_G5323, GmosDisperserOrder.One, WavelengthModel.Input.fromNanometers(520.0)).some
         _ <- filter                   := Option.empty[GmosSouthFilter]
         _ <- fpu                      := CreateFpu.builtin[GmosSouthFpu](GmosSouthFpu.LongSlit_1_00).some
       } yield ()

--- a/modules/service/src/test/scala/test/TestInit.scala
+++ b/modules/service/src/test/scala/test/TestInit.scala
@@ -343,7 +343,7 @@ object TestInit {
         _ <- readout.andThen(xBin)    := GmosXBinning.Two
         _ <- readout.andThen(yBin)    := GmosYBinning.Two
         _ <- roi                      := GmosRoi.CentralSpectrum
-        _ <- grating                  := GmosModel.CreateGrating[GmosSouthDisperser](GmosSouthDisperser.B600_G5323, GmosDisperserOrder.One, WavelengthModel.Input.fromNanometers(520.0)).some
+        _ <- grating                  := GmosModel.CreateGratingConfig[GmosSouthDisperser](GmosSouthDisperser.B600_G5323, GmosDisperserOrder.One, WavelengthModel.Input.fromNanometers(520.0)).some
         _ <- filter                   := Option.empty[GmosSouthFilter]
         _ <- fpu                      := GmosModel.CreateFpu.builtin[GmosSouthFpu](GmosSouthFpu.LongSlit_1_00).some
       } yield ()

--- a/modules/service/src/test/scala/test/TestInit.scala
+++ b/modules/service/src/test/scala/test/TestInit.scala
@@ -276,7 +276,7 @@ object TestInit {
 
   import GmosModel.{CreateCcdReadout, CreateSouthDynamic}
   import CreateCcdReadout.{ampRead, xBin, yBin}
-  import CreateSouthDynamic.{exposure, filter, fpu, grating, readout, roi, step}
+  import CreateSouthDynamic.{exposure, filter, fpu, gratingConfig, readout, roi, step}
   import StepConfig.CreateStepConfig
 
   private def edit[A](start: A)(state: State[A, _]): A =
@@ -343,7 +343,7 @@ object TestInit {
         _ <- readout.andThen(xBin)    := GmosXBinning.Two
         _ <- readout.andThen(yBin)    := GmosYBinning.Two
         _ <- roi                      := GmosRoi.CentralSpectrum
-        _ <- grating                  := GmosModel.CreateGratingConfig[GmosSouthDisperser](GmosSouthDisperser.B600_G5323, GmosDisperserOrder.One, WavelengthModel.Input.fromNanometers(520.0)).some
+        _ <- gratingConfig                  := GmosModel.CreateGratingConfig[GmosSouthDisperser](GmosSouthDisperser.B600_G5323, GmosDisperserOrder.One, WavelengthModel.Input.fromNanometers(520.0)).some
         _ <- filter                   := Option.empty[GmosSouthFilter]
         _ <- fpu                      := GmosModel.CreateFpu.builtin[GmosSouthFpu](GmosSouthFpu.LongSlit_1_00).some
       } yield ()


### PR DESCRIPTION
Renames GMOS "disperser" to "grating".  Sorry for the hassle but it isn't just capriciousness but rather a suggestion/request from Andy.  There's a matching change to `core` but it can be folded in later.