### PR TITLE
Remove slitWidth from longslit modes

### DIFF
--- a/modules/core/src/main/scala/lucuma/itc/client/ItcSpectroscopyInput.scala
+++ b/modules/core/src/main/scala/lucuma/itc/client/ItcSpectroscopyInput.scala
@@ -215,7 +215,7 @@ object ItcSpectroscopyInput {
       )
 
   implicit val EncoderScienceConfigurationModel: Encoder[ScienceConfigurationModel] = {
-    case ScienceConfigurationModel.Modes.GmosNorthLongSlit(filter, grating, fpu, _) =>
+    case ScienceConfigurationModel.Modes.GmosNorthLongSlit(filter, grating, fpu) =>
       Json.obj(
         "gmosN" ->
           Json.fromFields(
@@ -225,7 +225,7 @@ object ItcSpectroscopyInput {
             ) ++ filter.map(screaming(_)).tupleLeft("filter").toList
           )
       )
-    case ScienceConfigurationModel.Modes.GmosSouthLongSlit(filter, grating, fpu, _) =>
+    case ScienceConfigurationModel.Modes.GmosSouthLongSlit(filter, grating, fpu) =>
       Json.obj(
         "gmosS" ->
           Json.fromFields(

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ScienceConfigurationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ScienceConfigurationModel.scala
@@ -9,14 +9,10 @@ import cats.syntax.all._
 import cats.data.StateT
 import clue.data.Input
 import io.circe.Decoder
-import io.circe.generic.semiauto.deriveDecoder
 import lucuma.core.enum.GmosNorthFilter
 import lucuma.core.enum.GmosNorthDisperser
 import lucuma.core.enum.GmosSouthFilter
 import lucuma.core.enum.GmosSouthDisperser
-import lucuma.core.math.Angle
-import lucuma.core.util.Enumerated
-import lucuma.core.util.Display
 import lucuma.odb.api.model.ScienceConfigurationModel.Modes.{GmosNorthLongSlit, GmosNorthLongSlitInput, GmosSouthLongSlit, GmosSouthLongSlitInput}
 import lucuma.odb.api.model.syntax.input._
 import lucuma.odb.api.model.syntax.lens._
@@ -48,8 +44,7 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
     final case class GmosNorthLongSlit(
       filter:    Option[GmosNorthFilter],
       grating:   GmosNorthDisperser,
-      fpu:       GmosNorthFpu,
-      slitWidth: Angle
+      fpu:       GmosNorthFpu
     ) extends ScienceConfigurationModel {
       val mode: ConfigurationMode =
         ConfigurationMode.GmosNorthLongSlit
@@ -68,42 +63,35 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
       val fpu: Lens[GmosNorthLongSlit, GmosNorthFpu] =
         Focus[GmosNorthLongSlit](_.fpu)
 
-      val slitWidth: Lens[GmosNorthLongSlit, Angle] =
-        Focus[GmosNorthLongSlit](_.slitWidth)
-
       implicit val EqGmosNorth: Eq[GmosNorthLongSlit] =
-        Eq.by(a => (a.filter, a.grating, a.slitWidth))
+        Eq.by(a => (a.filter, a.grating, a.fpu))
     }
 
     final case class GmosNorthLongSlitInput(
       filter:    Input[GmosNorthFilter]    = Input.ignore,
       grating:   Input[GmosNorthDisperser] = Input.ignore,
-      fpu:       Input[GmosNorthFpu]       = Input.ignore,
-      slitWidth: Input[SlitWidthInput]     = Input.ignore
+      fpu:       Input[GmosNorthFpu]       = Input.ignore
     ) extends EditorInput[GmosNorthLongSlit] {
 
       override val create: ValidatedInput[GmosNorthLongSlit] =
         (grating.notMissing("grating"),
-         fpu.notMissing("fpu"),
-         slitWidth.notMissingAndThen("slitWidth")(_.toAngle)
-        ).mapN { case (d, u, s) =>
-          GmosNorthLongSlit(filter.toOption, d, u, s)
+         fpu.notMissing("fpu")
+        ).mapN { case (d, u) =>
+          GmosNorthLongSlit(filter.toOption, d, u)
         }
 
       override val edit: StateT[EitherInput, GmosNorthLongSlit, Unit] = {
         val validArgs =
           (grating.validateIsNotNull("grating"),
-           fpu.validateIsNotNull("fpu"),
-           slitWidth.validateNotNullable("slitWidth")(_.toAngle)
+           fpu.validateIsNotNull("fpu")
           ).tupled
 
         for {
           args <- validArgs.liftState
-          (grating, fpu, slitWidth) = args
+          (grating, fpu) = args
           _ <- GmosNorthLongSlit.filter    := filter.toOptionOption
           _ <- GmosNorthLongSlit.grating   := grating
           _ <- GmosNorthLongSlit.fpu       := fpu
-          _ <- GmosNorthLongSlit.slitWidth := slitWidth
         } yield ()
       }
     }
@@ -121,8 +109,7 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
         Eq.by { a => (
           a.filter,
           a.grating,
-          a.fpu,
-          a.slitWidth
+          a.fpu
         )}
 
     }
@@ -130,8 +117,7 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
     final case class GmosSouthLongSlit(
       filter:    Option[GmosSouthFilter],
       grating:   GmosSouthDisperser,
-      fpu:       GmosSouthFpu,
-      slitWidth: Angle
+      fpu:       GmosSouthFpu
     ) extends ScienceConfigurationModel {
       val mode: ConfigurationMode =
         ConfigurationMode.GmosSouthLongSlit
@@ -150,43 +136,36 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
       val fpu: Lens[GmosSouthLongSlit, GmosSouthFpu] =
         Focus[GmosSouthLongSlit](_.fpu)
 
-      val slitWidth: Lens[GmosSouthLongSlit, Angle] =
-        Focus[GmosSouthLongSlit](_.slitWidth)
-
       implicit val EqGmosSouth: Eq[GmosSouthLongSlit] =
-        Eq.by(a => (a.filter, a.grating, a.slitWidth))
+        Eq.by(a => (a.filter, a.grating, a.fpu))
 
     }
 
     final case class GmosSouthLongSlitInput(
       filter:    Input[GmosSouthFilter]    = Input.ignore,
       grating:   Input[GmosSouthDisperser] = Input.ignore,
-      fpu:       Input[GmosSouthFpu]       = Input.ignore,
-      slitWidth: Input[SlitWidthInput]     = Input.ignore
+      fpu:       Input[GmosSouthFpu]       = Input.ignore
     ) extends EditorInput[GmosSouthLongSlit] {
 
       override val create: ValidatedInput[GmosSouthLongSlit] =
         (grating.notMissing("grating"),
-         fpu.notMissing("fpu"),
-         slitWidth.notMissingAndThen("slitWidth")(_.toAngle)
-        ).mapN { case (d, u, s) =>
-          GmosSouthLongSlit(filter.toOption, d, u, s)
+         fpu.notMissing("fpu")
+        ).mapN { case (d, u) =>
+          GmosSouthLongSlit(filter.toOption, d, u)
         }
 
       def edit: StateT[EitherInput, GmosSouthLongSlit, Unit] = {
         val validArgs =
           (grating.validateIsNotNull("grating"),
-           fpu.validateIsNotNull("fpu"),
-           slitWidth.validateNotNullable("slitWidth")(_.toAngle)
+           fpu.validateIsNotNull("fpu")
           ).tupled
 
         for {
           args <- validArgs.liftState
-          (grating, fpu, slitWidth) = args
+          (grating, fpu) = args
           _ <- GmosSouthLongSlit.filter    := filter.toOptionOption
           _ <- GmosSouthLongSlit.grating   := grating
           _ <- GmosSouthLongSlit.fpu       := fpu
-          _ <- GmosSouthLongSlit.slitWidth := slitWidth
         } yield ()
       }
 
@@ -204,84 +183,10 @@ object ScienceConfigurationModel extends ScienceConfigurationModelOptics {
         Eq.by { a => (
           a.filter,
           a.grating,
-          a.fpu,
-          a.slitWidth
+          a.fpu
         )}
 
     }
-  }
-
-  final case class SlitWidthInput(
-    microarcseconds: Option[Long],
-    milliarcseconds: Option[BigDecimal],
-    arcseconds:      Option[BigDecimal]
-  ) {
-    import Units._
-
-    val toAngle: ValidatedInput[Angle] =
-      ValidatedInput.requireOne("slitWidthInput",
-        microarcseconds.map(Microarcseconds.readLong),
-        milliarcseconds.map(Milliarcseconds.readDecimal),
-        arcseconds     .map(Arcseconds.readDecimal)
-      )
-  }
-
-  object SlitWidthInput {
-    val Empty: SlitWidthInput =
-      SlitWidthInput(None, None, None)
-
-    def microarcseconds(a: Long): SlitWidthInput =
-      Empty.copy(microarcseconds = a.some)
-
-    def milliarcseconds(a: BigDecimal): SlitWidthInput =
-      Empty.copy(milliarcseconds = a.some)
-
-    def arcseconds(a: BigDecimal): SlitWidthInput =
-      Empty.copy(arcseconds = a.some)
-
-    implicit def DecoderFocalPlaneAngleInput: Decoder[SlitWidthInput] =
-      deriveDecoder[SlitWidthInput]
-
-    implicit val EqFocalPlaneAngleInput: Eq[SlitWidthInput] =
-      Eq.by { a => (
-        a.microarcseconds,
-        a.milliarcseconds,
-        a.arcseconds
-      )}
-
-  }
-
-  sealed abstract class Units(
-    val angleUnit: AngleModel.Units
-  ) extends Product with Serializable {
-
-    def readLong(value: Long): ValidatedInput[Angle] =
-      angleUnit.readSignedLong(value)
-
-    def readDecimal(value: BigDecimal): ValidatedInput[Angle] =
-      angleUnit.readSignedDecimal(value)
-  }
-
-  object Units {
-
-    case object Microarcseconds extends Units(AngleModel.Units.Microarcseconds)
-    case object Milliarcseconds extends Units(AngleModel.Units.Milliarcseconds)
-    case object Arcseconds      extends Units(AngleModel.Units.Arcseconds)
-
-    val microarcseconds: Units = Microarcseconds
-    val milliarcseconds: Units = Milliarcseconds
-    val arcseconds: Units      = Arcseconds
-
-    implicit val EnumeratedUnits: Enumerated[Units] =
-      Enumerated.of(
-        Microarcseconds,
-        Milliarcseconds,
-        Arcseconds
-      )
-
-    implicit def DisplayUnits: Display[Units] =
-      Display.byShortName(_.angleUnit.abbreviation)
-
   }
 
   import Modes._

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationMutation.scala
@@ -4,21 +4,13 @@
 package lucuma.odb.api.schema
 
 import lucuma.odb.api.model.{ScienceConfigurationInput, ScienceConfigurationModel}
-import sangria.macros.derive._
 import sangria.schema._
 
 trait ScienceConfigurationMutation {
 
   import syntax.inputtype._
   import ScienceConfigurationModel.Modes._
-  import ScienceConfigurationModel.SlitWidthInput
   import GmosSchema._
-
-  implicit val InputSlitWidthInput: InputType[SlitWidthInput] =
-    deriveInputObjectType[SlitWidthInput](
-      InputObjectTypeName("SlitWidthInput"),
-      InputObjectTypeDescription("Slit width in appropriate units"),
-    )
 
   implicit val InputObjectTypeGmosSouthLongSlit: InputObjectType[GmosSouthLongSlitInput] =
     InputObjectType[GmosSouthLongSlitInput](
@@ -27,8 +19,7 @@ trait ScienceConfigurationMutation {
       List(
         EnumTypeGmosSouthFilter.notNullableField("filter"),
         EnumTypeGmosSouthGrating.notNullableField("grating"),
-        EnumTypeGmosSouthFpu.notNullableField("fpu"),
-        InputSlitWidthInput.notNullableField("slitWidth")
+        EnumTypeGmosSouthFpu.notNullableField("fpu")
       )
     )
 
@@ -39,8 +30,7 @@ trait ScienceConfigurationMutation {
       List(
         EnumTypeGmosNorthFilter.notNullableField("filter"),
         EnumTypeGmosNorthGrating.notNullableField("grating"),
-        EnumTypeGmosNorthFpu.notNullableField("fpu"),
-        InputSlitWidthInput.notNullableField("slitWidth")
+        EnumTypeGmosNorthFpu.notNullableField("fpu")
       )
     )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationSchema.scala
@@ -12,7 +12,6 @@ import lucuma.odb.api.model.ScienceConfigurationModel.Modes
 import lucuma.odb.api.schema.syntax.all._
 
 import sangria.schema._
-import sangria.macros.derive._
 
 object ScienceConfigurationSchema {
   import GmosSchema._
@@ -22,18 +21,6 @@ object ScienceConfigurationSchema {
     EnumType.fromEnumerated(
       "ConfigurationModeType",
       "ConfigurationMode"
-    )
-
-  implicit val EnumSlitWidthAngleUnits: EnumType[ScienceConfigurationModel.Units] =
-    EnumType.fromEnumerated[ScienceConfigurationModel.Units](
-      "SlitWidthAngleUnits",
-      "Slit width units"
-    )
-
-  implicit val InputSlitWidthInput: InputType[ScienceConfigurationModel.SlitWidthInput] =
-    deriveInputObjectType[ScienceConfigurationModel.SlitWidthInput](
-      InputObjectTypeName("SlitWidthInput"),
-      InputObjectTypeDescription("Slit width in appropriate units"),
     )
 
   val SlitWidthType: ObjectType[Any, Angle]=
@@ -126,14 +113,7 @@ object ScienceConfigurationSchema {
           fieldType   = EnumTypeGmosNorthFpu,
           description = Some("GMOS North FPU"),
           resolve     = _.value.fpu
-        ),
-
-        Field(
-          name        = "slitWidth",
-          fieldType   = SlitWidthType,
-          description = Some("Slit width in appropriate units"),
-          resolve     = _.value.slitWidth
-        ),
+        )
       )
     )
 
@@ -162,14 +142,7 @@ object ScienceConfigurationSchema {
           fieldType   = EnumTypeGmosSouthFpu,
           description = Some("GMOS South  FPU"),
           resolve     = _.value.fpu
-        ),
-
-        Field(
-          name        = "slitWidth",
-          fieldType   = SlitWidthType,
-          description = Some("Slit width in appropriate units"),
-          resolve     = _.value.slitWidth
-        ),
+        )
       )
     )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceConfigurationSchema.scala
@@ -5,7 +5,6 @@ package lucuma.odb.api.schema
 
 import cats.syntax.option._
 
-import lucuma.core.math.Angle
 import lucuma.odb.api.model.ConfigurationMode
 import lucuma.odb.api.model.ScienceConfigurationModel
 import lucuma.odb.api.model.ScienceConfigurationModel.Modes
@@ -21,35 +20,6 @@ object ScienceConfigurationSchema {
     EnumType.fromEnumerated(
       "ConfigurationModeType",
       "ConfigurationMode"
-    )
-
-  val SlitWidthType: ObjectType[Any, Angle]=
-    ObjectType(
-      name     = "slitWidth",
-      fieldsFn = () => fields(
-
-        Field(
-          name        = "microarcseconds",
-          fieldType   = LongType,
-          description = Some("Slit width in µas"),
-          resolve     = v => Angle.signedMicroarcseconds.get(v.value)
-        ),
-
-        Field(
-          name        = "milliarcseconds",
-          fieldType   = BigDecimalType,
-          description = Some("Slit width in mas"),
-          resolve     = v => Angle.signedDecimalMilliarcseconds.get(v.value)
-        ),
-
-        Field(
-          name        = "arcseconds",
-          fieldType   = BigDecimalType,
-          description = Some("Slit width in arcsec"),
-          resolve     = v => Angle.signedDecimalArcseconds.get(v.value)
-        )
-
-      )
     )
 
   def ScienceConfigurationType: ObjectType[Any, ScienceConfigurationModel] =

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbScienceConfigurationModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbScienceConfigurationModel.scala
@@ -5,8 +5,6 @@ package lucuma.odb.api.model
 package arb
 
 import lucuma.core.`enum`.{GmosNorthDisperser, GmosNorthFilter, GmosNorthFpu}
-import lucuma.core.math.Angle
-import lucuma.core.math.arb.ArbAngle
 import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck.Arbitrary
 import org.scalacheck.Cogen
@@ -17,7 +15,6 @@ trait ArbScienceConfigurationModel {
 
   import ScienceConfigurationModel.Modes.GmosNorthLongSlit
 
-  import ArbAngle._
   import ArbEnumerated._
 
   implicit val arbGmosNorthLongSlit: Arbitrary[GmosNorthLongSlit] =
@@ -26,21 +23,18 @@ trait ArbScienceConfigurationModel {
         f <- arbitrary[Option[GmosNorthFilter]]
         d <- arbitrary[GmosNorthDisperser]
         u <- arbitrary[GmosNorthFpu]
-        a <- arbitrary[Angle]
-      } yield GmosNorthLongSlit(f, d, u, a)
+      } yield GmosNorthLongSlit(f, d, u)
     }
 
   implicit val cogGmosNorthLongSlit: Cogen[GmosNorthLongSlit] =
     Cogen[(
       Option[GmosNorthFilter],
       GmosNorthDisperser,
-      GmosNorthFpu,
-      Angle
+      GmosNorthFpu
     )].contramap { in => (
       in.filter,
       in.grating,
-      in.fpu,
-      in.slitWidth
+      in.fpu
     )}
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -21,7 +21,6 @@ import lucuma.core.model.Program
 import lucuma.odb.api.model.GmosModel.CreateFpu
 import lucuma.odb.api.model.OffsetModel.ComponentInput
 import lucuma.odb.api.model.ScienceConfigurationModel.Modes.{GmosNorthLongSlitInput, GmosSouthLongSlitInput}
-import lucuma.odb.api.model.ScienceConfigurationModel.SlitWidthInput
 
 import scala.concurrent.duration._
 
@@ -400,8 +399,7 @@ object Init {
         ScienceConfigurationInput(
           gmosSouthLongSlit = GmosSouthLongSlitInput(
             grating   = GmosSouthDisperser.B600_G5323.assign,
-            fpu       = GmosSouthFpu.LongSlit_1_00.assign,
-            slitWidth = SlitWidthInput.arcseconds(1.0).assign
+            fpu       = GmosSouthFpu.LongSlit_1_00.assign
           ).assign
         ).some
     )(baseObs(pid, target))
@@ -426,8 +424,7 @@ object Init {
         ScienceConfigurationInput(
           gmosNorthLongSlit = GmosNorthLongSlitInput(
             grating   = GmosNorthDisperser.B600_G5307.assign,
-            fpu       = GmosNorthFpu.LongSlit_1_00.assign,
-            slitWidth = SlitWidthInput.arcseconds(1.0).assign
+            fpu       = GmosNorthFpu.LongSlit_1_00.assign
           ).assign
         ).some
     )(baseObs(pid, target))


### PR DESCRIPTION
Removes the `slitWidth` field of the long slit modes.  The slit width is determined by the FPU. It isn't clear what we'd do with `slitWidth` and we shouldn't allow it to differ from FPU anyway.  Over in `ScienceRequirements` there is a `focalPlaneAngle` which I believe is used to hold the user's requirement for the slit width.