### PR TITLE
Respect settings in AdvancedConfig when generating the sequence

### DIFF
--- a/modules/core/src/main/scala/lucuma/gen/gmos/GmosNorthInitialDynamicConfig.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/GmosNorthInitialDynamicConfig.scala
@@ -1,22 +1,21 @@
 // Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package lucuma.gen
-package gmos
+package lucuma.gen.gmos
 
 import lucuma.core.`enum`.{GmosAmpCount, GmosAmpGain, GmosAmpReadMode, GmosDtax, GmosRoi, GmosXBinning, GmosYBinning}
 import lucuma.odb.api.model.GmosModel.{CcdReadout, NorthDynamic}
 
 import scala.concurrent.duration._
 
-private[gmos] trait GmosNorthSequenceState extends SequenceState[NorthDynamic] {
+private[gmos] trait GmosNorthInitialDynamicConfig {
 
   /**
    * Starting point, default dynamic configuration for GMOS North.  This will
    * serve as the initial state in state computations that produce sequence
    * steps.
    */
-  override val initialConfig: NorthDynamic =
+  val initialConfig: NorthDynamic =
     NorthDynamic(
       exposure = 0.seconds,
       readout  = CcdReadout(

--- a/modules/core/src/main/scala/lucuma/gen/gmos/GmosSouthInitialDynamicConfig.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/GmosSouthInitialDynamicConfig.scala
@@ -9,14 +9,14 @@ import lucuma.odb.api.model.GmosModel.{CcdReadout, SouthDynamic}
 
 import scala.concurrent.duration._
 
-private[gmos] trait GmosSouthSequenceState extends SequenceState[SouthDynamic] {
+private[gmos] trait GmosSouthInitialDynamicConfig {
 
   /**
    * Starting point, default dynamic configuration for GMOS South.  This will
    * serve as the initial state in state computations that produce sequence
    * steps.
    */
-  override val initialConfig: SouthDynamic =
+  val initialConfig: SouthDynamic =
     SouthDynamic(
       exposure = 0.seconds,
       readout  = CcdReadout(

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/Acquisition.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/Acquisition.scala
@@ -1,0 +1,103 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.gen.gmos.longslit
+
+import cats.data.NonEmptyList
+import cats.syntax.either._
+import cats.syntax.option._
+import lucuma.core.`enum`.{GmosNorthFilter, GmosNorthFpu, GmosNorthGrating, GmosRoi, GmosSouthFilter, GmosSouthFpu, GmosSouthGrating, GmosXBinning, GmosYBinning}
+import lucuma.core.math.Wavelength
+import lucuma.core.math.syntax.int._
+import lucuma.core.optics.syntax.lens._
+import lucuma.gen.gmos.{GmosNorthInitialDynamicConfig, GmosSouthInitialDynamicConfig}
+import lucuma.gen.{AcqExposureTime, SequenceState}
+import lucuma.odb.api.model.GmosModel.{CustomMask, DynamicOptics, GratingConfig, NorthDynamic, SouthDynamic}
+import lucuma.odb.api.model.StepConfig
+
+import scala.concurrent.duration._
+
+/**
+ * GMOS long slit acquisition step.
+ */
+sealed trait Acquisition[D, G, F, U] extends SequenceState[D] {
+
+  def optics: DynamicOptics[D, G, F, U]
+
+  def compute(
+    filters:      NonEmptyList[(F, Wavelength)],
+    fpu:          U,
+    exposureTime: AcqExposureTime,
+    λ:            Wavelength,
+  ): Acquisition.Steps[D] = {
+
+    def filter: F = filters.toList.minBy { case (_, w) =>
+      (λ.toPicometers.value.value - w.toPicometers.value.value).abs
+    }._1
+
+    eval {
+      for {
+        _  <- optics.exposure      := exposureTime.value
+        _  <- optics.filter        := filter.some
+        _  <- optics.fpu           := none[Either[CustomMask, U]]
+        _  <- optics.gratingConfig := none[GratingConfig[G]]
+        _  <- optics.xBin          := GmosXBinning.Two
+        _  <- optics.yBin          := GmosYBinning.Two
+        _  <- optics.roi           := GmosRoi.Ccd2
+        s0 <- scienceStep(0.arcsec, 0.arcsec)
+
+        _  <- optics.exposure      := 20.seconds
+        _  <- optics.fpu           := fpu.asRight.some
+        _  <- optics.xBin          := GmosXBinning.One
+        _  <- optics.yBin          := GmosYBinning.One
+        _  <- optics.roi           := GmosRoi.CentralStamp
+        s1 <- scienceStep(10.arcsec, 0.arcsec)
+
+        _  <- optics.exposure      := exposureTime.value * 4
+        s2 <- scienceStep(0.arcsec, 0.arcsec)
+
+      } yield Acquisition.Steps(s0, s1, s2)
+    }
+
+  }
+
+}
+
+object Acquisition {
+
+  /**
+   * Unique step configurations used to form an acquisition sequence.
+   *
+   * @param ccd2 image, 2x2 using CCD2 ROI
+   * @param p10  20 second exposure, 1x1 Central Stamp, 10 arcsec offset in p
+   * @param slit image through the slit
+   */
+  final case class Steps[D](
+    ccd2: StepConfig[D],
+    p10:  StepConfig[D],
+    slit: StepConfig[D]
+  ) {
+
+    val initialAtom: NonEmptyList[StepConfig[D]] =
+      NonEmptyList.of(ccd2, p10, slit)
+
+    val repeatingAtom: NonEmptyList[StepConfig[D]] =
+      NonEmptyList.of(slit)
+
+  }
+
+  object GmosNorth extends GmosNorthInitialDynamicConfig
+                      with Acquisition[NorthDynamic, GmosNorthGrating, GmosNorthFilter, GmosNorthFpu] {
+
+    def optics: DynamicOptics[NorthDynamic, GmosNorthGrating, GmosNorthFilter, GmosNorthFpu] =
+      NorthDynamic
+  }
+
+  object GmosSouth extends GmosSouthInitialDynamicConfig
+                      with Acquisition[SouthDynamic, GmosSouthGrating, GmosSouthFilter, GmosSouthFpu] {
+
+    def optics: DynamicOptics[SouthDynamic, GmosSouthGrating, GmosSouthFilter, GmosSouthFpu] =
+      SouthDynamic
+  }
+
+}

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/Acquisition.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/Acquisition.scala
@@ -18,20 +18,25 @@ import lucuma.odb.api.model.StepConfig
 import scala.concurrent.duration._
 
 /**
- * GMOS long slit acquisition step.
+ * GMOS long slit acquisition steps.
+ *
+ * @tparam D dynamic config type
+ * @tparam G grating type
+ * @tparam F filter type
+ * @tparam U FPU type
  */
 sealed trait Acquisition[D, G, F, U] extends SequenceState[D] {
 
   def optics: DynamicOptics[D, G, F, U]
 
   def compute(
-    filters:      NonEmptyList[(F, Wavelength)],
+    acqFilters:   NonEmptyList[(F, Wavelength)],
     fpu:          U,
     exposureTime: AcqExposureTime,
     λ:            Wavelength,
   ): Acquisition.Steps[D] = {
 
-    def filter: F = filters.toList.minBy { case (_, w) =>
+    def filter: F = acqFilters.toList.minBy { case (_, w) =>
       (λ.toPicometers.value.value - w.toPicometers.value.value).abs
     }._1
 

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosLongSlit.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosLongSlit.scala
@@ -6,7 +6,6 @@ package gmos
 package longslit
 
 import cats.Eq
-import cats.data.NonEmptyList
 import cats.effect.Sync
 import cats.syntax.eq._
 import cats.syntax.functor._
@@ -18,18 +17,16 @@ import lucuma.core.math.Wavelength
 import lucuma.core.math.units.Nanometer
 import lucuma.core.model.SourceProfile
 import lucuma.itc.client.{ItcClient, ItcResult}
-import lucuma.odb.api.model.{ObservationModel, ScienceMode, Sequence, StepConfig}
+import lucuma.odb.api.model.{ObservationModel, ScienceMode, Sequence}
 import lucuma.odb.api.repo.OdbRepo
 
 import scala.concurrent.duration._
 
 trait GmosLongSlit[F[_], S, D] extends Generator[F, S, D] with GeneratorHelper[D] {
 
-  import GmosLongSlit.{AcquisitionSteps, ScienceSteps}
+  def acquisitionSteps: Acquisition.Steps[D]
 
-  def acquisitionSteps: AcquisitionSteps[D]
-
-  def scienceSteps: ScienceSteps[D]
+  def scienceAtoms: LazyList[Science.Atom[D]]
 
   def longSlitAcquisition(
     recordedSteps: List[RecordedStep[D]]
@@ -66,10 +63,7 @@ trait GmosLongSlit[F[_], S, D] extends Generator[F, S, D] with GeneratorHelper[D
     recordedSteps: List[RecordedStep[D]]
   )(implicit ev1: Sync[F]): F[Sequence[D]] = {
 
-    val sciSteps      = scienceSteps
-    val wholeSequence = List.unfold(0) { i =>
-      Option.when(i < exposureCount)((sciSteps.atom(i), i + 1))
-    }
+    val wholeSequence = scienceAtoms.take(exposureCount).toList.map(_.steps)
 
     createSequence(
       remainingSteps(wholeSequence, recordedSteps)(identity)
@@ -151,59 +145,4 @@ object GmosLongSlit {
 
   }
 
-  /**
-   * Unique step configurations used to form an acquisition sequence.
-   *
-   * @param ccd2 image, 2x2 using CCD2 ROI
-   * @param p10  20 second exposure, 1x1 Central Stamp, 10 arcsec offset in p
-   * @param slit image through the slit
-   */
-  final case class AcquisitionSteps[D](
-    ccd2: StepConfig[D],
-    p10:  StepConfig[D],
-    slit: StepConfig[D]
-  ) {
-
-    val initialAtom: NonEmptyList[StepConfig[D]] =
-      NonEmptyList.of(ccd2, p10, slit)
-
-    val repeatingAtom: NonEmptyList[StepConfig[D]] =
-      NonEmptyList.of(slit)
-
-  }
-
-  /**
-   * Unique step configurations used to form a science sequence.
-   *
-   * @param science0 science step at offset (0, 0) and requested λ
-   * @param flat0    smart flat matching `science0`
-   * @param science1 science step at offset (0, 15) and λ + Δ
-   * @param flat1    smart flat matching `science1`
-   */
-  final case class ScienceSteps[D](
-    science0: StepConfig[D],
-    flat0:    StepConfig[D],
-    science1: StepConfig[D],
-    flat1:    StepConfig[D]
-  ) {
-
-    val atom0: NonEmptyList[StepConfig[D]] =
-      NonEmptyList.of(science0, flat0)
-
-    val atom1: NonEmptyList[StepConfig[D]] =
-      NonEmptyList.of(flat1, science1)
-
-    val atom2: NonEmptyList[StepConfig[D]] =
-      NonEmptyList.of(science1, flat1)
-
-    val atom3: NonEmptyList[StepConfig[D]] =
-      NonEmptyList.of(flat0, science0)
-
-    val uniqueAtoms: Vector[NonEmptyList[StepConfig[D]]] =
-      Vector(atom0, atom1, atom2, atom3)
-
-    def atom(i: Int): NonEmptyList[StepConfig[D]] =
-      uniqueAtoms((i % 4).abs)
-
-  }
 }

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/Science.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/Science.scala
@@ -23,7 +23,12 @@ import lucuma.odb.api.model.gmos.longslit.{DeltaWavelengthCalculator, LongSlit, 
 import scala.collection.immutable.LazyList
 
 /**
- * GMOS long slit science step
+ * GMOS long slit science atoms
+ *
+ * @tparam D dynamic config type
+ * @tparam G grating type
+ * @tparam F filter type
+ * @tparam U FPU type
  */
 sealed trait Science[D, G, F, U] extends SequenceState[D] {
 

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/Science.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/Science.scala
@@ -1,0 +1,110 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.gen.gmos.longslit
+
+import cats.data.NonEmptyList
+import cats.syntax.either._
+import cats.syntax.eq._
+import cats.syntax.option._
+import eu.timepit.refined.types.all.PosDouble
+import lucuma.core.`enum`.{GmosGratingOrder, GmosNorthFilter, GmosNorthFpu, GmosNorthGrating, GmosSouthFilter, GmosSouthFpu, GmosSouthGrating, ImageQuality}
+import lucuma.core.math.{Offset, Wavelength}
+import lucuma.core.math.syntax.int._
+import lucuma.core.model.SourceProfile
+import lucuma.core.optics.syntax.lens._
+import lucuma.core.optics.syntax.optional._
+import lucuma.gen.gmos.{GmosNorthInitialDynamicConfig, GmosSouthInitialDynamicConfig}
+import lucuma.gen.{SciExposureTime, SequenceState}
+import lucuma.odb.api.model.GmosModel.{DynamicOptics, GratingConfig, NorthDynamic, SouthDynamic}
+import lucuma.odb.api.model.StepConfig
+import lucuma.odb.api.model.gmos.longslit.{DeltaWavelengthCalculator, LongSlit, XBinCalculator}
+
+import scala.collection.immutable.LazyList
+
+/**
+ * GMOS long slit science step
+ */
+sealed trait Science[D, G, F, U] extends SequenceState[D] {
+
+  def optics: DynamicOptics[D, G, F, U]
+
+  def compute(
+    mode:          LongSlit[G, F, U],
+    exposureTime:  SciExposureTime,
+    λ:             Wavelength,
+    sourceProfile: SourceProfile,
+    imageQuality:  ImageQuality,
+    sampling:      PosDouble
+  )(implicit wc: DeltaWavelengthCalculator[G],
+             xb: XBinCalculator[U]
+  ): LazyList[Science.Atom[D]] = {
+
+    val p0  = Offset.P(0.arcsec)
+    val Δλs = mode.λDithers.toList
+    val qs  = mode.spatialOffsets.toList
+
+    def nextAtom(index: Int, d: D): Science.Atom[D] = {
+      val Δ = Δλs(index % Δλs.length)
+      val q = qs(index % qs.length)
+
+      (for {
+        _ <- optics.wavelength := GmosLongSlit.wavelengthDither(λ, Δ)
+        s <- scienceStep(Offset(p0, q))
+        f <- flatStep
+      } yield Science.Atom(index, s, f)).runA(d).value
+    }
+
+    val init: D =
+      (for {
+        _ <- optics.exposure      := exposureTime.value
+        _ <- optics.gratingConfig := GratingConfig(mode.grating, GmosGratingOrder.One, λ).some
+        _ <- optics.filter        := mode.filter
+        _ <- optics.fpu           := mode.fpu.asRight.some
+
+        _ <- optics.xBin          := mode.xBin(sourceProfile, imageQuality, sampling)
+        _ <- optics.yBin          := mode.yBin
+        _ <- optics.ampReadMode   := mode.ampReadMode
+        _ <- optics.ampGain       := mode.ampGain
+      } yield ()).runS(initialConfig).value
+
+    LazyList.unfold((0, init)) { case (i, d) =>
+      val a = nextAtom(i, d)
+      Some((a, (i+1, a.science.instrumentConfig)))
+    }
+  }
+
+}
+
+object Science {
+
+  /**
+   * Science and associated matching flat.
+   */
+  final case class Atom[D](
+    index:   Int,
+    science: StepConfig[D],
+    flat:    StepConfig[D]
+  ) {
+
+    def steps: NonEmptyList[StepConfig[D]] =
+      if ((index % 2) === 0) NonEmptyList.of(science, flat)
+      else NonEmptyList.of(flat, science)
+
+  }
+
+  object GmosNorth extends GmosNorthInitialDynamicConfig
+                      with Science[NorthDynamic, GmosNorthGrating, GmosNorthFilter, GmosNorthFpu] {
+
+    def optics: DynamicOptics[NorthDynamic, GmosNorthGrating, GmosNorthFilter, GmosNorthFpu] =
+      NorthDynamic
+  }
+
+  object GmosSouth extends GmosSouthInitialDynamicConfig
+                      with Science[SouthDynamic, GmosSouthGrating, GmosSouthFilter, GmosSouthFpu] {
+
+    def optics: DynamicOptics[SouthDynamic, GmosSouthGrating, GmosSouthFilter, GmosSouthFpu] =
+      SouthDynamic
+  }
+
+}

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/Science.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/Science.scala
@@ -66,6 +66,8 @@ sealed trait Science[D, G, F, U] extends SequenceState[D] {
         _ <- optics.yBin          := mode.yBin
         _ <- optics.ampReadMode   := mode.ampReadMode
         _ <- optics.ampGain       := mode.ampGain
+
+        _ <- optics.roi           := mode.roi
       } yield ()).runS(initialConfig).value
 
     LazyList.unfold((0, init)) { case (i, d) =>

--- a/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/GmosModel.scala
@@ -465,14 +465,44 @@ object GmosModel {
 
   }
 
-  sealed trait Dynamic[D, L, U] {
+  sealed trait Dynamic[G, F, U] {
     def exposure:      FiniteDuration
     def readout:       CcdReadout
     def dtax:          GmosDtax
     def roi:           GmosRoi
-    def gratingConfig: Option[GratingConfig[D]]
-    def filter:        Option[L]
+    def gratingConfig: Option[GratingConfig[G]]
+    def filter:        Option[F]
     def fpu:           Option[Either[CustomMask, U]]
+  }
+
+  sealed trait DynamicOptics[D, G, F, U] {
+    def exposure:      Lens[D, FiniteDuration]
+    def readout:       Lens[D, CcdReadout]
+
+    lazy val xBin: Lens[D, GmosXBinning] =
+      readout andThen CcdReadout.xBin
+
+    lazy val yBin: Lens[D, GmosYBinning] =
+      readout andThen CcdReadout.yBin
+
+    lazy val ampReadMode: Lens[D, GmosAmpReadMode] =
+      readout andThen CcdReadout.ampRead
+
+    lazy val ampGain: Lens[D, GmosAmpGain] =
+      readout andThen CcdReadout.ampGain
+
+    def dtax: Lens[D, GmosDtax]
+
+    def roi: Lens[D, GmosRoi]
+
+    def gratingConfig: Lens[D, Option[GratingConfig[G]]]
+
+    def wavelength: Optional[D, Wavelength]
+
+    def filter: Lens[D, Option[F]]
+
+    def fpu: Lens[D, Option[Either[CustomMask, U]]]
+
   }
 
   final case class NorthDynamic (
@@ -500,40 +530,34 @@ object GmosModel {
 
   }
 
-  sealed trait NorthDynamicOptics { self: NorthDynamic.type =>
+  sealed trait NorthDynamicOptics extends DynamicOptics[NorthDynamic, GmosNorthGrating, GmosNorthFilter, GmosNorthFpu] { self: NorthDynamic.type =>
 
-    val exposure: Lens[NorthDynamic, FiniteDuration] =
+    lazy val exposure: Lens[NorthDynamic, FiniteDuration] =
       Focus[NorthDynamic](_.exposure)
 
-    val readout: Lens[NorthDynamic, CcdReadout] =
+    lazy val readout: Lens[NorthDynamic, CcdReadout] =
       Focus[NorthDynamic](_.readout)
 
-    val xBin: Lens[NorthDynamic, GmosXBinning] =
-      readout andThen CcdReadout.xBin
-
-    val yBin: Lens[NorthDynamic, GmosYBinning] =
-      readout andThen CcdReadout.yBin
-
-    val dtax: Lens[NorthDynamic, GmosDtax] =
+    lazy val dtax: Lens[NorthDynamic, GmosDtax] =
       Focus[NorthDynamic](_.dtax)
 
-    val roi: Lens[NorthDynamic, GmosRoi] =
+    lazy val roi: Lens[NorthDynamic, GmosRoi] =
       Focus[NorthDynamic](_.roi)
 
-    val gratingConfig: Lens[NorthDynamic, Option[GratingConfig[GmosNorthGrating]]] =
+    lazy val gratingConfig: Lens[NorthDynamic, Option[GratingConfig[GmosNorthGrating]]] =
       Focus[NorthDynamic](_.gratingConfig)
 
-    val wavelength: Optional[NorthDynamic, Wavelength] =
+    lazy val wavelength: Optional[NorthDynamic, Wavelength] =
       Optional[NorthDynamic, Wavelength](
         _.gratingConfig.map(_.wavelength)
       )(
         λ => gratingConfig.modify(_.map(GratingConfig.wavelength.replace(λ)))
       )
 
-    val filter: Lens[NorthDynamic, Option[GmosNorthFilter]] =
+    lazy val filter: Lens[NorthDynamic, Option[GmosNorthFilter]] =
       Focus[NorthDynamic](_.filter)
 
-    val fpu: Lens[NorthDynamic, Option[Either[CustomMask, GmosNorthFpu]]] =
+    lazy val fpu: Lens[NorthDynamic, Option[Either[CustomMask, GmosNorthFpu]]] =
       Focus[NorthDynamic](_.fpu)
 
   }
@@ -563,40 +587,34 @@ object GmosModel {
 
   }
 
-  sealed trait SouthDynamicOptics { self: SouthDynamic.type =>
+  sealed trait SouthDynamicOptics extends DynamicOptics[SouthDynamic, GmosSouthGrating, GmosSouthFilter, GmosSouthFpu]  { self: SouthDynamic.type =>
 
-    val exposure: Lens[SouthDynamic, FiniteDuration] =
+    lazy val exposure: Lens[SouthDynamic, FiniteDuration] =
       Focus[SouthDynamic](_.exposure)
 
-    val readout: Lens[SouthDynamic, CcdReadout] =
+    lazy val readout: Lens[SouthDynamic, CcdReadout] =
       Focus[SouthDynamic](_.readout)
 
-    val xBin: Lens[SouthDynamic, GmosXBinning] =
-      readout andThen CcdReadout.xBin
-
-    val yBin: Lens[SouthDynamic, GmosYBinning] =
-      readout andThen CcdReadout.yBin
-
-    val dtax: Lens[SouthDynamic, GmosDtax] =
+    lazy val dtax: Lens[SouthDynamic, GmosDtax] =
       Focus[SouthDynamic](_.dtax)
 
-    val roi: Lens[SouthDynamic, GmosRoi] =
+    lazy val roi: Lens[SouthDynamic, GmosRoi] =
       Focus[SouthDynamic](_.roi)
 
-    val gratingConfig: Lens[SouthDynamic, Option[GratingConfig[GmosSouthGrating]]] =
+    lazy val gratingConfig: Lens[SouthDynamic, Option[GratingConfig[GmosSouthGrating]]] =
       Focus[SouthDynamic](_.gratingConfig)
 
-    val wavelength: Optional[SouthDynamic, Wavelength] =
+    lazy val wavelength: Optional[SouthDynamic, Wavelength] =
       Optional[SouthDynamic, Wavelength](
         _.gratingConfig.map(_.wavelength)
       )(
         λ => gratingConfig.modify(_.map(GratingConfig.wavelength.replace(λ)))
       )
 
-    val filter: Lens[SouthDynamic, Option[GmosSouthFilter]] =
+    lazy val filter: Lens[SouthDynamic, Option[GmosSouthFilter]] =
       Focus[SouthDynamic](_.filter)
 
-    val fpu: Lens[SouthDynamic, Option[Either[CustomMask, GmosSouthFpu]]] =
+    lazy val fpu: Lens[SouthDynamic, Option[Either[CustomMask, GmosSouthFpu]]] =
       Focus[SouthDynamic](_.fpu)
 
   }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/AdvancedConfig.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/AdvancedConfig.scala
@@ -34,6 +34,12 @@ final case class AdvancedConfig[G, F, U](
 
 object AdvancedConfig extends AdvancedConfigOptics {
 
+  val Q15: Offset.Q =
+    Offset.Q(Angle.arcseconds.reverseGet(15))
+
+  val zeroNm: Quantity[Int, Nanometer] =
+    Quantity[Int, Nanometer](0)
+
   val DefaultYBinning: GmosYBinning =
     GmosYBinning.Two
 
@@ -50,14 +56,13 @@ object AdvancedConfig extends AdvancedConfigOptics {
     grating: G
   )(
     implicit calc: DeltaWavelengthCalculator[G]
-  ): NonEmptyList[Quantity[Int, Nanometer]] =
-      NonEmptyList.of(
-        Quantity[Int, Nanometer](0),
-        calc.Δλ(grating)
-      )
+  ): NonEmptyList[Quantity[Int, Nanometer]] = {
+    val deltaNm = calc.Δλ(grating)
+    NonEmptyList.of(zeroNm, deltaNm, deltaNm, zeroNm)
+  }
 
   val DefaultSpatialOffsets: NonEmptyList[Offset.Q] =
-    NonEmptyList.of(Offset.Q.Zero, Offset.Q(Angle.arcseconds.reverseGet(15)))
+    NonEmptyList.of(Offset.Q.Zero, Q15, Q15, Offset.Q.Zero)
 
   implicit def EqAdvancedConfig[G: Eq, F: Eq, U: Eq]: Eq[AdvancedConfig[G, F, U]] =
     Eq.by { a => (

--- a/modules/core/src/main/scala/lucuma/odb/api/model/gmos/syntax/GmosNorthFilterOps.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/gmos/syntax/GmosNorthFilterOps.scala
@@ -3,13 +3,14 @@
 
 package lucuma.odb.api.model.gmos.syntax
 
+import cats.data.NonEmptyList
 import lucuma.core.`enum`.GmosNorthFilter
 import lucuma.core.`enum`.GmosNorthFilter.{GPrime, IPrime, RPrime, UPrime, ZPrime}
 
 final class GmosNorthFilterCompanionOps(val self: GmosNorthFilter.type) extends AnyVal {
 
-  def allAcquisition: List[GmosNorthFilter] =
-    List(UPrime, GPrime, RPrime, IPrime, ZPrime)
+  def allAcquisition: NonEmptyList[GmosNorthFilter] =
+    NonEmptyList.of(UPrime, GPrime, RPrime, IPrime, ZPrime)
 
 }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/gmos/syntax/GmosSouthFilterOps.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/gmos/syntax/GmosSouthFilterOps.scala
@@ -3,13 +3,14 @@
 
 package lucuma.odb.api.model.gmos.syntax
 
+import cats.data.NonEmptyList
 import lucuma.core.`enum`.GmosSouthFilter
 import lucuma.core.`enum`.GmosSouthFilter.{GPrime, IPrime, RPrime, UPrime, ZPrime}
 
 final class GmosSouthFilterCompanionOps(val self: GmosSouthFilter.type) extends AnyVal {
 
-  def allAcquisition: List[GmosSouthFilter] =
-    List(UPrime, GPrime, RPrime, IPrime, ZPrime)
+  def allAcquisition: NonEmptyList[GmosSouthFilter] =
+    NonEmptyList.of(UPrime, GPrime, RPrime, IPrime, ZPrime)
 
 }
 


### PR DESCRIPTION
Applies the values in the `AdvancedConfig`, if any, to produce GMOS long slit sequences.

Wavelength dithers and spatial offsets are now simply looped as long as necessary.  To get the standard repeating ABBA sequence the default wavelength dithers have to be 0, 5, 5, 0 nm for example and the spatial offsets 0, 15, 15, 0 arcsec.