### PR TITLE
Clone obs

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -217,6 +217,76 @@ object ObservationModel extends ObservationOptics {
 
   }
 
+  final case class CloneInput(
+    existingObservationId: Observation.Id,
+    suggestedCloneId:      Option[Observation.Id],
+    programId:             Option[Program.Id],
+    subtitle:              Option[NonEmptyString],
+    status:                Option[ObsStatus],
+    activeStatus:          Option[ObsActiveStatus],
+    targetEnvironment:     Option[TargetEnvironmentInput],
+    constraintSet:         Option[ConstraintSetInput],
+    scienceRequirements:   Option[ScienceRequirementsInput],
+    scienceMode:           Option[ScienceModeInput],
+    config:                Option[ExecutionModel.Create]
+  ) {
+
+    def clone[F[_]: Sync]: F[StateT[EitherInput, Database, ObservationModel]] =
+      config.traverse(_.create).map { g =>
+        for {
+          o <- Database.observation.lookupValidated(existingObservationId)
+          i <- Database.observation.getUnusedKey(suggestedCloneId)
+          p <- programId.traverse(Database.program.lookupValidated(_))
+          t  = targetEnvironment.traverse(_.create)
+          c  = constraintSet.traverse(_.create)
+          q  = scienceRequirements.traverse(_.create)
+          u  = scienceMode.traverse(_.create)
+          oʹ = (o, p.sequence, t, c, q, u, g.sequence).mapN { (orig, pʹ, tʹ, cʹ, qʹ, uʹ, gʹ) =>
+            ObservationModel(
+              id                   = i,
+              existence            = Present,
+              programId            = pʹ.map(_.id).getOrElse(orig.programId),
+              subtitle             = subtitle.orElse(orig.subtitle),
+              status               = status.getOrElse(orig.status),
+              activeStatus         = activeStatus.getOrElse(orig.activeStatus),
+              targetEnvironment    = tʹ.getOrElse(orig.targetEnvironment),
+              constraintSet        = cʹ.getOrElse(orig.constraintSet),
+              scienceRequirements  = qʹ.getOrElse(orig.scienceRequirements),
+              scienceMode          = uʹ.orElse(orig.scienceMode),
+              config               = gʹ.orElse(orig.config),
+              plannedTimeSummary   = orig.plannedTimeSummary  // wrong.  need to remove from observation model
+            )
+          }
+          oʹʹ <- oʹ.traverse(_.validate)
+          _   <- Database.observation.saveNewIfValid(oʹʹ)(_.id)
+          v   <- Database.observation.lookup(i)
+        } yield v
+      }
+
+  }
+
+  object CloneInput {
+
+    implicit val DecoderCloneInput: Decoder[CloneInput] =
+      deriveDecoder[CloneInput]
+
+    implicit val EqCloneInput: Eq[CloneInput] =
+      Eq.by { a => (
+        a.existingObservationId,
+        a.suggestedCloneId,
+        a.programId,
+        a.subtitle,
+        a.status,
+        a.activeStatus,
+        a.targetEnvironment,
+        a.constraintSet,
+        a.scienceRequirements,
+        a.scienceMode,
+        a.config
+      )}
+
+  }
+
   final case class ObservationEvent (
     id:       Long,
     editType: Event.EditType,

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -247,7 +247,7 @@ object ObservationModel extends ObservationOptics {
               existence            = Present,
               programId            = pʹ.map(_.id).getOrElse(orig.programId),
               subtitle             = subtitle.orElse(orig.subtitle),
-              status               = status.getOrElse(orig.status),
+              status               = status.getOrElse(ObsStatus.New),
               activeStatus         = activeStatus.getOrElse(orig.activeStatus),
               targetEnvironment    = tʹ.getOrElse(orig.targetEnvironment),
               constraintSet        = cʹ.getOrElse(orig.constraintSet),

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -41,6 +41,19 @@ trait ObservationMutation {
       "Observation description"
     )
 
+  val InputObjectTypeObservationCloneInput: InputObjectType[ObservationModel.CloneInput] =
+    deriveInputObjectType[ObservationModel.CloneInput](
+      InputObjectTypeName("CloneObservationInput"),
+      InputObjectTypeDescription("Parameters for cloning an existing observation.  Unset values will be copied from the existing observation."),
+      ExcludeInputFields("config")
+    )
+
+  val ArgumentObservationCloneInput: Argument[ObservationModel.CloneInput] =
+    InputObjectTypeObservationCloneInput.argument(
+      "input",
+      "Observation clone parameters"
+    )
+
   val InputObjectTypeObservationEdit: InputObjectType[ObservationModel.Edit] =
     deriveInputObjectType[ObservationModel.Edit](
       InputObjectTypeName("EditObservationInput"),
@@ -121,6 +134,14 @@ trait ObservationMutation {
       resolve   = c => c.observation(_.edit(c.arg(ArgumentObservationEdit)))
     )
 
+  def clone[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
+    Field(
+      name      = "cloneObservation",
+      fieldType = ObservationType[F],
+      arguments = List(ArgumentObservationCloneInput),
+      resolve   = c => c.observation(_.clone(c.arg(ArgumentObservationCloneInput)))
+    )
+
   def updateAsterism[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
       name      = "updateAsterism",
@@ -173,6 +194,7 @@ trait ObservationMutation {
     List(
       create,
       update,
+      clone,
       updateAsterism,
       updateTargetEnvironment,
       updateConstraintSet,

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -44,7 +44,7 @@ trait ObservationMutation {
   val InputObjectTypeObservationCloneInput: InputObjectType[ObservationModel.CloneInput] =
     deriveInputObjectType[ObservationModel.CloneInput](
       InputObjectTypeName("CloneObservationInput"),
-      InputObjectTypeDescription("Parameters for cloning an existing observation.  Unset values will be copied from the existing observation."),
+      InputObjectTypeDescription("Parameters for cloning an existing observation.  The existingObservationId is required, all else is optional. Unset values will be copied from the existing observation, except that status will default to NEW."),
       ExcludeInputFields("config")
     )
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/ObservationSuite.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/ObservationSuite.scala
@@ -14,5 +14,7 @@ final class ObservationSuite extends DisciplineSuite {
   import ArbObservationModel._
 
   checkAll("ObservationModel", EqTests[ObservationModel].eqv)
+  checkAll("ObservationModel.Create", EqTests[ObservationModel.Create].eqv)
+  checkAll("ObservationModel.CloneInput", EqTests[ObservationModel.CloneInput].eqv)
 
 }

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
@@ -109,6 +109,52 @@ trait ArbObservationModel {
       in.constraintSet
     )}
 
+  implicit val arbObservationModelCloneInput: Arbitrary[ObservationModel.CloneInput] =
+    Arbitrary {
+      for {
+        ex <- arbitrary[Observation.Id]
+        sg <- arbitrary[Option[Observation.Id]]
+        pd <- arbitrary[Option[Program.Id]]
+        nm <- arbitrary[Option[NonEmptyString]]
+        st <- arbitrary[Option[ObsStatus]]
+        as <- arbitrary[Option[ObsActiveStatus]]
+        ts <- arbitrary[Option[TargetEnvironmentInput]]
+        cs <- arbitrary[Option[ConstraintSetInput]]
+      } yield ObservationModel.CloneInput(
+        ex,
+        sg,
+        pd,
+        nm,
+        st,
+        as,
+        ts,
+        cs,
+        None,
+        None,
+        None
+      )
+    }
+
+  implicit val cogObservationModelCloneInput: Cogen[ObservationModel.CloneInput] =
+    Cogen[(
+      Observation.Id,
+      Option[Observation.Id],
+      Option[Program.Id],
+      Option[String],
+      Option[ObsStatus],
+      Option[ObsActiveStatus],
+      Option[TargetEnvironmentInput],
+      Option[ConstraintSetInput]
+    )].contramap { in => (
+      in.existingObservationId,
+      in.suggestedCloneId,
+      in.programId,
+      in.subtitle.map(_.value),
+      in.status,
+      in.activeStatus,
+      in.targetEnvironment,
+      in.constraintSet
+    )}
 }
 
 object ArbObservationModel extends ArbObservationModel


### PR DESCRIPTION
By request, adds a simple `cloneObservation` mutation.  The `existingObservationId` parameter is required and all others are optional.  The idea is that you get a clone (except for observation status which is reset to `NEW`) by default but can override any of the other values if desired.