### PR TITLE
Sort queries, mutations and subscriptions

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/schema/MutationType.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/MutationType.scala
@@ -19,12 +19,13 @@ object MutationType {
   ): ObjectType[OdbCtx[F], Unit] =
     ObjectType(
       name   = "Mutation",
-      fields =
+      fields = (
         ProgramMutation.allFields[F]                 ++
         ObservationMutation.allFields[F]             ++
         TargetMutation.allFields[F]                  ++
         ExecutionEventMutation.allFields[F](testing) ++
         DatasetMutation.allFields[F]
+      ).sortBy(_.name)
     )
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/QueryType.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/QueryType.scala
@@ -17,11 +17,12 @@ object QueryType {
   def apply[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], Unit] =
     ObjectType(
       name   = "Query",
-      fields =
+      fields = (
         ObservationQuery.allFields[F]   ++
         ProgramQuery.allFields[F]       ++
         TargetQuery.allFields[F]        ++
         DatasetQuery.allFields[F]
+      ).sortBy(_.name)
     )
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SubscriptionType.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SubscriptionType.scala
@@ -164,12 +164,6 @@ object SubscriptionType {
           _.value.id
         ) { (_, e) => Set(e.value.programId).pure[F] },
 
-        editedField[F, Target.Id, TargetModel, TargetEvent](
-          "target",
-          ArgumentOptionalTargetId,
-          _.value.id
-        ) { (_, e) => Set(e.value.programId).pure[F] },
-
         // ProgramEvent handled differently.  It would not make sense to
         // filter on program id twice.
         subscriptionField[F, ProgramEvent](
@@ -181,7 +175,13 @@ object SubscriptionType {
             |""".stripMargin,
           EditEventType[F, ProgramModel, ProgramEvent]("ProgramEdit"),
           List(OptionalProgramIdArgument)
-        ) { (c, e) => c.optionalProgramId.fold(true)(_ === e.value.id).pure[F] }
+        ) { (c, e) => c.optionalProgramId.fold(true)(_ === e.value.id).pure[F] },
+
+        editedField[F, Target.Id, TargetModel, TargetEvent](
+          "target",
+          ArgumentOptionalTargetId,
+          _.value.id
+        ) { (_, e) => Set(e.value.programId).pure[F] }
 
       )
     )


### PR DESCRIPTION
No actual API update, just sorts the order by name so that they appear sorted in the playground.