### PR TITLE
Event API Standardization

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ExecutionEventModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ExecutionEventModel.scala
@@ -206,16 +206,30 @@ object ExecutionEventModel {
         a.stepId,
         a.received,
         a.sequenceType,
-        a.stage,
+        a.stage
       )}
+
+    final case class Payload(
+      sequenceType:  SequenceModel.SequenceType,
+      stage:         StepStageType
+    )
+
+    object Payload {
+      implicit val DecoderPayload: Decoder[Payload] =
+        deriveDecoder[Payload]
+
+      implicit val OrderPayload: Order[Payload] =
+        Order.by { a => (
+          a.sequenceType,
+          a.stage
+        )}
+    }
 
     final case class Add(
       observationId: Observation.Id,
       visitId:       Visit.Id,
       stepId:        Step.Id,
-
-      sequenceType:  SequenceModel.SequenceType,
-      stage:         StepStageType
+      payload:       Payload
     ) {
 
       def add(
@@ -233,8 +247,8 @@ object ExecutionEventModel {
               visitId,
               stepId,
               received,
-              sequenceType,
-              stage
+              payload.sequenceType,
+              payload.stage
             )
           _ <- Database.executionEvent.saveNew(i, e)
         } yield e
@@ -251,8 +265,7 @@ object ExecutionEventModel {
           a.observationId,
           a.visitId,
           a.stepId,
-          a.sequenceType,
-          a.stage
+          a.payload
         )}
 
     }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/StepRecord.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/StepRecord.scala
@@ -87,7 +87,7 @@ object StepRecord {
       ).getOrElse(0.nanoseconds)
 
     def isExecuted: Boolean =
-      stepEvents.exists(_.stage === ExecutionEventModel.StepStageType.EndStep)
+      stepEvents.exists(_.payload.stage === ExecutionEventModel.StepStageType.EndStep)
 
     def qaState: Option[StepQaState] =
       StepQaState.rollup(datasets.map(_.dataset.qaState))
@@ -96,7 +96,7 @@ object StepRecord {
      * Whether this is an acquisition or science step.
      */
     def sequenceType: SequenceModel.SequenceType =
-      stepEvents.map(_.sequenceType).distinct match {
+      stepEvents.map(_.payload.sequenceType).distinct match {
         case List(t) => t
         case _       => SequenceModel.SequenceType.Science
       }

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ExecutionEventRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ExecutionEventRepo.scala
@@ -147,7 +147,7 @@ object ExecutionEventRepo {
           e match {
             case _: SequenceEvent => m
             case d: DatasetEvent  => m.updatedWith(d.location.stepId)(_.map(x => StepRecord.Output.datasetEvents.modify(_ :+ d)(x)))
-            case s: StepEvent     => m.updatedWith(s.stepId)(_.map(x => StepRecord.Output.stepEvents.modify(_ :+ s)(x)))
+            case s: StepEvent     => m.updatedWith(s.location.stepId)(_.map(x => StepRecord.Output.stepEvents.modify(_ :+ s)(x)))
           }
         }
 
@@ -167,7 +167,7 @@ object ExecutionEventRepo {
 
         val events  = sortedEvents(db) {
           case SequenceEvent(_, o, _, _, _)                       => o === oid
-          case StepEvent(_, o, _, s, _, _, _)                     => o === oid && s === stepId
+          case StepEvent(_, _, _, StepEvent.Location(o, s), _)    => o === oid && s === stepId
           case DatasetEvent(_, _, _, DatasetModel.Id(o, s, _), _) => o === oid && s === stepId
         }
 
@@ -297,7 +297,7 @@ object ExecutionEventRepo {
       ): F[ResultPage[StepEvent]] =
         databaseRef.get.map { db =>
           val events = sortedEvents(db)(_.observationId === oid).collect {
-            case s @ StepEvent(_, _, _, _, _, _, _) => s
+            case s @ StepEvent(_, _, _, _, _) => s
           }
           ResultPage.fromSeq(events, count, afterGid, _.id)
         }

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ExecutionEventRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ExecutionEventRepo.scala
@@ -166,9 +166,9 @@ object ExecutionEventRepo {
       ): Option[StepRecord.Output[D]] = {
 
         val events  = sortedEvents(db) {
-          case SequenceEvent(_, o, _, _, _)                       => o === oid
-          case StepEvent(_, _, _, StepEvent.Location(o, s), _)    => o === oid && s === stepId
-          case DatasetEvent(_, _, _, DatasetModel.Id(o, s, _), _) => o === oid && s === stepId
+          case SequenceEvent(_, _, _, SequenceEvent.Location(o), _) => o === oid
+          case StepEvent(_, _, _, StepEvent.Location(o, s), _)      => o === oid && s === stepId
+          case DatasetEvent(_, _, _, DatasetModel.Id(o, s, _), _)   => o === oid && s === stepId
         }
 
         val stepRec = Database.visitRecordsAt(oid).get(db).toList.flatMap { vrs =>

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ExecutionEventRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ExecutionEventRepo.scala
@@ -8,7 +8,7 @@ import cats.implicits.catsKernelOrderingForOrder
 import cats.syntax.all._
 import cats.effect.{Clock, Ref, Sync}
 import lucuma.core.`enum`.Instrument
-import lucuma.odb.api.model.{Database, DatasetModel, DatasetTable, EitherInput, ExecutionEventModel, InputValidator, Step, StepRecord, ValidatedInput, Visit, VisitRecord, VisitRecords}
+import lucuma.odb.api.model.{Database, DatasetTable, EitherInput, ExecutionEventModel, InputValidator, Step, StepRecord, ValidatedInput, Visit, VisitRecord, VisitRecords}
 import lucuma.odb.api.model.ExecutionEventModel.{DatasetEvent, SequenceEvent, StepEvent}
 import lucuma.odb.api.model.syntax.databasestate._
 import lucuma.odb.api.model.syntax.eitherinput._
@@ -166,9 +166,9 @@ object ExecutionEventRepo {
       ): Option[StepRecord.Output[D]] = {
 
         val events  = sortedEvents(db) {
-          case SequenceEvent(_, _, _, SequenceEvent.Location(o), _) => o === oid
-          case StepEvent(_, _, _, StepEvent.Location(o, s), _)      => o === oid && s === stepId
-          case DatasetEvent(_, _, _, DatasetModel.Id(o, s, _), _)   => o === oid && s === stepId
+          case SequenceEvent(_, _, _, SequenceEvent.Location(o), _)     => o === oid
+          case StepEvent(_, _, _, StepEvent.Location(o, s), _)          => o === oid && s === stepId
+          case DatasetEvent(_, _, _, DatasetEvent.Location(o, s, _), _) => o === oid && s === stepId
         }
 
         val stepRec = Database.visitRecordsAt(oid).get(db).toList.flatMap { vrs =>

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/DatasetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/DatasetMutation.scala
@@ -5,16 +5,25 @@ package lucuma.odb.api.schema
 
 import cats.effect.Async
 import cats.effect.std.Dispatcher
+import lucuma.odb.api.model.DatasetModel
 import lucuma.odb.api.repo.OdbCtx
 import org.typelevel.log4cats.Logger
+import sangria.macros.derive._
 import sangria.schema._
 
 trait DatasetMutation {
 
   import DatasetSchema.{ArgumentDatasetQaState, ArgumentOptionalDatasetIndex, DatasetType}
-  import ObservationSchema.ObservationIdArgument
-  import StepSchema.ArgumentOptionalStepId
+  import ObservationSchema.{ObservationIdArgument, ObservationIdType}
+  import RefinedSchema.InputObjectPosInt
+  import StepSchema.{ArgumentOptionalStepId, StepIdType}
   import context._
+
+  implicit val InputObjectTypeDatasetId: InputObjectType[DatasetModel.Id] =
+    deriveInputObjectType[DatasetModel.Id](
+      InputObjectTypeName("DatasetModelIdInput"),
+      InputObjectTypeDescription("Dataset model id creation parameters")
+    )
 
   def setDatasetQaState[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
@@ -204,6 +204,12 @@ trait ExecutionEventMutation {
 
   // StepEvent ----------------------------------------------------------------
 
+  implicit val InputObjectTypeStepEventPayload: InputObjectType[StepEvent.Payload] =
+    deriveInputObjectType[StepEvent.Payload](
+      InputObjectTypeName("StepEventPayloadInput"),
+      InputObjectTypeDescription("StepEvent creation payload parameters")
+    )
+
   val InputObjectTypeStepEventAdd: InputObjectType[StepEvent.Add] =
     deriveInputObjectType[StepEvent.Add](
       InputObjectTypeName("AddStepEventInput"),

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
@@ -201,16 +201,27 @@ trait ExecutionEventMutation {
 
   val ArgumentSequenceEventAdd: Argument[SequenceEvent.Add] =
     InputObjectTypeSequenceEventAdd.argument(
-      "input",
-      "Sequence event description"
+      name        = "input",
+      description =
+      """Describes the sequence event to add.  All events are associated with a
+        |particular visit (see 'record{InstrumentName}Visit').  Sequence events
+        |are further associated with an observation (i.e., its 'location').
+        |Each sequence event 'payload' identifies the sequence command that
+        |acted upon the sequence.
+      """.stripMargin
     )
 
   def addSequenceEvent[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name      = "addSequenceEvent",
-      fieldType = SequenceEventType[F],
-      arguments = List(ArgumentSequenceEventAdd),
-      resolve   = c => c.executionEvent(_.insertSequenceEvent(c.arg(ArgumentSequenceEventAdd)))
+      name        = "addSequenceEvent",
+      description =
+      """Adds a sequence event associated with the given visit. Multiple events
+        |will be produced during the execution of a sequence as it is started,
+        |paused, continued, etc.
+      """.stripMargin.some,
+      fieldType   = SequenceEventType[F],
+      arguments   = List(ArgumentSequenceEventAdd),
+      resolve     = c => c.executionEvent(_.insertSequenceEvent(c.arg(ArgumentSequenceEventAdd)))
     )
 
 
@@ -236,16 +247,28 @@ trait ExecutionEventMutation {
 
   val ArgumentStepEventAdd: Argument[StepEvent.Add] =
     InputObjectTypeStepEventAdd.argument(
-      "input",
-      "Step event description"
+      name        = "input",
+      description =
+      """Describes the step event to add.  All events are associated with a
+        |particular visit (see 'record{InstrumentName}Visit'.  Step events are
+        |further associated with an observation and step (i.e., its 'location').
+        |(See also 'record{InstrumentName}Step'.) Each step event 'payload'
+        |identifies the sequence type (acquisition or science) and the stage
+        |through which the step execution is passing.
+      """.stripMargin
     )
 
   def addStepEvent[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name      = "addStepEvent",
-      fieldType = StepEventType[F],
-      arguments = List(ArgumentStepEventAdd),
-      resolve   = c => c.executionEvent(_.insertStepEvent(c.arg(ArgumentStepEventAdd)))
+      name        = "addStepEvent",
+      description =
+      """Adds a new step event associated with the given visit. Multiple events
+        |will be produced during the execution of a single step as it
+        |transitions through configure and observe stages.
+      """.stripMargin.some,
+      fieldType   = StepEventType[F],
+      arguments   = List(ArgumentStepEventAdd),
+      resolve     = c => c.executionEvent(_.insertStepEvent(c.arg(ArgumentStepEventAdd)))
     )
 
 
@@ -271,16 +294,29 @@ trait ExecutionEventMutation {
 
   val ArgumentDatasetEventAdd: Argument[DatasetEvent.Add] =
     InputObjectTypeDatasetEventAdd.argument(
-      "input",
-      "Dataset event description"
+      name        = "input",
+      description =
+      """Describes the dataset event to add.  All events are associated with a
+        |particular visit (see 'record{InstrumentName}Visit').  Dataset events
+        |are further associated with an |observation, step and index because a
+        |step may produce multiple datasets.  The three form its 'location'.
+        |(See also 'record{InstrumentName}Step'.) Each dataset event 'payload'
+        |identifies the stage (observe, readout, or write) and possibly the
+        |dataset filename.
+      """.stripMargin
     )
 
   def addDatasetEvent[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name      = "addDatasetEvent",
-      fieldType = DatasetEventType[F],
-      arguments = List(ArgumentDatasetEventAdd),
-      resolve   = c => c.executionEvent(_.insertDatasetEvent(c.arg(ArgumentDatasetEventAdd)))
+      name        = "addDatasetEvent",
+      description =
+      """Adds a new dataset event associated with the given visit.  The
+        |generation of a single dataset will produce multiple events as it
+        |transitions through the observe, readout and write stages.
+      """.stripMargin.some,
+      fieldType   = DatasetEventType[F],
+      arguments   = List(ArgumentDatasetEventAdd),
+      resolve     = c => c.executionEvent(_.insertDatasetEvent(c.arg(ArgumentDatasetEventAdd)))
     )
 
   // --------------------------------------------------------------------------

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
@@ -181,6 +181,12 @@ trait ExecutionEventMutation {
 
   // SequenceEvent ------------------------------------------------------------
 
+  implicit val InputObjectTypeSequenceEventPayload: InputObjectType[SequenceEvent.Payload] =
+    deriveInputObjectType[SequenceEvent.Payload](
+      InputObjectTypeName("SequenceEventPayloadInput"),
+      InputObjectTypeDescription("SequenceEvent payload creation parameters")
+    )
+
   val InputObjectTypeSequenceEventAdd: InputObjectType[SequenceEvent.Add] =
     deriveInputObjectType[SequenceEvent.Add](
       InputObjectTypeName("AddSequenceEventInput"),
@@ -207,7 +213,7 @@ trait ExecutionEventMutation {
   implicit val InputObjectTypeStepEventPayload: InputObjectType[StepEvent.Payload] =
     deriveInputObjectType[StepEvent.Payload](
       InputObjectTypeName("StepEventPayloadInput"),
-      InputObjectTypeDescription("StepEvent creation payload parameters")
+      InputObjectTypeDescription("StepEvent payload parameters")
     )
 
   val InputObjectTypeStepEventAdd: InputObjectType[StepEvent.Add] =
@@ -236,7 +242,7 @@ trait ExecutionEventMutation {
   implicit val InputObjectTypeDatasetEventPayload: InputObjectType[DatasetEvent.Payload] =
     deriveInputObjectType[DatasetEvent.Payload](
       InputObjectTypeName("DatasetEventPayloadInput"),
-      InputObjectTypeDescription("DatasetEvent creation payload parameters")
+      InputObjectTypeDescription("DatasetEvent payload parameters")
     )
 
   val InputObjectTypeDatasetEventAdd: InputObjectType[DatasetEvent.Add] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
@@ -25,10 +25,10 @@ import scala.collection.immutable.ListMap
 trait ExecutionEventMutation {
 
   import DatasetSchema.DatasetFilenameScalar
-  import DatasetMutation.InputObjectTypeDatasetId
   import ExecutionEventSchema.{DatasetEventType, EnumTypeDatasetStage, EnumTypeSequenceCommand, EnumTypeStepStage, SequenceEventType, StepEventType}
   import ExecutionEventModel.{DatasetEvent, SequenceEvent, StepEvent}
   import ObservationSchema.ObservationIdType
+  import RefinedSchema.InputObjectPosInt
   import SequenceSchema.EnumTypeSequenceType
   import StepMutation.InputObjectTypeCreateStepConfig
   import StepSchema.{ArgumentStepId, StepIdType}
@@ -250,6 +250,12 @@ trait ExecutionEventMutation {
 
 
   // DatasetEvent -------------------------------------------------------------
+
+  implicit val InputObjectTypeDatasetEventLocation: InputObjectType[DatasetEvent.Location] =
+    deriveInputObjectType[DatasetEvent.Location](
+      InputObjectTypeName("DatasetEventLocationInput"),
+      InputObjectTypeDescription("DatasetEvent location parameters")
+    )
 
   implicit val InputObjectTypeDatasetEventPayload: InputObjectType[DatasetEvent.Payload] =
     deriveInputObjectType[DatasetEvent.Payload](

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
@@ -25,10 +25,10 @@ import scala.collection.immutable.ListMap
 trait ExecutionEventMutation {
 
   import DatasetSchema.DatasetFilenameScalar
+  import DatasetMutation.InputObjectTypeDatasetId
   import ExecutionEventSchema.{DatasetEventType, EnumTypeDatasetStage, EnumTypeSequenceCommand, EnumTypeStepStage, SequenceEventType, StepEventType}
   import ExecutionEventModel.{DatasetEvent, SequenceEvent, StepEvent}
   import ObservationSchema.ObservationIdType
-  import RefinedSchema.InputObjectPosInt
   import SequenceSchema.EnumTypeSequenceType
   import StepMutation.InputObjectTypeCreateStepConfig
   import StepSchema.{ArgumentStepId, StepIdType}

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
@@ -227,6 +227,12 @@ trait ExecutionEventMutation {
 
   // DatasetEvent -------------------------------------------------------------
 
+  implicit val InputObjectTypeDatasetEventPayload: InputObjectType[DatasetEvent.Payload] =
+    deriveInputObjectType[DatasetEvent.Payload](
+      InputObjectTypeName("DatasetEventPayloadInput"),
+      InputObjectTypeDescription("DatasetEvent creation payload parameters")
+    )
+
   val InputObjectTypeDatasetEventAdd: InputObjectType[DatasetEvent.Add] =
     deriveInputObjectType[DatasetEvent.Add](
       InputObjectTypeName("AddDatasetEventInput"),

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
@@ -181,6 +181,12 @@ trait ExecutionEventMutation {
 
   // SequenceEvent ------------------------------------------------------------
 
+  implicit val InputObjectTypeSequenceEventLocation: InputObjectType[SequenceEvent.Location] =
+    deriveInputObjectType[SequenceEvent.Location](
+      InputObjectTypeName("SequenceEventLocationInput"),
+      InputObjectTypeDescription("SequenceEvent location parameters")
+    )
+
   implicit val InputObjectTypeSequenceEventPayload: InputObjectType[SequenceEvent.Payload] =
     deriveInputObjectType[SequenceEvent.Payload](
       InputObjectTypeName("SequenceEventPayloadInput"),

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
@@ -210,6 +210,12 @@ trait ExecutionEventMutation {
 
   // StepEvent ----------------------------------------------------------------
 
+  implicit val InputObjectTypeStepEventLocation: InputObjectType[StepEvent.Location] =
+    deriveInputObjectType[StepEvent.Location](
+      InputObjectTypeName("StepEventLocationInput"),
+      InputObjectTypeDescription("StepEvent location parameters")
+    )
+
   implicit val InputObjectTypeStepEventPayload: InputObjectType[StepEvent.Payload] =
     deriveInputObjectType[StepEvent.Payload](
       InputObjectTypeName("StepEventPayloadInput"),

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventSchema.scala
@@ -104,7 +104,7 @@ object ExecutionEventSchema {
   val SequenceEventLocationType: ObjectType[Any, SequenceEvent.Location] =
     ObjectType[Any, SequenceEvent.Location](
       name        = "SequenceEventLocation",
-      description = "Sequence event location, i.e., to which observation the event refers",
+      description = "Sequence event location, i.e., to which observation the event refers.",
       fields      = List[Field[Any, SequenceEvent.Location]](
 
         Field(
@@ -134,7 +134,7 @@ object ExecutionEventSchema {
   def SequenceEventType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], SequenceEvent] =
     ObjectType[OdbCtx[F], SequenceEvent](
       name        = "SequenceEvent",
-      description = "Sequence-level events",
+      description = "Sequence-level events.  As commands are issued to execute a sequence, corresponding events are generated.",
       interfaces  = List(PossibleInterface.apply[OdbCtx[F], SequenceEvent](ExecutionEventType[F])),
       fields      = List[Field[OdbCtx[F], SequenceEvent]](
 
@@ -195,7 +195,7 @@ object ExecutionEventSchema {
         Field(
           name        = "stage",
           fieldType   = EnumTypeStepStage,
-          description = Some("Step stage"),
+          description = Some("Step execution stage"),
           resolve     = _.value.stage
         )
       )
@@ -205,7 +205,7 @@ object ExecutionEventSchema {
   def StepEventType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], StepEvent] =
     ObjectType[OdbCtx[F], StepEvent](
       name        = "StepEvent",
-      description = "Step-level events",
+      description = "Step-level events.  The execution of a single step will generate multiple events.",
       interfaces  = List(PossibleInterface.apply[OdbCtx[F], StepEvent](ExecutionEventType[F])),
       fields      = List[Field[OdbCtx[F], StepEvent]](
 
@@ -219,7 +219,7 @@ object ExecutionEventSchema {
         Field(
           name        = "payload",
           fieldType   = StepEventPayloadType,
-          description = "Step event data".some,
+          description = "Step event data including the stage of execution through which it is passing.".some,
           resolve     = _.value.payload
         )
 
@@ -229,7 +229,7 @@ object ExecutionEventSchema {
   val DatasetEventLocationType: ObjectType[Any, DatasetEvent.Location] =
     ObjectType[Any, DatasetEvent.Location](
       name        = "DatasetEventLocation",
-      description = "Dataset event location",
+      description = "Dataset event location, pinpointing the observation, step and index of the associated dataset.",
       fields      = List[Field[Any, DatasetEvent.Location]](
         Field(
           name        = "observationId",
@@ -257,7 +257,7 @@ object ExecutionEventSchema {
   val DatasetEventPayloadType: ObjectType[Any, DatasetEvent.Payload] =
     ObjectType[Any, DatasetEvent.Payload](
       name        = "DatasetEventPayload",
-      description = "Dataset event payload",
+      description = "Dataset event payload.",
       fields      = List[Field[Any, DatasetEvent.Payload]](
 
         Field(
@@ -270,7 +270,7 @@ object ExecutionEventSchema {
         Field(
           name        = "stage",
           fieldType   = EnumTypeDatasetStage,
-          description = Some("Dataset stage"),
+          description = Some("Dataset execution stage"),
           resolve     = _.value.stage
         )
       )
@@ -279,7 +279,7 @@ object ExecutionEventSchema {
   def DatasetEventType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], DatasetEvent] =
     ObjectType[OdbCtx[F], DatasetEvent](
       name        = "DatasetEvent",
-      description = "Dataset-level events",
+      description = "Dataset-level events.  A single dataset will be associated with multiple events.",
       interfaces  = List(PossibleInterface.apply[OdbCtx[F], DatasetEvent](ExecutionEventType[F])),
       fields      = List[Field[OdbCtx[F], DatasetEvent]](
 
@@ -293,7 +293,7 @@ object ExecutionEventSchema {
         Field(
           name        = "payload",
           fieldType   = DatasetEventPayloadType,
-          description = "Dataset event payload".some,
+          description = "Dataset event payload, identifying the associated filename and stage of dataset execution".some,
           resolve     = _.value.payload
         )
       )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventSchema.scala
@@ -100,6 +100,36 @@ object ExecutionEventSchema {
       PossibleObject[OdbCtx[F], ExecutionEventModel](DatasetEventType[F])
     ))
 
+  val SequenceEventLocationType: ObjectType[Any, SequenceEvent.Location] =
+    ObjectType[Any, SequenceEvent.Location](
+      name        = "SequenceEventLocation",
+      description = "Sequence event location, i.e., to which observation the event refers",
+      fields      = List[Field[Any, SequenceEvent.Location]](
+
+        Field(
+          name        = "observationId",
+          fieldType   = ObservationIdType,
+          description = "Observation containing the sequence".some,
+          resolve     = _.value.observationId
+        )
+
+      )
+    )
+
+  val SequenceEventPayloadType: ObjectType[Any, SequenceEvent.Payload] =
+    ObjectType[Any, SequenceEvent.Payload](
+      name        = "SequenceEventPayload",
+      description = "Sequence event data",
+      fields      = List[Field[Any, SequenceEvent.Payload]](
+        Field(
+          name        = "command",
+          fieldType   = EnumTypeSequenceCommand,
+          description = Some("Sequence command"),
+          resolve     = _.value.command
+        )
+      )
+    )
+
   def SequenceEventType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], SequenceEvent] =
     ObjectType[OdbCtx[F], SequenceEvent](
       name        = "SequenceEvent",
@@ -108,10 +138,17 @@ object ExecutionEventSchema {
       fields      = List[Field[OdbCtx[F], SequenceEvent]](
 
         Field(
-          name        = "command",
-          fieldType   = EnumTypeSequenceCommand,
-          description = Some("Sequence command"),
-          resolve     = _.value.command
+          name        = "location",
+          fieldType   = SequenceEventLocationType,
+          description = "Identifies the observation to which the event refers".some,
+          resolve     = _.value.location
+        ),
+
+        Field(
+          name        = "payload",
+          fieldType   = SequenceEventPayloadType,
+          description = "Sequence event data".some,
+          resolve     = _.value.payload
         )
 
       )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventSchema.scala
@@ -20,6 +20,7 @@ object ExecutionEventSchema {
   import TimeSchema._
   import ExecutionEventModel._
   import ObservationSchema.ObservationIdType
+  import RefinedSchema.PosIntType
   import StepSchema.StepIdType
   import VisitRecordSchema.VisitIdType
   import syntax.`enum`._
@@ -225,6 +226,34 @@ object ExecutionEventSchema {
       )
     )
 
+  val DatasetEventLocationType: ObjectType[Any, DatasetEvent.Location] =
+    ObjectType[Any, DatasetEvent.Location](
+      name        = "DatasetEventLocation",
+      description = "Dataset event location",
+      fields      = List[Field[Any, DatasetEvent.Location]](
+        Field(
+          name        = "observationId",
+          fieldType   = ObservationIdType,
+          description = "Observation ID".some,
+          resolve     = _.value.observationId
+        ),
+
+        Field(
+          name        = "stepId",
+          fieldType   = StepIdType,
+          description = "Step ID".some,
+          resolve     = _.value.stepId
+        ),
+
+        Field(
+          name        = "index",
+          fieldType   = PosIntType,
+          description = "Dataset index".some,
+          resolve     = _.value.index
+        )
+      )
+    )
+
   val DatasetEventPayloadType: ObjectType[Any, DatasetEvent.Payload] =
     ObjectType[Any, DatasetEvent.Payload](
       name        = "DatasetEventPayload",
@@ -256,9 +285,9 @@ object ExecutionEventSchema {
 
         Field(
           name        = "location",
-          fieldType   = DatasetSchema.DatasetIdType,
+          fieldType   = DatasetEventLocationType,
           description = "Identifies the associated dataset".some,
-          resolve     = _.value.datasetId
+          resolve     = _.value.location
         ),
 
         Field(

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbDatabase.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbDatabase.scala
@@ -177,7 +177,7 @@ trait ArbDatabase extends SplitSetHelper {
           sids           = visits(vid).steps.keys.take(sidsSize).toList
 
           stpCnts       <- sids.traverse(tinySize.tupleRight)
-          stpEvents     <- stpCnts.flatTraverse { case (cnt, sid) => Gen.listOfN(cnt, arbStepEventAdd(oid, vid, sid, Science).arbitrary) }
+          stpEvents     <- stpCnts.flatTraverse { case (cnt, sid) => Gen.listOfN(cnt, arbStepEventAdd(vid, oid, sid, Science).arbitrary) }
 
           dstCnts       <- sids.traverse(tinySize.tupleRight)
           dstEvents     <- dstCnts.flatTraverse { case (cnt, sid) => Gen.listOfN(cnt, arbDatasetEventAdd(oid, vid, sid).arbitrary) }

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
@@ -80,40 +80,39 @@ trait ArbExecutionEventModel {
         rec <- arbitrary[Instant]
         tpe <- arbitrary[SequenceModel.SequenceType]
         sge <- arbitrary[StepStageType]
-      } yield StepEvent(id, oid, vid, sid, rec, tpe, sge)
+      } yield StepEvent(id, vid, rec, StepEvent.Location(oid, sid), StepEvent.Payload(tpe, sge))
     }
 
   implicit val cogStepEvent: Cogen[StepEvent] =
     Cogen[(
       ExecutionEvent.Id,
-      Observation.Id,
       Visit.Id,
-      Step.Id,
       Instant,
+      Observation.Id,
+      Step.Id,
       SequenceModel.SequenceType,
       StepStageType
     )].contramap { a => (
       a.id,
-      a.observationId,
       a.visitId,
-      a.stepId,
       a.received,
-      a.sequenceType,
-      a.stage
+      a.location.observationId,
+      a.location.stepId,
+      a.payload.sequenceType,
+      a.payload.stage
     )}
 
   def arbStepEventAdd(
-    oid: Observation.Id,
     vid: Visit.Id,
+    oid: Observation.Id,
     sid: Step.Id,
     stp: SequenceModel.SequenceType
   ): Arbitrary[StepEvent.Add] =
     Arbitrary {
       arbitrary[StepStageType].map { cmd =>
         StepEvent.Add(
-          oid,
           vid,
-          sid,
+          StepEvent.Location(oid, sid),
           StepEvent.Payload(stp, cmd)
         )
       }

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
@@ -131,7 +131,7 @@ trait ArbExecutionEventModel {
         idx <- arbitrary[PosInt]
         fnm <- arbitrary[Option[DatasetFilename]]
         sge <- arbitrary[DatasetStageType]
-      } yield DatasetEvent(id, oid, vid, sid, rec, idx, fnm, sge)
+      } yield DatasetEvent(id, oid, vid, sid, rec, idx,  sge, fnm)
     }
 
   implicit val cogDatasetEvent: Cogen[DatasetEvent] =
@@ -169,8 +169,7 @@ trait ArbExecutionEventModel {
         vid,
         sid,
         PosInt.MinValue,
-        fnm,
-        cmd
+        DatasetEvent.Payload(cmd, fnm)
       )
     }
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
@@ -66,7 +66,7 @@ trait ArbExecutionEventModel {
   ): Arbitrary[SequenceEvent.Add] =
     Arbitrary {
       arbitrary[SequenceCommandType].map { cmd =>
-        SequenceEvent.Add(oid, vid, cmd)
+        SequenceEvent.Add(oid, vid, SequenceEvent.Payload(cmd))
       }
     }
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
@@ -123,35 +123,35 @@ trait ArbExecutionEventModel {
     Arbitrary {
       for {
         id  <- arbitrary[ExecutionEvent.Id]
-        oid <- arbitrary[Observation.Id]
         vid <- arbitrary[Visit.Id]
-        sid <- arbitrary[Step.Id]
         rec <- arbitrary[Instant]
+        oid <- arbitrary[Observation.Id]
+        sid <- arbitrary[Step.Id]
         idx <- arbitrary[PosInt]
-        fnm <- arbitrary[Option[DatasetFilename]]
         sge <- arbitrary[DatasetStageType]
-      } yield DatasetEvent(id, oid, vid, sid, rec, idx,  sge, fnm)
+        fnm <- arbitrary[Option[DatasetFilename]]
+      } yield DatasetEvent(id, vid, rec, DatasetModel.Id(oid, sid, idx),  DatasetEvent.Payload(sge, fnm))
     }
 
   implicit val cogDatasetEvent: Cogen[DatasetEvent] =
     Cogen[(
       ExecutionEvent.Id,
-      Observation.Id,
       Visit.Id,
-      Step.Id,
       Instant,
+      Observation.Id,
+      Step.Id,
       Int,
-      Option[DatasetFilename],
-      DatasetStageType
+      DatasetStageType,
+      Option[DatasetFilename]
     )].contramap { in => (
       in.id,
-      in.observationId,
       in.visitId,
-      in.stepId,
       in.received,
-      in.datasetIndex.value,
-      in.filename,
-      in.stageType
+      in.location.observationId,
+      in.location.stepId,
+      in.location.index.value,
+      in.payload.stage,
+      in.payload.filename
     )}
 
   def arbDatasetEventAdd(
@@ -164,10 +164,8 @@ trait ArbExecutionEventModel {
         fnm <- arbitrary[Option[DatasetFilename]]
         cmd <- arbitrary[DatasetStageType]
       } yield DatasetEvent.Add(
-        oid,
         vid,
-        sid,
-        PosInt.MinValue,
+        DatasetModel.Id(oid, sid, PosInt.MinValue),
         DatasetEvent.Payload(cmd, fnm)
       )
     }

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
@@ -114,8 +114,7 @@ trait ArbExecutionEventModel {
           oid,
           vid,
           sid,
-          stp,
-          cmd
+          StepEvent.Payload(stp, cmd)
         )
       }
     }

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
@@ -129,7 +129,7 @@ trait ArbExecutionEventModel {
         idx <- arbitrary[PosInt]
         sge <- arbitrary[DatasetStageType]
         fnm <- arbitrary[Option[DatasetFilename]]
-      } yield DatasetEvent(id, vid, rec, DatasetModel.Id(oid, sid, idx),  DatasetEvent.Payload(sge, fnm))
+      } yield DatasetEvent(id, vid, rec, DatasetEvent.Location(oid, sid, idx),  DatasetEvent.Payload(sge, fnm))
     }
 
   implicit val cogDatasetEvent: Cogen[DatasetEvent] =
@@ -164,7 +164,7 @@ trait ArbExecutionEventModel {
         cmd <- arbitrary[DatasetStageType]
       } yield DatasetEvent.Add(
         vid,
-        DatasetModel.Id(oid, sid, PosInt.MinValue),
+        DatasetEvent.Location(oid, sid, PosInt.MinValue),
         DatasetEvent.Payload(cmd, fnm)
       )
     }

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExecutionEventModel.scala
@@ -38,26 +38,26 @@ trait ArbExecutionEventModel {
     Arbitrary {
       for {
         id  <- arbitrary[ExecutionEvent.Id]
-        oid <- arbitrary[Observation.Id]
         vid <- arbitrary[Visit.Id]
         rec <- arbitrary[Instant]
+        oid <- arbitrary[Observation.Id]
         cmd <- arbitrary[SequenceCommandType]
-      } yield SequenceEvent(id, oid, vid, rec, cmd)
+      } yield SequenceEvent(id, vid, rec, SequenceEvent.Location(oid), SequenceEvent.Payload(cmd))
     }
 
   implicit val cogSequenceEvent: Cogen[SequenceEvent] =
     Cogen[(
       ExecutionEvent.Id,
-      Observation.Id,
       Visit.Id,
       Instant,
+      Observation.Id,
       SequenceCommandType
     )].contramap { a => (
       a.id,
-      a.observationId,
       a.visitId,
       a.received,
-      a.command
+      a.location.observationId,
+      a.payload.command
     )}
 
   def arbSequenceEventAdd(
@@ -66,7 +66,7 @@ trait ArbExecutionEventModel {
   ): Arbitrary[SequenceEvent.Add] =
     Arbitrary {
       arbitrary[SequenceCommandType].map { cmd =>
-        SequenceEvent.Add(oid, vid, SequenceEvent.Payload(cmd))
+        SequenceEvent.Add(vid, SequenceEvent.Location(oid), SequenceEvent.Payload(cmd))
       }
     }
 

--- a/modules/core/src/test/scala/lucuma/odb/api/repo/ExecutionEventRepoSpec.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/repo/ExecutionEventRepoSpec.scala
@@ -48,7 +48,7 @@ final class ExecutionEventRepoSpec extends ScalaCheckSuite with OdbRepoTest {
        .toMap
 
       val expected = db.executionEvents.rows.values.toList.collect {
-        case StepEvent(_, observationId, _, stepId, _, _, stage) if stage == StepStageType.EndStep =>
+        case StepEvent(_, _, _, StepEvent.Location(observationId, stepId), StepEvent.Payload(_, stage)) if stage == StepStageType.EndStep =>
           (observationId, stepId)
       }.groupBy(_._1)
        .view

--- a/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
+++ b/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
@@ -149,8 +149,10 @@ class VisitSuite extends OdbSuite {
           "observationId": "o-2",
           "visitId": ${vid.toString},
           "stepId": ${sid.toString},
-          "sequenceType": "SCIENCE",
-          "stage": "START_STEP"
+          "payload": {
+             "sequenceType": "SCIENCE",
+             "stage": "START_STEP"
+          }
         }
       }
     """.some,

--- a/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
+++ b/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
@@ -52,22 +52,28 @@ class VisitSuite extends OdbSuite {
     query = s"""
       mutation AddSequenceEvent($$eventInput: AddSequenceEventInput!) {
         addSequenceEvent(input: $$eventInput) {
-          command
+          payload {
+            command
+          }
         }
       }
     """,
     expected =json"""
       {
         "addSequenceEvent": {
-          "command": "START"
+          "payload": {
+            "command": "START"
+          }
         }
       }
     """,
     variables = json"""
       {
         "eventInput": {
-          "observationId": "o-2",
           "visitId": ${vid.toString},
+          "location": {
+            "observationId": "o-2"
+          },
           "payload": {
             "command": "START"
           }

--- a/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
+++ b/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
@@ -68,7 +68,9 @@ class VisitSuite extends OdbSuite {
         "eventInput": {
           "observationId": "o-2",
           "visitId": ${vid.toString},
-          "command": "START"
+          "payload": {
+            "command": "START"
+          }
         }
       }
     """.some,

--- a/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
+++ b/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
@@ -177,11 +177,13 @@ class VisitSuite extends OdbSuite {
       {
         "eventInput": {
           "observationId": "o-2",
-          "visitId": ${vid.toString},
-          "stepId": ${sid.toString},
-          "datasetIndex": 1,
-          "filename": "S20220504S0001.fits",
-          "stage": "START_OBSERVE"
+          "visitId":        ${vid.toString},
+          "stepId":         ${sid.toString},
+          "datasetIndex":   1,
+          "payload": {
+            "stage":    "START_OBSERVE",
+            "filename": "S20220504S0001.fits"
+          }
         }
       }
     """.some,

--- a/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
+++ b/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
@@ -166,26 +166,32 @@ class VisitSuite extends OdbSuite {
     query = s"""
       mutation AddDatasetEvent($$eventInput: AddDatasetEventInput!) {
         addDatasetEvent(input: $$eventInput) {
-          stage
+          payload {
+            stage
+          }
         }
       }
     """,
     expected =json"""
       {
         "addDatasetEvent": {
-          "stage": "START_OBSERVE"
+          "payload": {
+             "stage": "START_OBSERVE"
+           }
         }
       }
     """,
     variables = json"""
       {
         "eventInput": {
-          "observationId": "o-2",
-          "visitId":        ${vid.toString},
-          "stepId":         ${sid.toString},
-          "datasetIndex":   1,
+          "visitId": ${vid.toString},
+          "location": {
+            "observationId": "o-2",
+            "stepId":         ${sid.toString},
+            "index":          1
+          },
           "payload": {
-            "stage":    "START_OBSERVE",
+            "stage": "START_OBSERVE",
             "filename": "S20220504S0001.fits"
           }
         }

--- a/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
+++ b/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
@@ -134,23 +134,29 @@ class VisitSuite extends OdbSuite {
     query = s"""
       mutation AddStepEvent($$eventInput: AddStepEventInput!) {
         addStepEvent(input: $$eventInput) {
-          stage
+          payload {
+            stage
+          }
         }
       }
     """,
     expected =json"""
       {
         "addStepEvent": {
-          "stage": "START_STEP"
+          "payload": {
+            "stage": "START_STEP"
+          }
         }
       }
     """,
     variables = json"""
       {
         "eventInput": {
-          "observationId": "o-2",
           "visitId": ${vid.toString},
-          "stepId": ${sid.toString},
+          "location": {
+            "observationId": "o-2",
+            "stepId": ${sid.toString}
+          },
           "payload": {
              "sequenceType": "SCIENCE",
              "stage": "START_STEP"


### PR DESCRIPTION
Refactors the event API, standardizing events for the sequence, step and dataset.  Each event is given a `location` identifying the associated element and a `payload` with actual event data.  This separates the two concerns and follows the recommended practice of nesting objects to facilitate API evolution.

Events are not added or directly used by Explore so hopefully this will not occasion any changes to the UI.  Instead, this is part of the the API intended for use by Observe as it executes an observation.