### PR TITLE
Bulk Edit Inputs

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -74,6 +74,16 @@ trait ObservationMutation {
       "Edit observation"
     )
 
+  implicit val InputObjectTypeBulkEditSelect: InputObjectType[BulkEdit.Select] =
+    InputObjectType[BulkEdit.Select](
+      name        = "BulkEditSelectInput",
+      description = "Bulk edit observation selection.  Choose either all observations in a program or else list individual observations.",
+      List(
+        InputField("programId",      OptionInputType(ProgramIdType)),
+        InputField("observationIds", OptionInputType(ListInputType(ObservationIdType)))
+      )
+    )
+
   private def bulkEditArgument[A: Decoder](
     name:       String,
     editType:   InputType[A]
@@ -84,9 +94,8 @@ trait ObservationMutation {
         s"BulkEdit${name.capitalize}Input",
         "Input for bulk editing multiple observations",
         List(
-          InputField("selectProgram",      OptionInputType(ProgramIdType)),
-          InputField("selectObservations", OptionInputType(ListInputType(ObservationIdType))),
-          InputField("edit",               editType)
+          InputField("select", InputObjectTypeBulkEditSelect),
+          InputField("edit",   editType)
         )
       )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -142,33 +142,33 @@ trait ObservationMutation {
       resolve   = c => c.observation(_.clone(c.arg(ArgumentObservationCloneInput)))
     )
 
-  def updateAsterism[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
+  def bulkEditAsterism[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name      = "updateAsterism",
+      name      = "bulkEditAsterism",
       fieldType = ListType(ObservationType[F]),
       arguments = List(ArgumentAsterismBulkEdit),
       resolve   = c => c.observation(_.bulkEditAsterism(c.arg(ArgumentAsterismBulkEdit)))
     )
 
-  def updateTargetEnvironment[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
+  def bulkEditTargetEnvironment[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name      = "updateTargetEnvironment",
+      name      = "bulkEditTargetEnvironment",
       fieldType = ListType(ObservationType[F]),
       arguments = List(ArgumentTargetEnvironmentBulkEdit),
       resolve   = c => c.observation(_.bulkEditTargetEnvironment(c.arg(ArgumentTargetEnvironmentBulkEdit)))
     )
 
-  def updateConstraintSet[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
+  def bulkEditConstraintSet[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name      = "updateConstraintSet",
+      name      = "bulkEditConstraintSet",
       fieldType = ListType(ObservationType[F]),
       arguments = List(ArgumentConstraintSetBulkEdit),
       resolve   = c => c.observation(_.bulkEditConstraintSet(c.arg(ArgumentConstraintSetBulkEdit)))
     )
 
-  def updateScienceRequirements[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
+  def bulkEditScienceRequirements[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name      = "updateScienceRequirements",
+      name      = "bulkEditScienceRequirements",
       fieldType = ListType(ObservationType[F]),
       arguments = List(ArgumentScienceRequirementsBulkEdit),
       resolve   = c => c.observation(_.bulkEditScienceRequirements(c.arg(ArgumentScienceRequirementsBulkEdit)))
@@ -195,10 +195,10 @@ trait ObservationMutation {
       create,
       update,
       clone,
-      updateAsterism,
-      updateTargetEnvironment,
-      updateConstraintSet,
-      updateScienceRequirements,
+      bulkEditAsterism,
+      bulkEditTargetEnvironment,
+      bulkEditConstraintSet,
+      bulkEditScienceRequirements,
       delete,
       undelete,
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -8,6 +8,7 @@ import lucuma.odb.api.model.ObservationModel.BulkEdit
 import lucuma.odb.api.schema.syntax.inputtype._
 import cats.effect.Async
 import cats.effect.std.Dispatcher
+import cats.syntax.option._
 import io.circe.Decoder
 import lucuma.odb.api.model.targetModel.{EditAsterismInput, TargetEnvironmentInput}
 import lucuma.odb.api.repo.OdbCtx
@@ -77,7 +78,10 @@ trait ObservationMutation {
   implicit val InputObjectTypeBulkEditSelect: InputObjectType[BulkEdit.Select] =
     InputObjectType[BulkEdit.Select](
       name        = "BulkEditSelectInput",
-      description = "Bulk edit observation selection.  Choose either all observations in a program or else list individual observations.",
+      description =
+      """Observation selection.  Choose 'programId' to select all of a program's
+        |observations or else list individual observations in 'observationIds'.
+      """.stripMargin,
       List(
         InputField("programId",      OptionInputType(ProgramIdType)),
         InputField("observationIds", OptionInputType(ListInputType(ObservationIdType)))
@@ -91,8 +95,11 @@ trait ObservationMutation {
 
     val io: InputObjectType[BulkEdit[A]] =
       InputObjectType[BulkEdit[A]](
-        s"BulkEdit${name.capitalize}Input",
-        "Input for bulk editing multiple observations",
+        name        = s"BulkEdit${name.capitalize}Input",
+        description =
+          """Input for bulk editing multiple observations.  Select observations
+            |with the 'select' input and specify the changes in 'edit'.
+            |""".stripMargin,
         List(
           InputField("select", InputObjectTypeBulkEditSelect),
           InputField("edit",   editType)
@@ -153,34 +160,50 @@ trait ObservationMutation {
 
   def bulkEditAsterism[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name      = "bulkEditAsterism",
-      fieldType = ListType(ObservationType[F]),
-      arguments = List(ArgumentAsterismBulkEdit),
-      resolve   = c => c.observation(_.bulkEditAsterism(c.arg(ArgumentAsterismBulkEdit)))
+      name        = "bulkEditAsterism",
+      description =
+        """Edit asterisms, adding or deleting targets, in (potentially) multiple
+          |observations at once.
+        """.stripMargin.some,
+      fieldType   = ListType(ObservationType[F]),
+      arguments   = List(ArgumentAsterismBulkEdit),
+      resolve     = c => c.observation(_.bulkEditAsterism(c.arg(ArgumentAsterismBulkEdit)))
     )
 
   def bulkEditTargetEnvironment[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name      = "bulkEditTargetEnvironment",
-      fieldType = ListType(ObservationType[F]),
-      arguments = List(ArgumentTargetEnvironmentBulkEdit),
-      resolve   = c => c.observation(_.bulkEditTargetEnvironment(c.arg(ArgumentTargetEnvironmentBulkEdit)))
+      name        = "bulkEditTargetEnvironment",
+      description =
+        """Edit target environments, setting an explicit base position or the
+          |asterism, in (potentially) multiple observations at once.
+        """.stripMargin.some,
+      fieldType   = ListType(ObservationType[F]),
+      arguments   = List(ArgumentTargetEnvironmentBulkEdit),
+      resolve     = c => c.observation(_.bulkEditTargetEnvironment(c.arg(ArgumentTargetEnvironmentBulkEdit)))
     )
 
   def bulkEditConstraintSet[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name      = "bulkEditConstraintSet",
-      fieldType = ListType(ObservationType[F]),
-      arguments = List(ArgumentConstraintSetBulkEdit),
-      resolve   = c => c.observation(_.bulkEditConstraintSet(c.arg(ArgumentConstraintSetBulkEdit)))
+      name        = "bulkEditConstraintSet",
+      description =
+        """Edit constraint sets, setting image quality or elevation ranges etc,
+          |in (potentially) multiple observations at once.
+        """.stripMargin.some,
+      fieldType   = ListType(ObservationType[F]),
+      arguments   = List(ArgumentConstraintSetBulkEdit),
+      resolve     = c => c.observation(_.bulkEditConstraintSet(c.arg(ArgumentConstraintSetBulkEdit)))
     )
 
   def bulkEditScienceRequirements[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name      = "bulkEditScienceRequirements",
-      fieldType = ListType(ObservationType[F]),
-      arguments = List(ArgumentScienceRequirementsBulkEdit),
-      resolve   = c => c.observation(_.bulkEditScienceRequirements(c.arg(ArgumentScienceRequirementsBulkEdit)))
+      name        = "bulkEditScienceRequirements",
+      description =
+        """Edit science requirements in (potentially) multiple observations at
+          |once.
+        """.stripMargin.some,
+      fieldType   = ListType(ObservationType[F]),
+      arguments   = List(ArgumentScienceRequirementsBulkEdit),
+      resolve     = c => c.observation(_.bulkEditScienceRequirements(c.arg(ArgumentScienceRequirementsBulkEdit)))
     )
 
   def delete[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
@@ -233,8 +233,10 @@ trait TargetMutation extends TargetScalars {
             t <- c.ctx.odbRepo.target.clone(c.arg(existing), c.arg(suggested))
             _ <- c.ctx.odbRepo.observation.bulkEditAsterism(
               ObservationModel.BulkEdit(
-                c.arg(OptionalListObservationIdArgument).map(_.toList),
-                None,
+                ObservationModel.BulkEdit.Select(
+                  None,
+                  c.arg(OptionalListObservationIdArgument).map(_.toList)
+                ),
                 List(
                   EditAsterismInput.delete(c.arg(existing)),
                   EditAsterismInput.add(t.id)

--- a/modules/service/src/test/scala/MutationSuite.scala
+++ b/modules/service/src/test/scala/MutationSuite.scala
@@ -39,7 +39,9 @@ class MutationSuite extends OdbSuite {
     variables = Some(json"""
       {
         "bulkEditConstraints": {
-          "selectObservations": [ "o-3", "o-4" ],
+          "select": {
+            "observationIds": [ "o-3", "o-4" ]
+          },
           "edit": {
             "skyBackground": "GRAY"
           }
@@ -75,7 +77,9 @@ class MutationSuite extends OdbSuite {
     variables = Some(json"""
       {
         "bulkEditConstraints": {
-          "selectObservations": [ "o-3", "o-4" ],
+          "select": {
+            "observationIds": [ "o-3", "o-4" ]
+          },
           "edit": {
             "skyBackground": "GRAY",
             "elevationRange": {

--- a/modules/service/src/test/scala/MutationSuite.scala
+++ b/modules/service/src/test/scala/MutationSuite.scala
@@ -10,7 +10,7 @@ class MutationSuite extends OdbSuite {
   queryTest(
     query = """
       mutation BulkEditConstraints($bulkEditConstraints: BulkEditConstraintSetInput!) {
-        updateConstraintSet(input: $bulkEditConstraints) {
+        bulkEditConstraintSet(input: $bulkEditConstraints) {
           id
           constraintSet {
             skyBackground
@@ -20,7 +20,7 @@ class MutationSuite extends OdbSuite {
     """,
     expected = json"""
       {
-        "updateConstraintSet" : [
+        "bulkEditConstraintSet" : [
           {
             "id" : "o-3",
             "constraintSet" : {
@@ -55,7 +55,7 @@ class MutationSuite extends OdbSuite {
     query =
       """
         mutation BulkEditConstraints($bulkEditConstraints: BulkEditConstraintSetInput!) {
-          updateConstraintSet(input: $bulkEditConstraints) {
+          bulkEditConstraintSet(input: $bulkEditConstraints) {
             id
             constraintSet {
               skyBackground

--- a/modules/service/src/test/scala/test/targets/AsterismMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/AsterismMutationSuite.scala
@@ -25,7 +25,7 @@ class AsterismMutationSuite extends OdbSuite {
   queryTest(
     query ="""
       mutation ReplaceTargets($listEdit: BulkEditAsterismInput!) {
-        updateAsterism(input: $listEdit) {
+        bulkEditAsterism(input: $listEdit) {
           id
           targetEnvironment {
             asterism {
@@ -37,7 +37,7 @@ class AsterismMutationSuite extends OdbSuite {
     """,
     expected =json"""
       {
-        "updateAsterism": [
+        "bulkEditAsterism": [
           {
             "id": "o-3",
             "targetEnvironment": {

--- a/modules/service/src/test/scala/test/targets/AsterismMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/AsterismMutationSuite.scala
@@ -64,7 +64,9 @@ class AsterismMutationSuite extends OdbSuite {
     variables =json"""
       {
         "listEdit": {
-          "selectObservations": [ "o-3", "o-4" ],
+          "select": {
+            "observationIds": [ "o-3", "o-4" ]
+          },
           "edit": [
             {
               "delete": "t-4"

--- a/modules/service/src/test/scala/test/targets/TargetEnvironmentMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetEnvironmentMutationSuite.scala
@@ -24,7 +24,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
   queryTest(
     query ="""
       mutation UpdateTargetEnvironment($envEdit: BulkEditTargetEnvironmentInput!) {
-        updateTargetEnvironment(input: $envEdit) {
+        bulkEditTargetEnvironment(input: $envEdit) {
           id
           targetEnvironment {
             asterism {
@@ -36,7 +36,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
     """,
     expected =json"""
       {
-        "updateTargetEnvironment": [
+        "bulkEditTargetEnvironment": [
           {
             "id": "o-3",
             "targetEnvironment": {
@@ -66,7 +66,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
   queryTestFailure(
     query ="""
       mutation UpdateTargetEnvironment($envEdit: BulkEditTargetEnvironmentInput!) {
-        updateTargetEnvironment(input: $envEdit) {
+        bulkEditTargetEnvironment(input: $envEdit) {
           id
           targetEnvironment {
             asterism {
@@ -94,7 +94,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
   queryTest(
     query ="""
       mutation UpdateTargetEnvironment($envEdit: BulkEditTargetEnvironmentInput!) {
-        updateTargetEnvironment(input: $envEdit) {
+        bulkEditTargetEnvironment(input: $envEdit) {
           id
           targetEnvironment {
             explicitBase {
@@ -107,7 +107,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
     """,
     expected =json"""
       {
-        "updateTargetEnvironment": [
+        "bulkEditTargetEnvironment": [
           {
             "id": "o-3",
             "targetEnvironment": {

--- a/modules/service/src/test/scala/test/targets/TargetEnvironmentMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetEnvironmentMutationSuite.scala
@@ -53,7 +53,9 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
     variables =json"""
       {
         "envEdit": {
-          "selectObservations": [ "o-3" ],
+          "select": {
+            "observationIds": [ "o-3" ]
+          },
           "edit": {
             "asterism": [ "t-2" ]
           }
@@ -80,7 +82,9 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
     variables =json"""
       {
         "envEdit": {
-          "selectObservations": [ "o-3" ],
+          "select": {
+            "observationIds": [ "o-3" ]
+          },
           "edit": {
             "asterism": [ "t-6" ]
           }
@@ -127,7 +131,9 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
     variables =json"""
       {
         "envEdit": {
-          "selectObservations": [ "o-3" ],
+          "select": {
+            "observationIds": [ "o-3" ]
+          },
           "edit": {
             "explicitBase": {
               "ra": {


### PR DESCRIPTION
Renamed the bulk edit mutations `bulkEdit*` for clarity and to match the corresponding `BulkEdit*Input`s.  Nested the selection into its own `BulkEditSelectInput` object.