### PR TITLE
Don't store planned time summary

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -40,8 +40,7 @@ final case class ObservationModel(
   constraintSet:       ConstraintSet,
   scienceRequirements: ScienceRequirements,
   scienceMode:         Option[ScienceMode],
-  config:              Option[ExecutionModel],
-  plannedTimeSummary:  PlannedTimeSummaryModel
+  config:              Option[ExecutionModel]
 ) {
 
   val validate: StateT[EitherInput, Database, ObservationModel] =
@@ -67,8 +66,7 @@ object ObservationModel extends ObservationOptics {
       o.constraintSet,
       o.scienceRequirements,
       o.scienceMode,
-      o.config,
-      o.plannedTimeSummary
+      o.config
     )}
 
 
@@ -85,9 +83,7 @@ object ObservationModel extends ObservationOptics {
     config:              Option[ExecutionModel.Create]
   ) {
 
-    def create[F[_]: Sync](
-      s: PlannedTimeSummaryModel
-    ): F[StateT[EitherInput, Database, ObservationModel]] =
+    def create[F[_]: Sync]: F[StateT[EitherInput, Database, ObservationModel]] =
       config.traverse(_.create).map { g =>
         for {
           i <- Database.observation.getUnusedKey(observationId)
@@ -108,8 +104,7 @@ object ObservationModel extends ObservationOptics {
               constraintSet        = cʹ.getOrElse(ConstraintSetModel.Default),
               scienceRequirements  = qʹ.getOrElse(ScienceRequirements.Default),
               scienceMode          = uʹ,
-              config               = gʹ,
-              plannedTimeSummary   = s
+              config               = gʹ
             )
           }
           oʹ <- o.traverse(_.validate)
@@ -253,8 +248,7 @@ object ObservationModel extends ObservationOptics {
               constraintSet        = cʹ.getOrElse(orig.constraintSet),
               scienceRequirements  = qʹ.getOrElse(orig.scienceRequirements),
               scienceMode          = uʹ.orElse(orig.scienceMode),
-              config               = gʹ.orElse(orig.config),
-              plannedTimeSummary   = orig.plannedTimeSummary  // wrong.  need to remove from observation model
+              config               = gʹ.orElse(orig.config)
             )
           }
           oʹʹ <- oʹ.traverse(_.validate)

--- a/modules/core/src/main/scala/lucuma/odb/api/model/PlannedTimeSummaryModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/PlannedTimeSummaryModel.scala
@@ -47,4 +47,14 @@ object PlannedTimeSummaryModel {
   implicit val EqPlannedTimeSummaryModel: Eq[PlannedTimeSummaryModel] =
     Eq.by(t => (t.piTime.toNanos, t.unchargedTime.toNanos))
 
+  // "calculate" the planned time.  want a stable value so ... here's something
+  // random for now
+  def forObservation(o: ObservationModel): PlannedTimeSummaryModel = {
+    val l = o.id.hashCode()
+    PlannedTimeSummaryModel(
+      (((l % 20).abs + 1) * 5).toLong.minutes,
+      (15 - (l % 15).abs).toLong.minutes
+    )
+  }
+
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
@@ -8,7 +8,7 @@ import cats.effect.std.Dispatcher
 import cats.syntax.all._
 import lucuma.core.`enum`.{ObsActiveStatus, ObsStatus}
 import lucuma.core.model.Observation
-import lucuma.odb.api.model.ObservationModel
+import lucuma.odb.api.model.{ObservationModel, PlannedTimeSummaryModel}
 import lucuma.odb.api.repo.OdbCtx
 import lucuma.odb.api.schema.TargetSchema.TargetEnvironmentType
 import org.typelevel.log4cats.Logger
@@ -130,7 +130,7 @@ object ObservationSchema {
           name        = "plannedTime",
           fieldType   = PlannedTimeSummaryType,
           description = Some("Observation planned time calculation."),
-          resolve     = _.value.plannedTimeSummary
+          resolve     = c => PlannedTimeSummaryModel.forObservation(c.value)
         ),
 
         Field(

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
@@ -3,7 +3,7 @@
 
 package lucuma.odb.api.schema
 
-import lucuma.odb.api.model.ProgramModel
+import lucuma.odb.api.model.{PlannedTimeSummaryModel, ProgramModel}
 import lucuma.core.model.Program
 import cats.effect.Async
 import cats.effect.std.Dispatcher
@@ -94,7 +94,7 @@ object ProgramSchema {
           arguments   = List(ArgumentIncludeDeleted),
           resolve     = c => c.observation {
             _.selectPageForProgram(c.value.id, Some(Integer.MAX_VALUE), None, c.includeDeleted)
-             .map(_.nodes.foldMap(_.plannedTimeSummary))
+             .map(_.nodes.foldMap(PlannedTimeSummaryModel.forObservation))
           }
         )
 

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbObservationModel.scala
@@ -34,7 +34,7 @@ trait ArbObservationModel {
         ts <- arbitrary[TargetEnvironmentModel]
         cs <- arbitrary[ConstraintSet]
         sr <- arbitrary[ScienceRequirements]
-      } yield ObservationModel(id, ex, pid, nm, os, as, ts, cs, sr, None, None, PlannedTimeSummaryModel.Zero)
+      } yield ObservationModel(id, ex, pid, nm, os, as, ts, cs, sr, None, None)
     }
 
   implicit val arbObservationModel: Arbitrary[ObservationModel] =


### PR DESCRIPTION
A small, nonbreaking, change to stop storing the planned time summary.  These are supposed to be computed and will change as you edit the observation.  For now we can just generate a stable, if bogus, value.