### PR TITLE
More advanced gmos long slit configuration

### DIFF
--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosLongSlit.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosLongSlit.scala
@@ -5,25 +5,30 @@ package lucuma.gen
 package gmos
 package longslit
 
-import cats.Eq
+import cats.{Eq, Order}
+import cats.data.EitherT
+import cats.Order.catsKernelOrderingForOrder
 import cats.effect.Sync
+import cats.syntax.either._
 import cats.syntax.eq._
 import cats.syntax.functor._
+import cats.syntax.traverse._
 import coulomb.Quantity
 import eu.timepit.refined.auto._
-import eu.timepit.refined.types.all.{PosDouble, PosInt}
+import eu.timepit.refined.types.all.{NonNegInt, PosDouble}
 import lucuma.core.`enum`.ImageQuality
-import lucuma.core.math.Wavelength
+import lucuma.core.math.{Angle, Wavelength}
 import lucuma.core.math.units.Nanometer
-import lucuma.core.model.SourceProfile
+import lucuma.core.model.{SourceProfile, Target}
 import lucuma.core.syntax.time._
-import lucuma.itc.client.{ItcClient, ItcResult}
+import lucuma.itc.client.ItcClient
 import lucuma.odb.api.model.{ObservationModel, ScienceMode, Sequence}
+import lucuma.odb.api.model.ExposureTimeMode.{FixedExposure, SignalToNoise}
+import lucuma.odb.api.model.gmos.longslit.{GmosLongslitMath, LongSlit}
+import lucuma.odb.api.model.time.NonNegDuration
 import lucuma.odb.api.repo.OdbRepo
 
 trait GmosLongSlit[F[_], S, D] extends Generator[F, S, D] with GeneratorHelper[D] {
-
-  def λ: Wavelength
 
   def acquisitionSteps: Acquisition.Steps[D]
 
@@ -89,61 +94,116 @@ object GmosLongSlit {
       .getOption(λ.toPicometers.value + Δ.value * 1000)
       .getOrElse(Wavelength.Min)
 
-
   final case class Input[M](
     mode:          M,
-    requirementλ:  Wavelength,
+    λ:             Wavelength,
     imageQuality:  ImageQuality,
     sampling:      PosDouble,
     sourceProfile: SourceProfile,
     acqTime:       AcqExposureTime,
     sciTime:       SciExposureTime,
-    exposureCount: PosInt
+    exposureCount: NonNegInt
   )
 
   object Input {
 
-    def query[F[_]: Sync, M](
-      itc:         ItcClient[F],
-      odb:         OdbRepo[F],
-      observation: ObservationModel,
-      sampling:    PosDouble = GmosLongSlit.DefaultSampling,
+    def query[F[_] : Sync, M <: LongSlit[_, _, _]](
+      itc:            ItcClient[F],
+      odb:            OdbRepo[F],
+      observation:    ObservationModel,
+      sampling:       PosDouble = GmosLongSlit.DefaultSampling,
+      includeDeleted: Boolean = false,
+      useCache:       Boolean = true
     )(
       f: PartialFunction[ScienceMode, M]
-    ): F[Either[ItcResult.Error, Option[Input[M]]]] =
+    ): F[Either[String, Input[M]]] =
 
-      itc
-        .query(observation.id, odb)
-        .map(_.map { case (target, result) =>
-          fromObservationAndItc(observation, sampling, target.sourceProfile, result)(f)
-        })
+      (for {
+        mode <- EitherT.fromOption[F](
+          observation.scienceMode.collect(f),
+          "There is no matching GMOS Long Slit mode definition"
+        )
 
+        λ <- EitherT.fromOption[F](
+          mode.advanced
+            .flatMap(_.overrideWavelength)
+            .orElse(observation.scienceRequirements.spectroscopy.wavelength),
+          "Could not determine the wavelength"
+        )
 
-    def fromObservationAndItc[M](
-      observation:   ObservationModel,
-      sampling:      PosDouble,
-      sourceProfile: SourceProfile,
-      itc:           ItcResult.Success
-    )(
-      f: PartialFunction[ScienceMode, M]
-    ): Option[Input[M]] =
+        sp <- EitherT(
+          selectSourceProfile(odb, observation, includeDeleted)
+            .map(_.toRight("Observation has no targets"))
+        )
 
-      for {
-        mode     <- observation.scienceMode.collect(f)
-        λ        <- observation.scienceRequirements.spectroscopy.wavelength
-        sciTime  <- SciExposureTime.from(itc.exposureTime)
-        expCount <- PosInt.from(itc.exposures).toOption
+        sci0 <- EitherT.fromOption[F](
+          mode
+            .advanced
+            .flatMap(_.overrideExposureTimeMode)
+            .orElse(
+              observation.scienceRequirements.spectroscopy.signalToNoise.map(sn => SignalToNoise(sn))
+            ),
+          "Observation S/N requirement not specified"
+        )
+
+        sci <- sci0 match {
+          case SignalToNoise(_)      => EitherT(queryItc(itc, odb, observation, includeDeleted, useCache))
+          case f@FixedExposure(_, _) => EitherT.pure[F, String](f)
+        }
+
       } yield Input[M](
         mode,
         λ,
         observation.constraintSet.imageQuality,
         sampling,
-        sourceProfile,
+        sp,
         GmosLongSlit.acquisitionExposureTime,
-        sciTime,
-        expCount
-      )
+        shapeless.tag[SciExposureTimeTag][NonNegDuration](sci.time),
+        sci.count
+      )).value
+
+    private def targets[F[_] : Sync](
+      odb:            OdbRepo[F],
+      observation:    ObservationModel,
+      includeDeleted: Boolean
+    ): F[List[Target]] =
+      observation
+        .targetEnvironment
+        .asterism
+        .toList
+        .flatTraverse { tid =>
+          odb.target.selectTarget(tid, includeDeleted).map(_.map(_.target).toList)
+        }
+
+    private def selectSourceProfile[F[_]: Sync](
+      odb:            OdbRepo[F],
+      observation:    ObservationModel,
+      includeDeleted: Boolean
+    ): F[Option[SourceProfile]] = {
+
+      implicit val AngleOrder: Order[Angle] =
+        Angle.AngleOrder
+
+      targets(odb, observation, includeDeleted).map { ts =>
+        ts.maxByOption { t =>
+          GmosLongslitMath.objectSize(t.sourceProfile)
+        }.map(_.sourceProfile)
+      }
+    }
+
+    private def queryItc[F[_]: Sync](
+      itc:            ItcClient[F],
+      odb:            OdbRepo[F],
+      observation:    ObservationModel,
+      includeDeleted: Boolean,
+      useCache:       Boolean
+    ): F[Either[String, FixedExposure]] =
+      itc
+        .query(observation.id, odb, includeDeleted, useCache)
+        .map {
+          _.leftMap(e => s"Problem querying the ITC: ${e.msg}")
+           .map { case (_, s) => FixedExposure(s.exposures, s.exposureTime) }
+        }
 
   }
-
 }

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosLongSlit.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosLongSlit.scala
@@ -23,6 +23,8 @@ import lucuma.odb.api.repo.OdbRepo
 
 trait GmosLongSlit[F[_], S, D] extends Generator[F, S, D] with GeneratorHelper[D] {
 
+  def λ: Wavelength
+
   def acquisitionSteps: Acquisition.Steps[D]
 
   def scienceAtoms: LazyList[Science.Atom[D]]
@@ -90,7 +92,7 @@ object GmosLongSlit {
 
   final case class Input[M](
     mode:          M,
-    λ:             Wavelength,
+    requirementλ:  Wavelength,
     imageQuality:  ImageQuality,
     sampling:      PosDouble,
     sourceProfile: SourceProfile,

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosNorthLongSlit.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosNorthLongSlit.scala
@@ -45,11 +45,11 @@ object GmosNorthLongSlit {
   def fromInput[F[_]: Sync](
     in: GmosLongSlit.Input[ScienceMode.GmosNorthLongSlit]
   ): GmosNorthLongSlit[F] =
-    apply(in.mode, in.λ, in.imageQuality, in.sampling, in.sourceProfile, in.acqTime, in.sciTime, in.exposureCount)
+    apply(in.mode, in.requirementλ, in.imageQuality, in.sampling, in.sourceProfile, in.acqTime, in.sciTime, in.exposureCount)
 
   def apply[F[_]: Sync](
     mode:          ScienceMode.GmosNorthLongSlit,
-    λ:             Wavelength,
+    requirementλ:  Wavelength,
     imageQuality:  ImageQuality,
     sampling:      PosDouble,
     sourceProfile: SourceProfile,
@@ -59,6 +59,9 @@ object GmosNorthLongSlit {
   ): GmosNorthLongSlit[F] =
 
     new GmosNorthLongSlit[F] with GmosLongSlit[F, NorthStatic, NorthDynamic] {
+
+      override val λ: Wavelength =
+        mode.advanced.flatMap(_.overrideWavelength).getOrElse(requirementλ)
 
       override def static: NorthStatic =
         NorthStatic(

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosNorthLongSlit.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosNorthLongSlit.scala
@@ -8,11 +8,9 @@ package longslit
 import cats.effect.Sync
 import cats.syntax.functor._
 import eu.timepit.refined.auto._
-import eu.timepit.refined.types.all.{PosDouble, PosInt}
+import eu.timepit.refined.types.all.PosDouble
 import lucuma.core.`enum`._
-import lucuma.core.math.Wavelength
-import lucuma.core.model.SourceProfile
-import lucuma.itc.client.{ItcClient, ItcResult}
+import lucuma.itc.client.ItcClient
 import lucuma.odb.api.model.{ObservationModel, ScienceMode, Sequence}
 import lucuma.odb.api.model.gmos.syntax.gmosNorthFilter._
 import lucuma.odb.api.model.GmosModel.{NorthDynamic, NorthStatic}
@@ -36,32 +34,17 @@ object GmosNorthLongSlit {
     odb:         OdbRepo[F],
     observation: ObservationModel,
     sampling:    PosDouble = GmosLongSlit.DefaultSampling,
-  ): F[Either[ItcResult.Error, Option[GmosNorthLongSlit[F]]]] =
+  ): F[Either[String, GmosNorthLongSlit[F]]] =
 
     GmosLongSlit.Input.query(itc, odb, observation, sampling) {
       case gnls: ScienceMode.GmosNorthLongSlit => gnls
-    }.map(_.map(_.map(fromInput[F])))
+    }.map(_.map(fromInput[F]))
 
   def fromInput[F[_]: Sync](
     in: GmosLongSlit.Input[ScienceMode.GmosNorthLongSlit]
   ): GmosNorthLongSlit[F] =
-    apply(in.mode, in.requirementλ, in.imageQuality, in.sampling, in.sourceProfile, in.acqTime, in.sciTime, in.exposureCount)
-
-  def apply[F[_]: Sync](
-    mode:          ScienceMode.GmosNorthLongSlit,
-    requirementλ:  Wavelength,
-    imageQuality:  ImageQuality,
-    sampling:      PosDouble,
-    sourceProfile: SourceProfile,
-    acqTime:       AcqExposureTime,
-    sciTime:       SciExposureTime,
-    exposureCount: PosInt
-  ): GmosNorthLongSlit[F] =
 
     new GmosNorthLongSlit[F] with GmosLongSlit[F, NorthStatic, NorthDynamic] {
-
-      override val λ: Wavelength =
-        mode.advanced.flatMap(_.overrideWavelength).getOrElse(requirementλ)
 
       override def static: NorthStatic =
         NorthStatic(
@@ -74,11 +57,11 @@ object GmosNorthLongSlit {
       override def acquisitionSteps: Acquisition.Steps[NorthDynamic] =
         Acquisition.GmosNorth.compute(
           GmosNorthFilter.allAcquisition.fproduct(_.wavelength),
-          mode.fpu, acqTime, λ
+          in.mode.fpu, in.acqTime, in.λ
         )
 
       override def scienceAtoms: LazyList[Science.Atom[NorthDynamic]] =
-        Science.GmosNorth.compute(mode, sciTime, λ, sourceProfile, imageQuality, sampling)
+        Science.GmosNorth.compute(in.mode, in.sciTime, in.λ, in.sourceProfile, in.imageQuality, in.sampling)
 
       override def acquisition(
         recordedSteps: List[RecordedStep[NorthDynamic]]
@@ -88,7 +71,7 @@ object GmosNorthLongSlit {
       override def science(
         recordedSteps: List[RecordedStep[NorthDynamic]]
       ): F[Sequence[NorthDynamic]] =
-        longSlitScience(exposureCount, recordedSteps)
+        longSlitScience(in.exposureCount, recordedSteps)
     }
 
 }

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosSouthLongSlit.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosSouthLongSlit.scala
@@ -44,11 +44,11 @@ object GmosSouthLongSlit {
   def fromInput[F[_]: Sync](
     in: GmosLongSlit.Input[ScienceMode.GmosSouthLongSlit]
   ): GmosSouthLongSlit[F] =
-    apply(in.mode, in.λ, in.imageQuality, in.sampling, in.sourceProfile, in.acqTime, in.sciTime, in.exposureCount)
+    apply(in.mode, in.requirementλ, in.imageQuality, in.sampling, in.sourceProfile, in.acqTime, in.sciTime, in.exposureCount)
 
   def apply[F[_]: Sync](
     mode:          ScienceMode.GmosSouthLongSlit,
-    λ:             Wavelength,
+    requirementλ:  Wavelength,
     imageQuality:  ImageQuality,
     sampling:      PosDouble,
     sourceProfile: SourceProfile,
@@ -58,6 +58,9 @@ object GmosSouthLongSlit {
   ): GmosSouthLongSlit[F] =
 
     new GmosSouthLongSlit[F] with GmosLongSlit[F, SouthStatic, SouthDynamic] {
+
+      override val λ: Wavelength =
+        mode.advanced.flatMap(_.overrideWavelength).getOrElse(requirementλ)
 
       override def static: SouthStatic =
         SouthStatic(

--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosSouthLongSlit.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosSouthLongSlit.scala
@@ -8,11 +8,9 @@ package longslit
 import cats.effect.Sync
 import cats.syntax.functor._
 import eu.timepit.refined.auto._
-import eu.timepit.refined.types.all.{PosDouble, PosInt}
+import eu.timepit.refined.types.all.PosDouble
 import lucuma.core.`enum`._
-import lucuma.core.math.Wavelength
-import lucuma.core.model.SourceProfile
-import lucuma.itc.client.{ItcClient, ItcResult}
+import lucuma.itc.client.ItcClient
 import lucuma.odb.api.model.GmosModel.{SouthDynamic, SouthStatic}
 import lucuma.odb.api.model.{ObservationModel, ScienceMode, Sequence}
 import lucuma.odb.api.model.gmos.syntax.gmosSouthFilter._
@@ -35,32 +33,17 @@ object GmosSouthLongSlit {
     odb:         OdbRepo[F],
     observation: ObservationModel,
     sampling:    PosDouble = GmosLongSlit.DefaultSampling,
-  ): F[Either[ItcResult.Error, Option[GmosSouthLongSlit[F]]]] =
+  ): F[Either[String, GmosSouthLongSlit[F]]] =
 
     GmosLongSlit.Input.query(itc, odb, observation, sampling) {
       case gnls: ScienceMode.GmosSouthLongSlit => gnls
-    }.map(_.map(_.map(fromInput[F])))
+    }.map(_.map(fromInput[F]))
 
   def fromInput[F[_]: Sync](
     in: GmosLongSlit.Input[ScienceMode.GmosSouthLongSlit]
   ): GmosSouthLongSlit[F] =
-    apply(in.mode, in.requirementλ, in.imageQuality, in.sampling, in.sourceProfile, in.acqTime, in.sciTime, in.exposureCount)
-
-  def apply[F[_]: Sync](
-    mode:          ScienceMode.GmosSouthLongSlit,
-    requirementλ:  Wavelength,
-    imageQuality:  ImageQuality,
-    sampling:      PosDouble,
-    sourceProfile: SourceProfile,
-    acqTime:       AcqExposureTime,
-    sciTime:       SciExposureTime,
-    exposureCount: PosInt
-  ): GmosSouthLongSlit[F] =
 
     new GmosSouthLongSlit[F] with GmosLongSlit[F, SouthStatic, SouthDynamic] {
-
-      override val λ: Wavelength =
-        mode.advanced.flatMap(_.overrideWavelength).getOrElse(requirementλ)
 
       override def static: SouthStatic =
         SouthStatic(
@@ -73,11 +56,11 @@ object GmosSouthLongSlit {
       override def acquisitionSteps: Acquisition.Steps[SouthDynamic] =
         Acquisition.GmosSouth.compute(
           GmosSouthFilter.allAcquisition.fproduct(_.wavelength),
-          mode.fpu, acqTime, λ
+          in.mode.fpu, in.acqTime, in.λ
         )
 
       override def scienceAtoms: LazyList[Science.Atom[SouthDynamic]] =
-        Science.GmosSouth.compute(mode, sciTime, λ, sourceProfile, imageQuality, sampling)
+        Science.GmosSouth.compute(in.mode, in.sciTime, in.λ, in.sourceProfile, in.imageQuality, in.sampling)
 
       override def acquisition(
         recordedSteps: List[RecordedStep[SouthDynamic]]
@@ -87,7 +70,7 @@ object GmosSouthLongSlit {
       override def science(
         recordedSteps: List[RecordedStep[SouthDynamic]]
       ): F[Sequence[SouthDynamic]] =
-        longSlitScience(exposureCount, recordedSteps)
+        longSlitScience(in.exposureCount, recordedSteps)
     }
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ConfigurationMode.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ConfigurationMode.scala
@@ -5,11 +5,11 @@ package lucuma.odb.api.model
 
 import lucuma.core.util.Enumerated
 
-sealed abstract class ConfigurationMode extends Product with Serializable
+sealed abstract class ConfigurationMode(val name: String) extends Product with Serializable
 
 object ConfigurationMode {
-  case object GmosNorthLongSlit extends ConfigurationMode
-  case object GmosSouthLongSlit extends ConfigurationMode
+  case object GmosNorthLongSlit extends ConfigurationMode("GMOS North Long Slit")
+  case object GmosSouthLongSlit extends ConfigurationMode("GMOS South Long Slit")
 
   implicit val ConfigurationModeEnumerated: Enumerated[ConfigurationMode] =
     Enumerated.of(GmosNorthLongSlit, GmosSouthLongSlit)

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ExposureMode.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ExposureMode.scala
@@ -1,0 +1,131 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import cats.Eq
+import cats.data.StateT
+import cats.syntax.eq._
+import cats.syntax.functor._
+import cats.syntax.validated._
+import clue.data.Input
+import clue.data.syntax._
+import eu.timepit.refined.cats._
+import eu.timepit.refined.types.all.{PosBigDecimal, PosInt}
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import io.circe.refined._
+import lucuma.odb.api.model.DurationModel.NonNegDurationInput
+import lucuma.odb.api.model.time.NonNegDuration
+import lucuma.odb.api.model.syntax.validatedinput._
+import monocle.Prism
+import monocle.macros.GenPrism
+
+sealed trait ExposureMode extends Product with Serializable
+
+object ExposureMode {
+
+  final case class SignalToNoise(value: PosBigDecimal)                extends ExposureMode
+  final case class FixedExposure(count: PosInt, time: NonNegDuration) extends ExposureMode
+
+  implicit val EqExposureMode: Eq[ExposureMode] =
+    Eq.instance {
+      case (SignalToNoise(a), SignalToNoise(b))           => a === b
+      case (FixedExposure(ac, ad), FixedExposure(bc, bd)) => ac === bc && ad.equals(bd)
+      case _                                              => false
+    }
+
+  final case class SignalToNoiseInput(
+    value: PosBigDecimal
+  ) extends EditorInput[SignalToNoise] {
+
+    def toSignalToNoise: SignalToNoise =
+      SignalToNoise(value)
+
+    override def create: ValidatedInput[SignalToNoise] =
+      toSignalToNoise.validNec[InputError]
+
+    override def edit: StateT[EitherInput, SignalToNoise, Unit] =
+      create.liftState[SignalToNoise].void
+
+  }
+
+  object SignalToNoiseInput {
+
+    implicit val DecoderSignalToNoiseInput: Decoder[SignalToNoiseInput] =
+      deriveDecoder[SignalToNoiseInput]
+
+    implicit val EqSignalToNoiseInput: Eq[SignalToNoiseInput] =
+      Eq.by(_.value)
+
+  }
+
+  final case class FixedExposureInput(
+    count: PosInt,
+    time:  NonNegDurationInput
+  ) extends EditorInput[FixedExposure] {
+
+    override def create: ValidatedInput[FixedExposure] =
+      time
+        .toNonNegDuration("time")
+        .map(t => FixedExposure(count, t))
+
+    override def edit: StateT[EitherInput, FixedExposure, Unit] =
+      create.liftState[FixedExposure].void
+
+  }
+
+  object FixedExposureInput {
+
+    implicit val DecoderFixedExposureInput: Decoder[FixedExposureInput] =
+      deriveDecoder[FixedExposureInput]
+
+    implicit val EqFixedExposureInput: Eq[FixedExposureInput] =
+      Eq.by { a => (
+        a.count,
+        a.time
+      )}
+  }
+
+  final case class ExposureModeInput(
+    signalToNoise: Input[SignalToNoiseInput],
+    fixedExposure: Input[FixedExposureInput]
+  ) extends EditorInput[ExposureMode] {
+
+    override def create: ValidatedInput[ExposureMode] =
+      ValidatedInput.requireOne("exposureMode",
+        signalToNoise.toOption.map(_.create),
+        fixedExposure.toOption.map(_.create)
+      )
+
+    override def edit: StateT[EitherInput, ExposureMode, Unit] =
+      create.liftState[ExposureMode].void
+
+  }
+
+  object ExposureModeInput {
+
+    def signalToNoise(s: SignalToNoiseInput): ExposureModeInput =
+      ExposureModeInput(s.assign, Input.ignore)
+
+    def fixedExposure(f: FixedExposureInput): ExposureModeInput =
+      ExposureModeInput(Input.ignore, f.assign)
+
+    implicit val DecoderExposureModeInput: Decoder[ExposureModeInput] =
+      deriveDecoder[ExposureModeInput]
+
+    implicit val EqExposureModeInput: Eq[ExposureModeInput] =
+      Eq.by { a => (
+        a.signalToNoise,
+        a.fixedExposure
+      )}
+
+  }
+
+  val signalToNoise: Prism[ExposureMode, SignalToNoise] =
+    GenPrism[ExposureMode, SignalToNoise]
+
+  val fixedExposure: Prism[ExposureMode, FixedExposure] =
+    GenPrism[ExposureMode, FixedExposure]
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/AdvancedConfig.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/AdvancedConfig.scala
@@ -12,7 +12,7 @@ import eu.timepit.refined.types.all.NonEmptyString
 import lucuma.core.`enum`.{GmosAmpGain, GmosAmpReadMode, GmosRoi, GmosXBinning, GmosYBinning}
 import lucuma.core.math.{Angle, Offset, Wavelength}
 import lucuma.core.math.units.Nanometer
-import lucuma.odb.api.model.ExposureMode
+import lucuma.odb.api.model.ExposureTimeMode
 import monocle.{Focus, Lens}
 
 /**
@@ -20,19 +20,19 @@ import monocle.{Focus, Lens}
  * generated without resorting to a manual sequence.
  */
 final case class AdvancedConfig[G, F, U](
-  name:                   Option[NonEmptyString],
-  overrideWavelength:     Option[Wavelength]                             = None,
-  overrideGrating:        Option[G]                                      = None,
-  overrideFilter:         Option[Option[F]]                              = None,
-  overrideFpu:            Option[U]                                      = None,
-  overrideExposureMode:   Option[ExposureMode]                           = None,
-  explicitXBin:           Option[GmosXBinning]                           = None,  // calculated from effective slit and sampling by default
-  explicitYBin:           Option[GmosYBinning]                           = None,
-  explicitAmpReadMode:    Option[GmosAmpReadMode]                        = None,
-  explicitAmpGain:        Option[GmosAmpGain]                            = None,
-  explicitRoi:            Option[GmosRoi]                                = None,
-  explicitλDithers:       Option[NonEmptyList[Quantity[Int, Nanometer]]] = None,
-  explicitSpatialOffsets: Option[NonEmptyList[Offset.Q]]                 = None
+  name:                     Option[NonEmptyString],
+  overrideWavelength:       Option[Wavelength]                             = None,
+  overrideGrating:          Option[G]                                      = None,
+  overrideFilter:           Option[Option[F]]                              = None,
+  overrideFpu:              Option[U]                                      = None,
+  overrideExposureTimeMode: Option[ExposureTimeMode]                       = None,
+  explicitXBin:             Option[GmosXBinning]                           = None,  // calculated from effective slit and sampling by default
+  explicitYBin:             Option[GmosYBinning]                           = None,
+  explicitAmpReadMode:      Option[GmosAmpReadMode]                        = None,
+  explicitAmpGain:          Option[GmosAmpGain]                            = None,
+  explicitRoi:              Option[GmosRoi]                                = None,
+  explicitλDithers:         Option[NonEmptyList[Quantity[Int, Nanometer]]] = None,
+  explicitSpatialOffsets:   Option[NonEmptyList[Offset.Q]]                 = None
 )
 
 object AdvancedConfig extends AdvancedConfigOptics {
@@ -74,7 +74,7 @@ object AdvancedConfig extends AdvancedConfigOptics {
       a.overrideGrating,
       a.overrideFilter,
       a.overrideFpu,
-      a.overrideExposureMode,
+      a.overrideExposureTimeMode,
       a.explicitXBin,
       a.explicitYBin,
       a.explicitAmpReadMode,
@@ -103,8 +103,8 @@ sealed trait AdvancedConfigOptics { self: AdvancedConfig.type =>
   def overrideFpu[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[U]] =
     Focus[AdvancedConfig[G, F, U]](_.overrideFpu)
 
-  def overrideExposureMode[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[ExposureMode]] =
-    Focus[AdvancedConfig[G, F, U]](_.overrideExposureMode)
+  def overrideExposureMode[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[ExposureTimeMode]] =
+    Focus[AdvancedConfig[G, F, U]](_.overrideExposureTimeMode)
 
   def explicitXBin[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[GmosXBinning]] =
     Focus[AdvancedConfig[G, F, U]](_.explicitXBin)

--- a/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/AdvancedConfig.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/AdvancedConfig.scala
@@ -10,7 +10,7 @@ import coulomb.cats.implicits._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.types.all.NonEmptyString
 import lucuma.core.`enum`.{GmosAmpGain, GmosAmpReadMode, GmosRoi, GmosXBinning, GmosYBinning}
-import lucuma.core.math.{Angle, Offset}
+import lucuma.core.math.{Angle, Offset, Wavelength}
 import lucuma.core.math.units.Nanometer
 import monocle.{Focus, Lens}
 
@@ -20,6 +20,7 @@ import monocle.{Focus, Lens}
  */
 final case class AdvancedConfig[G, F, U](
   name:                   Option[NonEmptyString],
+  overrideWavelength:     Option[Wavelength]                             = None,
   overrideGrating:        Option[G]                                      = None,
   overrideFilter:         Option[Option[F]]                              = None,
   overrideFpu:            Option[U]                                      = None,
@@ -67,6 +68,7 @@ object AdvancedConfig extends AdvancedConfigOptics {
   implicit def EqAdvancedConfig[G: Eq, F: Eq, U: Eq]: Eq[AdvancedConfig[G, F, U]] =
     Eq.by { a => (
       a.name,
+      a.overrideWavelength,
       a.overrideGrating,
       a.overrideFilter,
       a.overrideFpu,
@@ -86,14 +88,17 @@ sealed trait AdvancedConfigOptics { self: AdvancedConfig.type =>
   def name[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[NonEmptyString]] =
     Focus[AdvancedConfig[G, F, U]](_.name)
 
+  def overrideWavelength[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[Wavelength]] =
+    Focus[AdvancedConfig[G, F, U]](_.overrideWavelength)
+
   def overrideGrating[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[G]] =
-      Focus[AdvancedConfig[G, F, U]](_.overrideGrating)
+    Focus[AdvancedConfig[G, F, U]](_.overrideGrating)
 
   def overrideFilter[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[Option[F]]] =
-      Focus[AdvancedConfig[G, F, U]](_.overrideFilter)
+    Focus[AdvancedConfig[G, F, U]](_.overrideFilter)
 
   def overrideFpu[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[U]] =
-      Focus[AdvancedConfig[G, F, U]](_.overrideFpu)
+    Focus[AdvancedConfig[G, F, U]](_.overrideFpu)
 
   def explicitXBin[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[GmosXBinning]] =
     Focus[AdvancedConfig[G, F, U]](_.explicitXBin)

--- a/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/AdvancedConfig.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/AdvancedConfig.scala
@@ -12,6 +12,7 @@ import eu.timepit.refined.types.all.NonEmptyString
 import lucuma.core.`enum`.{GmosAmpGain, GmosAmpReadMode, GmosRoi, GmosXBinning, GmosYBinning}
 import lucuma.core.math.{Angle, Offset, Wavelength}
 import lucuma.core.math.units.Nanometer
+import lucuma.odb.api.model.ExposureMode
 import monocle.{Focus, Lens}
 
 /**
@@ -24,6 +25,7 @@ final case class AdvancedConfig[G, F, U](
   overrideGrating:        Option[G]                                      = None,
   overrideFilter:         Option[Option[F]]                              = None,
   overrideFpu:            Option[U]                                      = None,
+  overrideExposureMode:   Option[ExposureMode]                           = None,
   explicitXBin:           Option[GmosXBinning]                           = None,  // calculated from effective slit and sampling by default
   explicitYBin:           Option[GmosYBinning]                           = None,
   explicitAmpReadMode:    Option[GmosAmpReadMode]                        = None,
@@ -72,6 +74,7 @@ object AdvancedConfig extends AdvancedConfigOptics {
       a.overrideGrating,
       a.overrideFilter,
       a.overrideFpu,
+      a.overrideExposureMode,
       a.explicitXBin,
       a.explicitYBin,
       a.explicitAmpReadMode,
@@ -99,6 +102,9 @@ sealed trait AdvancedConfigOptics { self: AdvancedConfig.type =>
 
   def overrideFpu[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[U]] =
     Focus[AdvancedConfig[G, F, U]](_.overrideFpu)
+
+  def overrideExposureMode[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[ExposureMode]] =
+    Focus[AdvancedConfig[G, F, U]](_.overrideExposureMode)
 
   def explicitXBin[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[GmosXBinning]] =
     Focus[AdvancedConfig[G, F, U]](_.explicitXBin)

--- a/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/AdvancedConfigInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/AdvancedConfigInput.scala
@@ -19,7 +19,8 @@ import lucuma.core.`enum`.{GmosAmpGain, GmosAmpReadMode, GmosRoi, GmosXBinning, 
 import lucuma.core.math.Axis.Q
 import lucuma.core.math.{Offset, Wavelength}
 import lucuma.core.math.units.Nanometer
-import lucuma.odb.api.model.{EditorInput, EitherInput, ExposureMode, InputError, OffsetModel, ValidatedInput}
+import lucuma.odb.api.model.{EditorInput, EitherInput, InputError, OffsetModel, ValidatedInput}
+import lucuma.odb.api.model.ExposureTimeMode.ExposureModeInput
 import lucuma.odb.api.model.WavelengthModel.WavelengthInput
 import lucuma.odb.api.model.syntax.input._
 import lucuma.odb.api.model.syntax.lens._
@@ -31,7 +32,7 @@ final case class AdvancedConfigInput[G, F, U](
   overrideGrating:           Input[G]                                = Input.ignore,
   overrideFilter:            Input[Option[F]]                        = Input.ignore,
   overrideFpu:               Input[U]                                = Input.ignore,
-  overrideExposureMode:      Input[ExposureMode.ExposureModeInput]   = Input.ignore,
+  overrideExposureTimeMode:  Input[ExposureModeInput]                = Input.ignore,
   explicitXBin:              Input[GmosXBinning]                     = Input.ignore,
   explicitYBin:              Input[GmosYBinning]                     = Input.ignore,
   explicitAmpReadMode:       Input[GmosAmpReadMode]                  = Input.ignore,
@@ -44,22 +45,22 @@ final case class AdvancedConfigInput[G, F, U](
   override val create: ValidatedInput[AdvancedConfig[G, F, U]] =
     (explicitSpatialOffsets.toOption.toList.flatten.traverse(_.toComponent[Q]),
      overrideWavelength.toOption.traverse(_.toWavelength("overrideWavelength")),
-     overrideExposureMode.toOption.traverse(_.create)
+     overrideExposureTimeMode.toOption.traverse(_.create)
     ).mapN { (os, wavelength, exp) =>
       AdvancedConfig(
         name.toOption,
-        overrideWavelength     = wavelength,
-        overrideGrating        = overrideGrating.toOption,
-        overrideFilter         = overrideFilter.toOption,
-        overrideFpu            = overrideFpu.toOption,
-        overrideExposureMode   = exp,
-        explicitXBin           = explicitXBin.toOption,
-        explicitYBin           = explicitYBin.toOption,
-        explicitAmpReadMode    = explicitAmpReadMode.toOption,
-        explicitAmpGain        = explicitAmpGain.toOption,
-        explicitRoi            = explicitRoi.toOption,
-        explicitλDithers       = NonEmptyList.fromList(explicitWavelengthDithers.toOption.toList.flatten.map(i => Quantity[Int, Nanometer](i))),
-        explicitSpatialOffsets = NonEmptyList.fromList(os)
+        overrideWavelength       = wavelength,
+        overrideGrating          = overrideGrating.toOption,
+        overrideFilter           = overrideFilter.toOption,
+        overrideFpu              = overrideFpu.toOption,
+        overrideExposureTimeMode = exp,
+        explicitXBin             = explicitXBin.toOption,
+        explicitYBin             = explicitYBin.toOption,
+        explicitAmpReadMode      = explicitAmpReadMode.toOption,
+        explicitAmpGain          = explicitAmpGain.toOption,
+        explicitRoi              = explicitRoi.toOption,
+        explicitλDithers         = NonEmptyList.fromList(explicitWavelengthDithers.toOption.toList.flatten.map(i => Quantity[Int, Nanometer](i))),
+        explicitSpatialOffsets   = NonEmptyList.fromList(os)
       )
     }
 
@@ -75,7 +76,7 @@ final case class AdvancedConfigInput[G, F, U](
       _ <- AdvancedConfig.overrideGrating[G, F, U]      := overrideGrating.toOptionOption
       _ <- AdvancedConfig.overrideFilter[G, F, U]       := overrideFilter.toOptionOption
       _ <- AdvancedConfig.overrideFpu[G, F, U]          := overrideFpu.toOptionOption
-      _ <- AdvancedConfig.overrideExposureMode[G, F, U] :? overrideExposureMode
+      _ <- AdvancedConfig.overrideExposureMode[G, F, U] :? overrideExposureTimeMode
       _ <- AdvancedConfig.explicitXBin                  := explicitXBin.toOptionOption
       _ <- AdvancedConfig.explicitYBin                  := explicitYBin.toOptionOption
       _ <- AdvancedConfig.explicitAmpReadMode           := explicitAmpReadMode.toOptionOption
@@ -119,7 +120,7 @@ object AdvancedConfigInput {
       a.overrideGrating,
       a.overrideFilter,
       a.overrideFpu,
-      a.overrideExposureMode,
+      a.overrideExposureTimeMode,
       a.explicitXBin,
       a.explicitYBin,
       a.explicitAmpReadMode,

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionSchema.scala
@@ -197,11 +197,14 @@ object ExecutionSchema {
 
         Field(
           name        = "executionConfig",
-          fieldType   = OptionType(ExecutionConfigType[F]),
+          fieldType   = ExecutionConfigType[F],
           description = "Execution config".some,
           resolve     = c =>
             c.unsafeToFuture(
-              SequenceComputation.compute[F](c.value, c.ctx.itcClient, c.ctx.odbRepo)
+              for {
+                s <- SequenceComputation.compute[F](c.value, c.ctx.itcClient, c.ctx.odbRepo)
+                e <- s.leftMap(m => InputError.fromMessage(m).toException).liftTo[F]
+              } yield e
             )
         )
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/GmosSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/GmosSchema.scala
@@ -531,7 +531,7 @@ object GmosSchema {
       s"${gmos(site).tag.capitalize}DynamicInput",
       s"${gmos(site).longName} instrument configuration input",
       List(
-        InputField("exposure",      InputObjectTypeDuration,            "Exposure time"),
+        InputField("exposure",      InputObjectTypeNonNegDuration,            "Exposure time"),
         InputField("readout",       InputObjectTypeGmosCcdReadoutInput, "GMOS CCD readout"),
         InputField("dtax",          EnumTypeGmosDtax,                   "GMOS detector x offset"),
         InputField("roi",           EnumTypeGmosRoi,                    "GMOS region of interest"),

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ItcSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ItcSchema.scala
@@ -8,7 +8,7 @@ import sangria.schema.{Field, _}
 
 object ItcSchema {
 
-  import RefinedSchema.PosBigDecimalType
+  import RefinedSchema.{PosBigDecimalType, NonNegIntType}
   import TimeSchema.NonNegativeDurationType
 
   val ItcSuccessType: ObjectType[Any, ItcResult.Success] =
@@ -24,7 +24,7 @@ object ItcSchema {
 
         Field(
           name      = "exposures",
-          fieldType = IntType,
+          fieldType = NonNegIntType,
           resolve   = _.value.exposures
         ),
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceModeMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceModeMutation.scala
@@ -12,6 +12,7 @@ trait ScienceModeMutation {
 
   import syntax.inputtype._
   import GmosSchema._
+  import WavelengthSchema.InputWavelength
 
   def inputObjectTypeGmosLongSlitBasicConfig[G, F, U](
     siteName:    String,
@@ -55,6 +56,7 @@ trait ScienceModeMutation {
       s"Gmos${siteName.capitalize}LongSlitAdvancedConfigInput",
       s"Edit or create GMOS ${siteName.capitalize} Long Slit advanced configuration",
       List(
+        InputWavelength.nullableField("overrideWavelength"),
         gratingEnum.nullableField("overrideGrating"),
         filterEnum.nullableField("overrideFilter"),
         fpuEnum.nullableField("overrideFpu"),

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceModeSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceModeSchema.scala
@@ -108,6 +108,13 @@ object ScienceModeSchema {
       fields[Any, AdvancedConfig[G, F, U]](
 
         Field(
+          name        = "overrideWavelength",
+          fieldType   = OptionType(WavelengthSchema.WavelengthType),
+          description = "Overrides the science requirement wavelength".some,
+          resolve     = _.value.overrideWavelength
+        ),
+
+        Field(
           name        = "overrideGrating",
           fieldType   = OptionType(gratingEnum),
           description = "GMOS North Grating override, taking the place of the basic configuration grating".some,

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TimeSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TimeSchema.scala
@@ -81,7 +81,7 @@ object TimeSchema {
     )
   }
 
-  val InputObjectTypeDuration: InputObjectType[DurationModel.NonNegDurationInput] =
+  val InputObjectTypeNonNegDuration: InputObjectType[DurationModel.NonNegDurationInput] =
     InputObjectType[DurationModel.NonNegDurationInput](
       "NonNegDurationInput",
       "Time duration input",

--- a/modules/core/src/test/scala/lucuma/gen/gmos/longslit/GmosNorthLongSlitSuite.scala
+++ b/modules/core/src/test/scala/lucuma/gen/gmos/longslit/GmosNorthLongSlitSuite.scala
@@ -57,6 +57,8 @@ final class GmosNorthLongSlitSuite extends ScalaCheckSuite {
         exposureCount
       )
 
+  def wavelength(m: ScienceMode.GmosNorthLongSlit): Wavelength =
+    m.advanced.flatMap(_.overrideWavelength).getOrElse(λ)
 
   property("all atoms and steps have unique ids") {
     forAll { (mode: ScienceMode.GmosNorthLongSlit, sp: SourceProfile, iq: ImageQuality) =>
@@ -84,7 +86,7 @@ final class GmosNorthLongSlitSuite extends ScalaCheckSuite {
 
       val acq = Acquisition.GmosNorth.compute(
         GmosNorthFilter.allAcquisition.fproduct(_.wavelength),
-        mode.fpu, acqTime, λ
+        mode.fpu, acqTime, wavelength(mode)
       )
       val stp = List(
         RecordedStep(acq.ccd2, successfullyExecuted = true),
@@ -135,7 +137,7 @@ final class GmosNorthLongSlitSuite extends ScalaCheckSuite {
 
   property("skip executed atoms") {
     forAll { (mode: ScienceMode.GmosNorthLongSlit, sp: SourceProfile, iq: ImageQuality) =>
-      val sci   = Science.GmosNorth.compute(mode, sciTime, λ, sp, iq, sampling)
+      val sci   = Science.GmosNorth.compute(mode, sciTime, wavelength(mode), sp, iq, sampling)
       val stp   = sci.head.steps.toList.map(c => RecordedStep(c, successfullyExecuted = true))
       val seq   = longSlit(mode, sp, iq).science(stp)
       val atoms = seq.unsafeRunSync().atoms.flatMap(_.steps.toList).map(_.config)
@@ -145,7 +147,7 @@ final class GmosNorthLongSlitSuite extends ScalaCheckSuite {
 
   property("executing part of an atom is not executing it at all") {
     forAll { (mode: ScienceMode.GmosNorthLongSlit, sp: SourceProfile, iq: ImageQuality) =>
-      val sci   = Science.GmosNorth.compute(mode, sciTime, λ, sp, iq, sampling)
+      val sci   = Science.GmosNorth.compute(mode, sciTime, wavelength(mode), sp, iq, sampling)
       val steps = sci.take(exposureCount).toList.map(a => RecordedStep(a.science, successfullyExecuted = true))
       val seq   = longSlit(mode, sp, iq).science(steps)
       val atoms = seq.unsafeRunSync().atoms.flatMap(_.steps.toList).map(_.config)
@@ -155,7 +157,7 @@ final class GmosNorthLongSlitSuite extends ScalaCheckSuite {
 
   property("executing all the steps stops the sequence") {
     forAll { (mode: ScienceMode.GmosNorthLongSlit, sp: SourceProfile, iq: ImageQuality) =>
-      val sci   = Science.GmosNorth.compute(mode, sciTime, λ, sp, iq, sampling)
+      val sci   = Science.GmosNorth.compute(mode, sciTime, wavelength(mode), sp, iq, sampling)
       val steps = sci.take(exposureCount).toList.flatMap(_.steps.toList.map(RecordedStep(_, successfullyExecuted = true)))
       val seq   = longSlit(mode, sp, iq).science(steps)
       val atoms = seq.unsafeRunSync().atoms.flatMap(_.steps.toList).map(_.config)
@@ -166,7 +168,7 @@ final class GmosNorthLongSlitSuite extends ScalaCheckSuite {
   property("non-contiguous steps do not make an atom") {
     forAll { (mode: ScienceMode.GmosNorthLongSlit, sp: SourceProfile, iq: ImageQuality) =>
       val acq   = Acquisition.GmosNorth.compute(GmosNorthFilter.allAcquisition.fproduct(_.wavelength), mode.fpu, acqTime, λ)
-      val sci   = Science.GmosNorth.compute(mode, sciTime, λ, sp, iq, sampling)
+      val sci   = Science.GmosNorth.compute(mode, sciTime, wavelength(mode), sp, iq, sampling)
       val steps =
         sci.take(exposureCount).toList.flatMap(_.steps.toList).flatMap { sc =>
           List(

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExposureMode.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExposureMode.scala
@@ -5,7 +5,7 @@ package lucuma.odb.api.model
 package arb
 
 import clue.data.Input
-import eu.timepit.refined.types.all.{PosBigDecimal, PosInt}
+import eu.timepit.refined.types.all.{NonNegInt, PosBigDecimal}
 import eu.timepit.refined.scalacheck.all._
 import lucuma.core.math.arb.ArbRefined
 import lucuma.odb.api.model.time.NonNegDuration
@@ -15,7 +15,7 @@ import org.scalacheck.Arbitrary.arbitrary
 
 sealed trait ArbExposureMode {
 
-  import ExposureMode._
+  import ExposureTimeMode._
 
   import ArbDurationModel._
   import ArbNonNegDuration._
@@ -41,14 +41,14 @@ sealed trait ArbExposureMode {
   implicit val arbFixedExposure: Arbitrary[FixedExposure] =
     Arbitrary {
       for {
-        c <- arbitrary[PosInt]
+        c <- arbitrary[NonNegInt]
         t <- arbitrary[NonNegDuration]
       } yield FixedExposure(c, t)
     }
 
   implicit val cogFixedExposure: Cogen[FixedExposure] =
     Cogen[(
-      PosInt,
+      NonNegInt,
       NonNegDuration
     )].contramap { in => (
       in.count,
@@ -58,29 +58,32 @@ sealed trait ArbExposureMode {
   implicit val arbFixedExposureInput: Arbitrary[FixedExposureInput] =
     Arbitrary {
       for {
-        c <- arbitrary[PosInt]
+        c <- arbitrary[NonNegInt]
         t <- arbitrary[DurationModel.NonNegDurationInput]
       } yield FixedExposureInput(c, t)
     }
 
   implicit val cogFixedExposureInput: Cogen[FixedExposureInput] =
-    Cogen[(PosInt, DurationModel.NonNegDurationInput)].contramap { a => (
+    Cogen[(
+      NonNegInt,
+      DurationModel.NonNegDurationInput
+    )].contramap { a => (
       a.count,
       a.time
     )}
 
-  implicit val arbExposureMode: Arbitrary[ExposureMode] =
+  implicit val arbExposureMode: Arbitrary[ExposureTimeMode] =
     Arbitrary {
       Gen.oneOf(arbitrary[FixedExposure], arbitrary[FixedExposure])
     }
 
-  implicit val cogExposureMode: Cogen[ExposureMode] =
+  implicit val cogExposureMode: Cogen[ExposureTimeMode] =
     Cogen[(
       Option[SignalToNoise],
       Option[FixedExposure]
     )].contramap { in => (
-      ExposureMode.signalToNoise.getOption(in),
-      ExposureMode.fixedExposure.getOption(in)
+      ExposureTimeMode.signalToNoise.getOption(in),
+      ExposureTimeMode.fixedExposure.getOption(in)
     )}
 
   implicit val arbExposureModeInput: Arbitrary[ExposureModeInput] =

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExposureMode.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbExposureMode.scala
@@ -1,0 +1,104 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+package arb
+
+import clue.data.Input
+import eu.timepit.refined.types.all.{PosBigDecimal, PosInt}
+import eu.timepit.refined.scalacheck.all._
+import lucuma.core.math.arb.ArbRefined
+import lucuma.odb.api.model.time.NonNegDuration
+import org.scalacheck._
+import org.scalacheck.Arbitrary.arbitrary
+
+
+sealed trait ArbExposureMode {
+
+  import ExposureMode._
+
+  import ArbDurationModel._
+  import ArbNonNegDuration._
+  import ArbInput._
+  import ArbRefined._
+
+  implicit val arbSignalToNoise: Arbitrary[SignalToNoise] =
+    Arbitrary {
+      arbitrary[PosBigDecimal].map(SignalToNoise)
+    }
+
+  implicit val cogSignalToNoise: Cogen[SignalToNoise] =
+    Cogen[PosBigDecimal].contramap(_.value)
+
+  implicit val arbSignalToNoiseInput: Arbitrary[SignalToNoiseInput] =
+    Arbitrary {
+      arbitrary[PosBigDecimal].map(SignalToNoiseInput.apply)
+    }
+
+  implicit val cogSignalToNoiseInput: Cogen[SignalToNoiseInput] =
+    Cogen[PosBigDecimal].contramap(_.value)
+
+  implicit val arbFixedExposure: Arbitrary[FixedExposure] =
+    Arbitrary {
+      for {
+        c <- arbitrary[PosInt]
+        t <- arbitrary[NonNegDuration]
+      } yield FixedExposure(c, t)
+    }
+
+  implicit val cogFixedExposure: Cogen[FixedExposure] =
+    Cogen[(
+      PosInt,
+      NonNegDuration
+    )].contramap { in => (
+      in.count,
+      in.time
+    )}
+
+  implicit val arbFixedExposureInput: Arbitrary[FixedExposureInput] =
+    Arbitrary {
+      for {
+        c <- arbitrary[PosInt]
+        t <- arbitrary[DurationModel.NonNegDurationInput]
+      } yield FixedExposureInput(c, t)
+    }
+
+  implicit val cogFixedExposureInput: Cogen[FixedExposureInput] =
+    Cogen[(PosInt, DurationModel.NonNegDurationInput)].contramap { a => (
+      a.count,
+      a.time
+    )}
+
+  implicit val arbExposureMode: Arbitrary[ExposureMode] =
+    Arbitrary {
+      Gen.oneOf(arbitrary[FixedExposure], arbitrary[FixedExposure])
+    }
+
+  implicit val cogExposureMode: Cogen[ExposureMode] =
+    Cogen[(
+      Option[SignalToNoise],
+      Option[FixedExposure]
+    )].contramap { in => (
+      ExposureMode.signalToNoise.getOption(in),
+      ExposureMode.fixedExposure.getOption(in)
+    )}
+
+  implicit val arbExposureModeInput: Arbitrary[ExposureModeInput] =
+    Arbitrary {
+      Gen.oneOf(
+        arbitrary[SignalToNoiseInput].map(ExposureModeInput.signalToNoise),
+        arbitrary[FixedExposureInput].map(ExposureModeInput.fixedExposure)
+      )
+    }
+
+  implicit val cogExposureModeInput: Cogen[ExposureModeInput] =
+    Cogen[(
+      Input[SignalToNoiseInput],
+      Input[FixedExposureInput]
+    )].contramap { in => (
+      in.signalToNoise,
+      in.fixedExposure
+    )}
+}
+
+object ArbExposureMode extends ArbExposureMode

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbScienceMode.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbScienceMode.scala
@@ -52,7 +52,7 @@ trait ArbScienceMode {
         g  <- arbitrary[Option[G]]
         f  <- arbitrary[Option[Option[F]]]
         u  <- arbitrary[Option[U]]
-        e  <- arbitrary[Option[ExposureMode]]
+        e  <- arbitrary[Option[ExposureTimeMode]]
         x  <- arbitrary[Option[GmosXBinning]]
         y  <- arbitrary[Option[GmosYBinning]]
         ar <- arbitrary[Option[GmosAmpReadMode]]
@@ -68,7 +68,7 @@ trait ArbScienceMode {
       Option[G],
       Option[Option[F]],
       Option[U],
-      Option[ExposureMode],
+      Option[ExposureTimeMode],
       Option[GmosXBinning],
       Option[GmosYBinning],
       Option[GmosAmpReadMode],
@@ -80,7 +80,7 @@ trait ArbScienceMode {
       a.overrideGrating,
       a.overrideFilter,
       a.overrideFpu,
-      a.overrideExposureMode,
+      a.overrideExposureTimeMode,
       a.explicitXBin,
       a.explicitYBin,
       a.explicitAmpReadMode,

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbScienceMode.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbScienceMode.scala
@@ -21,6 +21,7 @@ trait ArbScienceMode {
   import ScienceMode.{GmosNorthLongSlit, GmosSouthLongSlit}
 
   import ArbEnumerated._
+  import ArbExposureMode._
   import ArbWavelength._
 
   implicit def arbBasicConfig[G: Arbitrary, F: Arbitrary, U: Arbitrary]: Arbitrary[BasicConfig[G, F, U]] =
@@ -51,12 +52,13 @@ trait ArbScienceMode {
         g  <- arbitrary[Option[G]]
         f  <- arbitrary[Option[Option[F]]]
         u  <- arbitrary[Option[U]]
+        e  <- arbitrary[Option[ExposureMode]]
         x  <- arbitrary[Option[GmosXBinning]]
         y  <- arbitrary[Option[GmosYBinning]]
         ar <- arbitrary[Option[GmosAmpReadMode]]
         ag <- arbitrary[Option[GmosAmpGain]]
         ro <- arbitrary[Option[GmosRoi]]
-      } yield AdvancedConfig(n, w, g, f, u, x, y, ar, ag, ro)
+      } yield AdvancedConfig(n, w, g, f, u, e, x, y, ar, ag, ro)
     }
 
   implicit def cogAdvancedConfig[G: Cogen, F: Cogen, U: Cogen]: Cogen[AdvancedConfig[G, F, U]] =
@@ -66,6 +68,7 @@ trait ArbScienceMode {
       Option[G],
       Option[Option[F]],
       Option[U],
+      Option[ExposureMode],
       Option[GmosXBinning],
       Option[GmosYBinning],
       Option[GmosAmpReadMode],
@@ -77,6 +80,7 @@ trait ArbScienceMode {
       a.overrideGrating,
       a.overrideFilter,
       a.overrideFpu,
+      a.overrideExposureMode,
       a.explicitXBin,
       a.explicitYBin,
       a.explicitAmpReadMode,

--- a/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbScienceMode.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/model/arb/ArbScienceMode.scala
@@ -7,6 +7,8 @@ package arb
 import eu.timepit.refined.scalacheck.string._
 import eu.timepit.refined.types.all.NonEmptyString
 import lucuma.core.`enum`.{GmosAmpGain, GmosAmpReadMode, GmosNorthFilter, GmosNorthFpu, GmosNorthGrating, GmosRoi, GmosSouthFilter, GmosSouthFpu, GmosSouthGrating, GmosXBinning, GmosYBinning}
+import lucuma.core.math.Wavelength
+import lucuma.core.math.arb.ArbWavelength
 import lucuma.odb.api.model.gmos.longslit.{AdvancedConfig, BasicConfig}
 import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck.Arbitrary
@@ -19,6 +21,7 @@ trait ArbScienceMode {
   import ScienceMode.{GmosNorthLongSlit, GmosSouthLongSlit}
 
   import ArbEnumerated._
+  import ArbWavelength._
 
   implicit def arbBasicConfig[G: Arbitrary, F: Arbitrary, U: Arbitrary]: Arbitrary[BasicConfig[G, F, U]] =
     Arbitrary {
@@ -44,6 +47,7 @@ trait ArbScienceMode {
     Arbitrary {
       for {
         n  <- arbitrary[Option[NonEmptyString]]
+        w  <- arbitrary[Option[Wavelength]]
         g  <- arbitrary[Option[G]]
         f  <- arbitrary[Option[Option[F]]]
         u  <- arbitrary[Option[U]]
@@ -52,12 +56,13 @@ trait ArbScienceMode {
         ar <- arbitrary[Option[GmosAmpReadMode]]
         ag <- arbitrary[Option[GmosAmpGain]]
         ro <- arbitrary[Option[GmosRoi]]
-      } yield AdvancedConfig(n, g, f, u, x, y, ar, ag, ro)
+      } yield AdvancedConfig(n, w, g, f, u, x, y, ar, ag, ro)
     }
 
   implicit def cogAdvancedConfig[G: Cogen, F: Cogen, U: Cogen]: Cogen[AdvancedConfig[G, F, U]] =
     Cogen[(
       Option[String],
+      Option[Wavelength],
       Option[G],
       Option[Option[F]],
       Option[U],
@@ -68,6 +73,7 @@ trait ArbScienceMode {
       Option[GmosRoi]
     )].contramap { a => (
       a.name.map(_.value),
+      a.overrideWavelength,
       a.overrideGrating,
       a.overrideFilter,
       a.overrideFpu,

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Config.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Config.scala
@@ -68,8 +68,7 @@ object Config {
   def fromCiris[F[_]]: ConfigValue[F, Config] =
     (
       (envOrProp[F]("ODB_PORT") or envOrProp[F]("PORT") or ConfigValue.default("8080")).as[Int],
-      (envOrProp[F]("ITC_URI") or ConfigValue.default("https://itc-development.herokuapp.com/itc")).as[Uri]
-//      (envOrProp[F]("ITC_URI") or ConfigValue.default("https://itc-staging.herokuapp.com/itc")).as[Uri]
+      (envOrProp[F]("ITC_URI") or ConfigValue.default("https://itc-staging.herokuapp.com/itc")).as[Uri]
     ).parMapN(Config.apply)
 
 // TODO: SSO


### PR DESCRIPTION
Adds `overrideWavelength` and `overrideExposureTimeMode` to the science mode advanced configuration input and output.  They can be set to ignore the science requirements and use a different wavelength and/or exposure time mode.  If set to explicit exposure count and time then the call to ITC is bypassed (for now anyway -- eventually we need to make a call to get the acquisition time).

<img width="928" alt="Screen Shot 2022-05-25 at 16 29 29" src="https://user-images.githubusercontent.com/4906023/170361715-6745bdc3-b493-40a3-aa51-6c5a93922973.png">

![Screen Shot 2022-05-25 at 16 28 11](https://user-images.githubusercontent.com/4906023/170361408-85c6a2c6-7115-4e82-9495-d382d2f74db8.png)
