### PR TITLE
Normalize observe mutations

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/repo/DatasetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/DatasetRepo.scala
@@ -75,24 +75,6 @@ object DatasetRepo {
       ): F[List[DatasetModel]] =
         databaseRef.modifyState(editInput.editor.flipF).flatMap(_.liftTo[F])
 
-      //      override def markQaState(
-//        oid:   Observation.Id,
-//        sid:   Option[Step.Id],
-//        index: Option[PosInt],
-//        qa:    DatasetQaState
-//      ): F[List[DatasetModel]] =
-//
-//        databaseRef.modify { db =>
-//          val dbʹ =
-//            Database.datasets.modify { t =>
-//              t.selectAll(oid, sid, index).foldLeft(t) { (tʹ, d) =>
-//                tʹ.updatedWith(d.id)(_.map(DatasetModel.Dataset.qaState.replace(qa.some)))
-//              }
-//            }(db)
-//
-//          (dbʹ, dbʹ.datasets.selectAll(oid, sid, index))
-//        }
-
     }
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/DatasetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/DatasetMutation.scala
@@ -7,16 +7,19 @@ import cats.effect.Async
 import cats.effect.std.Dispatcher
 import lucuma.odb.api.model.DatasetModel
 import lucuma.odb.api.repo.OdbCtx
+import lucuma.odb.api.schema.syntax.inputobjecttype._
+import lucuma.odb.api.schema.syntax.inputtype._
 import org.typelevel.log4cats.Logger
 import sangria.macros.derive._
+import sangria.marshalling.circe._
 import sangria.schema._
 
 trait DatasetMutation {
 
-  import DatasetSchema.{ArgumentDatasetQaState, ArgumentOptionalDatasetIndex, DatasetType}
-  import ObservationSchema.{ObservationIdArgument, ObservationIdType}
+  import DatasetSchema.{EnumTypeDatasetQaState, DatasetType}
+  import ObservationSchema.ObservationIdType
   import RefinedSchema.PosIntType
-  import StepSchema.{ArgumentOptionalStepId, StepIdType}
+  import StepSchema.StepIdType
   import context._
 
   implicit val InputObjectTypeDatasetId: InputObjectType[DatasetModel.Id] =
@@ -25,29 +28,58 @@ trait DatasetMutation {
       InputObjectTypeDescription("Dataset model id creation parameters")
     )
 
-  def setDatasetQaState[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
+  implicit val InputObjectTypeDatasetSelect: InputObjectType[DatasetModel.SelectInput] =
+    InputObjectType[DatasetModel.SelectInput](
+      "DatasetSelectInput",
+      """Choose observationId to include all of its datasets, add a step id to
+        |limit it to a particular step, and an index to limit to a particular
+        |dataset produced by the step.
+        |""".stripMargin,
+      List(
+        InputField("observationId", ObservationIdType),
+        StepIdType.optionField("stepId"),
+        PosIntType.optionField("index")
+      )
+    )
+
+  implicit val InputObjectTypeDatasetProperties: InputObjectType[DatasetModel.PropertiesInput] =
+    InputObjectType[DatasetModel.PropertiesInput](
+      "DatasetPropertiesInput",
+      "Editable dataset properties",
+      List(
+        EnumTypeDatasetQaState.optionField("qaState")
+      )
+    )
+
+  val InputObjectTypeDatasetEdit: InputObjectType[DatasetModel.EditInput] =
+    InputObjectType[DatasetModel.EditInput](
+      "EditDatasetInput",
+      "Dataset selection and update description",
+      List(
+        InputField("select", InputObjectTypeDatasetSelect),
+        InputField("patch",  InputObjectTypeDatasetProperties)
+      )
+    )
+
+  val ArgumentDatasetEdit: Argument[DatasetModel.EditInput] =
+    InputObjectTypeDatasetEdit.argument(
+      "input",
+      "Parameters for editing existing datasets"
+    )
+
+  def editDataset[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name      = "setDatasetQaState",
+      name      = "editDataset",
       fieldType = ListType(DatasetType[F]),
       arguments = List(
-        ObservationIdArgument,
-        ArgumentOptionalStepId,
-        ArgumentOptionalDatasetIndex,
-        ArgumentDatasetQaState
+        ArgumentDatasetEdit
       ),
-      resolve   = c => c.dataset(
-        _.markQaState(
-          c.observationId,
-          c.optionalStepId,
-          c.arg(ArgumentOptionalDatasetIndex),
-          c.arg(ArgumentDatasetQaState)
-        )
-      )
+      resolve   = c => c.dataset(_.edit(c.arg(ArgumentDatasetEdit)))
     )
 
   def allFields[F[_]: Dispatcher: Async: Logger]: List[Field[OdbCtx[F], Unit]] =
     List(
-      setDatasetQaState
+      editDataset
     )
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
@@ -43,7 +43,7 @@ trait ExecutionEventMutation {
     staticInput: InputObjectType[SI]
   ): InputObjectType[VisitRecord.Input[SI]] =
     InputObjectType[VisitRecord.Input[SI]](
-      s"${typePrefix.capitalize}VisitRecordInput",
+      s"Record${typePrefix.capitalize}VisitInput",
       s"Input parameters for creating a new ${typePrefix.capitalize} VisitRecord",
       List(
         InputField("observationId", ObservationIdType),
@@ -115,7 +115,7 @@ trait ExecutionEventMutation {
     stepType:   InputType[DI]
   ): InputObjectType[StepRecord.Input[DI]] =
     InputObjectType[StepRecord.Input[DI]](
-      s"${typePrefix.capitalize}StepRecordInput",
+      s"Record${typePrefix.capitalize}StepInput",
       s"Input parameters for creating a new ${typePrefix.capitalize} StepRecord",
       List(
         InputField("observationId", ObservationIdType),

--- a/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
+++ b/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
@@ -252,9 +252,9 @@ class VisitSuite extends OdbSuite {
 
   // Set the QA State
   queryTest(
-    query = s"""
-      mutation SetQaState {
-        setDatasetQaState(observationId: "o-2", qaState: PASS) {
+    query = """
+      mutation EditDataset($editDatasetInput: EditDatasetInput!) {
+        editDataset(input: $editDatasetInput) {
           id {
             observationId
             stepId
@@ -267,7 +267,7 @@ class VisitSuite extends OdbSuite {
     """,
     expected =json"""
       {
-        "setDatasetQaState": [
+        "editDataset": [
           {
             "id": {
               "observationId": "o-2",
@@ -280,7 +280,19 @@ class VisitSuite extends OdbSuite {
         ]
       }
     """,
-    variables = None,
+    variables =json"""
+      {
+        "editDatasetInput": {
+          "select": {
+            "observationId": "o-2",
+            "stepId": ${sid.toString}
+          },
+          "patch": {
+            "qaState": "PASS"
+          }
+        }
+      }
+    """.some,
     List(ClientOption.Http)
   )
 

--- a/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
+++ b/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
@@ -19,7 +19,7 @@ class VisitSuite extends OdbSuite {
   // Record a visit.
   queryTest(
     query = s"""
-      mutation RecordGmosSouthVisit($$recordInput: GmosSouthVisitRecordInput!) {
+      mutation RecordGmosSouthVisit($$recordInput: RecordGmosSouthVisitInput!) {
         recordGmosSouthVisit(input: $$recordInput, visitId: "$vid") {
           id
         }
@@ -86,7 +86,7 @@ class VisitSuite extends OdbSuite {
   // Record a step.
   queryTest(
     query = s"""
-      mutation RecordGmosSouthStep($$recordInput: GmosSouthStepRecordInput!) {
+      mutation RecordGmosSouthStep($$recordInput: RecordGmosSouthStepInput!) {
         recordGmosSouthStep(input: $$recordInput, stepId: "$sid") {
           id
         }


### PR DESCRIPTION
Normalizes the mutations that are intended for Observe and Chronicle.  In particular, the `setDatasetQaState` with its list of arguments turned into `editDataset` with `select` and `patch` inputs like the other edit mutations.

I don't think this one will necessitate any substantive changes to Explore.