### PR TITLE
normalize (un)delete

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -140,17 +140,7 @@ object ObservationModel extends ObservationOptics {
   object PropertiesInput {
 
     val Empty: PropertiesInput =
-      PropertiesInput(
-        subtitle            = Input.ignore,
-        status              = Input.ignore,
-        activeStatus        = Input.ignore,
-        targetEnvironment   = Input.ignore,
-        constraintSet       = Input.ignore,
-        scienceRequirements = Input.ignore,
-        scienceMode         = Input.ignore,
-        config              = Input.ignore,
-        existence           = Input.ignore
-      )
+      PropertiesInput()
 
     import io.circe.generic.extras.semiauto._
     import io.circe.generic.extras.Configuration

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
@@ -124,6 +124,9 @@ object TargetModel extends TargetModelOptics {
 
   object PropertiesInput {
 
+    val Empty: PropertiesInput =
+      PropertiesInput()
+
     import io.circe.generic.extras.semiauto._
     import io.circe.generic.extras.Configuration
     implicit val customConfig: Configuration = Configuration.default.withDefaults

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TopLevelRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TopLevelRepo.scala
@@ -68,9 +68,9 @@ trait TopLevelRepo[F[_], I, T] {
     editor: ValidatedInput[State[T, Unit]]
   ): F[T]
 
-  def delete(id: I): F[T]
+  def deleteOne(id: I): F[T]
 
-  def undelete(id: I): F[T]
+  def undeleteOne(id: I): F[T]
 
 }
 
@@ -201,10 +201,10 @@ abstract class TopLevelRepoBase[F[_], I: Gid, T: TopLevelModel[I, *]: Eq](
   private def setExistence(id: I, newState: Existence): F[T] =
     edit(id, TopLevelModel[I, T].existenceEditor(newState).validNec)
 
-  def delete(id: I): F[T] =
+  def deleteOne(id: I): F[T] =
     setExistence(id, Existence.Deleted)
 
-  def undelete(id: I): F[T] =
+  def undeleteOne(id: I): F[T] =
     setExistence(id, Existence.Present)
 
 }

--- a/modules/service/src/test/scala/test/GroupIncludeDeletedSuite.scala
+++ b/modules/service/src/test/scala/test/GroupIncludeDeletedSuite.scala
@@ -3,25 +3,37 @@
 
 package test
 
+import cats.syntax.option._
 import io.circe.literal._
 
 class GroupIncludeDeletedSuite extends OdbSuite {
 
   queryTest(
     query ="""
-      mutation DeleteObservation {
-        deleteObservation(observationId: "o-5") {
+      mutation DeleteObservation($deleteObservationInput: DeleteObservationInput!) {
+        deleteObservation(input: $deleteObservationInput) {
           id
         }
       }
     """,
     expected = json"""
       {
-        "deleteObservation": {
-          "id": "o-5"
+        "deleteObservation": [
+          {
+            "id": "o-5"
+          }
+        ]
+      }
+    """,
+    variables =json"""
+      {
+        "deleteObservationInput": {
+          "select": {
+            "observationIds": [ "o-5" ]
+          }
         }
       }
-    """
+    """.some
   )
 
   // After deletion of "o-5", the grouping will not contain it

--- a/modules/service/src/test/scala/test/targets/TargetGroupIncludeDeletedSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetGroupIncludeDeletedSuite.scala
@@ -4,6 +4,7 @@
 package test
 package targets
 
+import cats.syntax.option._
 import io.circe.literal._
 
 class TargetGroupIncludeDeletedSuite extends OdbSuite {
@@ -22,19 +23,30 @@ class TargetGroupIncludeDeletedSuite extends OdbSuite {
   // Delete NGC 3269 (t-3)
   queryTest(
     query ="""
-      mutation DeleteTarget {
-        deleteTarget(targetId: "t-3") {
+      mutation DeleteTarget($deleteTargetInput: DeleteTargetInput!) {
+        deleteTarget(input: $deleteTargetInput) {
           id
         }
       }
     """,
     expected = json"""
       {
-        "deleteTarget": {
-          "id": "t-3"
-        }
+        "deleteTarget": [
+          {
+            "id": "t-3"
+          }
+        ]
       }
     """,
+    variables = json"""
+      {
+        "deleteTargetInput": {
+          "select": {
+            "targetIds": [ "t-3" ]
+          }
+        }
+      }
+    """.some,
     clients = List(ClientOption.Http)
   )
 

--- a/modules/service/src/test/scala/test/targets/TargetMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetMutationSuite.scala
@@ -54,8 +54,8 @@ class TargetMutationSuite extends OdbSuite {
   // Delete a target by id.  No need to specify a target environment.
   queryTest(
     query = """
-      mutation DeleteTarget {
-        deleteTarget(targetId: "t-4") {
+      mutation DeleteTarget($deleteTargetInput: DeleteTargetInput!) {
+        deleteTarget(input: $deleteTargetInput) {
           id
           name
           existence
@@ -64,14 +64,24 @@ class TargetMutationSuite extends OdbSuite {
     """,
     expected = json"""
       {
-        "deleteTarget": {
-          "id": "t-4",
-          "name": "NGC 3312",
-          "existence": "DELETED"
-        }
+        "deleteTarget": [
+          {
+            "id": "t-4",
+            "name": "NGC 3312",
+            "existence": "DELETED"
+          }
+        ]
       }
     """,
-    None,
+    variables = json"""
+      {
+        "deleteTargetInput": {
+          "select": {
+            "targetIds": [ "t-4" ]
+          }
+        }
+      }
+    """.some,
     clients = List(ClientOption.Http)  // cannot run this test twice since it changes required state
   )
 


### PR DESCRIPTION
Updates `deleteObservation`, `deleteTarget`, `undeleteObservation` and `undeleteTarget` to follow the convention of taking a single input object parameter named after the mutation itself (e.g., `DeleteObservationInput`).  All the inputs reuse the same selection input used by the corresponding `edit` method.  For example,

```
{
  "deleteObservationInput": {
    "select": {
       "observationIds": [ "o-2" ]
    }
  }
}
```

For better or worse, this makes it very easy to delete many observations at once.  For example by selecting the program you could delete _all_ of its observations in a single mutation.  Fortunately this is easy to undo using the same selection input with `undeleteObservation`.