### PR TITLE
Payload

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/DatasetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/DatasetModel.scala
@@ -176,6 +176,17 @@ object DatasetModel extends DatasetModelOptics {
 
   }
 
+  final case class EditResult(
+    datasets: List[DatasetModel]
+  )
+
+  object EditResult {
+
+    implicit val EqEditResult: Eq[EditResult] =
+      Eq.by(_.datasets)
+
+  }
+
 }
 
 sealed trait DatasetModelOptics { self: DatasetModel.type =>

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ExecutionEventModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ExecutionEventModel.scala
@@ -171,6 +171,17 @@ object ExecutionEventModel {
 
     }
 
+    final case class Result(
+      newEvent: SequenceEvent
+    )
+
+    object Result {
+
+      implicit val OrderResult: Order[Result] =
+        Order.by(_.newEvent)
+
+    }
+
   }
 
 
@@ -311,6 +322,18 @@ object ExecutionEventModel {
         )}
 
     }
+
+    final case class Result(
+      newEvent: StepEvent
+    )
+
+    object Result {
+
+      implicit val OrderResult: Order[Result] =
+        Order.by(_.newEvent)
+
+    }
+
 
   }
 
@@ -486,6 +509,17 @@ object ExecutionEventModel {
           a.location,
           a.payload
         )}
+    }
+
+    final case class Result(
+      newEvent: DatasetEvent
+    )
+
+    object Result {
+
+      implicit val OrderResult: Order[Result] =
+        Order.by(_.newEvent)
+
     }
 
   }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ExecutionEventModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ExecutionEventModel.scala
@@ -172,13 +172,13 @@ object ExecutionEventModel {
     }
 
     final case class Result(
-      newEvent: SequenceEvent
+      event: SequenceEvent
     )
 
     object Result {
 
       implicit val OrderResult: Order[Result] =
-        Order.by(_.newEvent)
+        Order.by(_.event)
 
     }
 
@@ -324,13 +324,13 @@ object ExecutionEventModel {
     }
 
     final case class Result(
-      newEvent: StepEvent
+      event: StepEvent
     )
 
     object Result {
 
       implicit val OrderResult: Order[Result] =
-        Order.by(_.newEvent)
+        Order.by(_.event)
 
     }
 
@@ -512,13 +512,13 @@ object ExecutionEventModel {
     }
 
     final case class Result(
-      newEvent: DatasetEvent
+      event: DatasetEvent
     )
 
     object Result {
 
       implicit val OrderResult: Order[Result] =
-        Order.by(_.newEvent)
+        Order.by(_.event)
 
     }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -316,6 +316,18 @@ object ObservationModel extends ObservationOptics {
 
   }
 
+  final case class EditResult(
+    observations: List[ObservationModel]
+  )
+
+  object EditResult {
+
+    implicit val EqEditResult: Eq[EditResult] =
+      Eq.by(_.observations)
+
+  }
+
+
   final case class CloneResult(
     originalObservation: ObservationModel,
     newObservation:      ObservationModel

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -238,13 +238,13 @@ object ObservationModel extends ObservationOptics {
   }
 
   final case class CreateResult(
-    newObservation: ObservationModel
+    observation: ObservationModel
   )
 
   object CreateResult {
 
     implicit val EqCreateResult: Eq[CreateResult] =
-      Eq.by(_.newObservation)
+      Eq.by(_.observation)
   }
 
   final case class SelectInput(

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -237,6 +237,16 @@ object ObservationModel extends ObservationOptics {
       properties.some.andThen(PropertiesInput.manualConfig)
   }
 
+  final case class CreateResult(
+    newObservation: ObservationModel
+  )
+
+  object CreateResult {
+
+    implicit val EqCreateResult: Eq[CreateResult] =
+      Eq.by(_.newObservation)
+  }
+
   final case class SelectInput(
     programId:      Option[Program.Id],
     observationIds: Option[List[Observation.Id]]

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -306,13 +306,28 @@ object ObservationModel extends ObservationOptics {
 
   }
 
+  final case class CloneResult(
+    originalObservation: ObservationModel,
+    newObservation:      ObservationModel
+  )
+
+  object CloneResult {
+
+    implicit val EqCloneResult: Eq[CloneResult] =
+      Eq.by { a => (
+        a.originalObservation,
+        a.newObservation
+      )}
+
+  }
+
   final case class CloneInput(
     observationId: Observation.Id,
     patch:         Option[PropertiesInput]
   ) {
 
     // At the moment, manual config (if present in patch) is ignored
-    val go: StateT[EitherInput, Database, ObservationModel] =
+    val go: StateT[EitherInput, Database, CloneResult] =
       for {
         o  <- Database.observation.lookup(observationId)
         i  <- Database.observation.cycleNextUnused
@@ -324,7 +339,7 @@ object ObservationModel extends ObservationOptics {
             p
           ).editor.map(_.head)
         }
-      } yield cʹ
+      } yield CloneResult(originalObservation = o, newObservation = cʹ)
 
   }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
@@ -113,13 +113,13 @@ object ProgramModel extends ProgramOptics {
   }
 
   final case class CreateResult(
-    newProgram: ProgramModel
+    program: ProgramModel
   )
 
   object CreateResult {
 
     implicit val EqCreateResult: Eq[CreateResult] =
-      Eq.by(_.newProgram)
+      Eq.by(_.program)
 
   }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
@@ -175,6 +175,17 @@ object ProgramModel extends ProgramOptics {
 
   }
 
+  final case class EditResult(
+    program: Option[ProgramModel]
+  )
+
+  object EditResult {
+
+    implicit val EqEditResult: Eq[EditResult] =
+      Eq.by(_.program)
+
+  }
+
   final case class ProgramEvent (
     id:       Long,
     editType: Event.EditType,

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
@@ -112,6 +112,17 @@ object ProgramModel extends ProgramOptics {
 
   }
 
+  final case class CreateResult(
+    newProgram: ProgramModel
+  )
+
+  object CreateResult {
+
+    implicit val EqCreateResult: Eq[CreateResult] =
+      Eq.by(_.newProgram)
+
+  }
+
   final case class SelectInput(
     programId: Option[Program.Id]
   ) {

--- a/modules/core/src/main/scala/lucuma/odb/api/model/StepRecord.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/StepRecord.scala
@@ -137,6 +137,17 @@ object StepRecord {
 
   }
 
+  final case class RecordResult[D](
+    stepRecord: Output[D]
+  )
+
+  object RecordResult {
+
+    implicit def EqRecordResult[D: Eq]: Eq[RecordResult[D]] =
+      Eq.by(_.stepRecord)
+
+  }
+
 }
 
 trait StepRecordOptics { self: StepRecord.type =>

--- a/modules/core/src/main/scala/lucuma/odb/api/model/VisitRecord.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/VisitRecord.scala
@@ -122,6 +122,17 @@ object VisitRecord extends VisitRecordOptics {
 
   }
 
+  final case class RecordResult[S, D](
+    visitRecord: Output[S, D]
+  )
+
+  object RecordResult {
+
+    implicit def EqRecordResult[S: Eq, D: Eq]: Eq[RecordResult[S, D]] =
+      Eq.by(_.visitRecord)
+
+  }
+
 }
 
 trait VisitRecordOptics { self: VisitRecord.type =>

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
@@ -191,13 +191,13 @@ object TargetModel extends TargetModelOptics {
   }
 
   final case class CreateResult(
-    newTarget: TargetModel
+    target: TargetModel
   )
 
   object CreateResult {
 
     implicit val EqCreateResult: Eq[CreateResult] =
-      Eq.by(_.newTarget)
+      Eq.by(_.target)
 
   }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
@@ -258,13 +258,28 @@ object TargetModel extends TargetModelOptics {
 
   }
 
+  final case class CloneResult(
+    originalTarget: TargetModel,
+    newTarget:      TargetModel
+  )
+
+  object CloneResult {
+
+    implicit val EqCloneResult: Eq[CloneResult] =
+      Eq.by { a => (
+        a.originalTarget,
+        a.newTarget
+      )}
+
+  }
+
   final case class CloneInput(
     targetId:  Target.Id,
     patch:     Option[PropertiesInput],
     replaceIn: Option[List[Observation.Id]]
   ) {
 
-    val go: StateT[EitherInput, Database, TargetModel] =
+    val go: StateT[EitherInput, Database, CloneResult] =
       for {
         t  <- Database.target.lookup(targetId)
         i  <- Database.target.cycleNextUnused
@@ -276,7 +291,7 @@ object TargetModel extends TargetModelOptics {
             p
           ).editor.map(_.head)
         }
-      } yield cʹ
+      } yield CloneResult(originalTarget = t, newTarget = cʹ)
 
   }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
@@ -269,6 +269,17 @@ object TargetModel extends TargetModelOptics {
 
   }
 
+  final case class EditResult(
+    targets: List[TargetModel]
+  )
+
+  object EditResult {
+
+    implicit val EqEditResult: Eq[EditResult] =
+      Eq.by(_.targets)
+
+  }
+
   final case class CloneResult(
     originalTarget: TargetModel,
     newTarget:      TargetModel

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
@@ -190,6 +190,17 @@ object TargetModel extends TargetModelOptics {
       )}
   }
 
+  final case class CreateResult(
+    newTarget: TargetModel
+  )
+
+  object CreateResult {
+
+    implicit val EqCreateResult: Eq[CreateResult] =
+      Eq.by(_.newTarget)
+
+  }
+
   final case class SelectInput(
     programId:      Option[Program.Id],
     observationIds: Option[List[Observation.Id]],

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/DatasetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/DatasetRepo.scala
@@ -32,7 +32,7 @@ sealed trait DatasetRepo[F[_]] {
 
   def edit(
     editInput: DatasetModel.EditInput
-  ): F[List[DatasetModel]]
+  ): F[DatasetModel.EditResult]
 
 }
 
@@ -72,8 +72,11 @@ object DatasetRepo {
 
       override def edit(
         editInput: DatasetModel.EditInput
-      ): F[List[DatasetModel]] =
-        databaseRef.modifyState(editInput.editor.flipF).flatMap(_.liftTo[F])
+      ): F[DatasetModel.EditResult] =
+        databaseRef
+          .modifyState(editInput.editor.flipF)
+          .flatMap(_.liftTo[F])
+          .map(ds => DatasetModel.EditResult(ds))
 
     }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
@@ -39,7 +39,7 @@ sealed trait ObservationRepo[F[_]] extends TopLevelRepo[F, Observation.Id, Obser
 
   def insert(input: CreateInput): F[ObservationModel.CreateResult]
 
-  def edit(edit: EditInput): F[List[ObservationModel]]
+  def edit(edit: EditInput): F[ObservationModel.EditResult]
 
   def clone(input: CloneInput): F[ObservationModel.CloneResult]
 
@@ -152,7 +152,7 @@ object ObservationRepo {
 
       }
 
-      override def edit(editInput: ObservationModel.EditInput): F[List[ObservationModel]] = {
+      override def edit(editInput: ObservationModel.EditInput): F[ObservationModel.EditResult] = {
         val editAndValidate =
           for {
             os  <- editInput.editor
@@ -162,7 +162,7 @@ object ObservationRepo {
         for {
           os <- databaseRef.modifyState(editAndValidate.flipF).flatMap(_.liftTo[F])
           _  <- os.traverse(o => eventService.publish(ObservationEvent.updated(o)))
-        } yield os
+        } yield ObservationModel.EditResult(os)
       }
 
       override def clone(

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
@@ -37,7 +37,7 @@ sealed trait ObservationRepo[F[_]] extends TopLevelRepo[F, Observation.Id, Obser
     includeDeleted: Boolean                = false
   ): F[Option[ExecutionModel]]
 
-  def insert(input: CreateInput): F[ObservationModel]
+  def insert(input: CreateInput): F[ObservationModel.CreateResult]
 
   def edit(edit: EditInput): F[List[ObservationModel]]
 
@@ -128,7 +128,7 @@ object ObservationRepo {
       ): F[Option[ExecutionModel]] =
         select(oid, includeDeleted).map(_.flatMap(_.manualConfig))
 
-      override def insert(newObs: CreateInput): F[ObservationModel] = {
+      override def insert(newObs: CreateInput): F[ObservationModel.CreateResult] = {
 
         // Create the observation
         val create: F[ObservationModel] =
@@ -148,7 +148,7 @@ object ObservationRepo {
         for {
           o <- create
           _ <- eventService.publish(ObservationEvent(_, Event.EditType.Created, o))
-        } yield o
+        } yield ObservationModel.CreateResult(o)
 
       }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ObservationRepo.scala
@@ -41,7 +41,7 @@ sealed trait ObservationRepo[F[_]] extends TopLevelRepo[F, Observation.Id, Obser
 
   def edit(edit: EditInput): F[List[ObservationModel]]
 
-  def clone(input: CloneInput): F[ObservationModel]
+  def clone(input: CloneInput): F[ObservationModel.CloneResult]
 
   def groupByTarget(
     pid:            Program.Id,
@@ -167,11 +167,11 @@ object ObservationRepo {
 
       override def clone(
         cloneInput: CloneInput
-      ): F[ObservationModel] =
+      ): F[ObservationModel.CloneResult] =
         for {
-          o <- databaseRef.modifyState(cloneInput.go.flipF).flatMap(_.liftTo[F])
-          _ <- eventService.publish(ObservationEvent(_, Event.EditType.Created, o))
-        } yield o
+          r <- databaseRef.modifyState(cloneInput.go.flipF).flatMap(_.liftTo[F])
+          _ <- eventService.publish(ObservationEvent(_, Event.EditType.Created, r.newObservation))
+        } yield r
 
       // Targets are different because they exist apart from observations.
       // In other words, there are targets which no observations reference.

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
@@ -24,7 +24,7 @@ trait ProgramRepo[F[_]] extends TopLevelRepo[F, Program.Id, ProgramModel] {
 
   def insert(input: ProgramModel.CreateInput): F[ProgramModel.CreateResult]
 
-  def edit(input: ProgramModel.EditInput): F[Option[ProgramModel]]
+  def edit(input: ProgramModel.EditInput): F[ProgramModel.EditResult]
 }
 
 object ProgramRepo {
@@ -75,12 +75,12 @@ object ProgramRepo {
 
       override def edit(
         input: ProgramModel.EditInput
-      ): F[Option[ProgramModel]] =
+      ): F[ProgramModel.EditResult] =
 
         for {
           p <- databaseRef.modifyState(input.editor.flipF).flatMap(_.liftTo[F])
           _ <- p.traverse(p => eventService.publish(ProgramModel.ProgramEvent.updated(p)))
-        } yield p
+        } yield ProgramModel.EditResult(p)
 
     }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/ProgramRepo.scala
@@ -22,7 +22,7 @@ trait ProgramRepo[F[_]] extends TopLevelRepo[F, Program.Id, ProgramModel] {
     includeDeleted: Boolean            = false
   ): F[ResultPage[ProgramModel]]
 
-  def insert(input: ProgramModel.CreateInput): F[ProgramModel]
+  def insert(input: ProgramModel.CreateInput): F[ProgramModel.CreateResult]
 
   def edit(input: ProgramModel.EditInput): F[Option[ProgramModel]]
 }
@@ -53,7 +53,7 @@ object ProgramRepo {
 
       override def insert(
         input: ProgramModel.CreateInput
-      ): F[ProgramModel] = {
+      ): F[ProgramModel.CreateResult] = {
 
         val create = EitherT(
           databaseRef.modify { db =>
@@ -70,7 +70,7 @@ object ProgramRepo {
         for {
           p <- create
           _ <- eventService.publish(ProgramEvent(_, Event.EditType.Created, p))
-        } yield p
+        } yield ProgramModel.CreateResult(p)
       }
 
       override def edit(

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
@@ -112,7 +112,7 @@ sealed trait TargetRepo[F[_]] extends TopLevelRepo[F, Target.Id, TargetModel] {
     oid: Observation.Id
   ): F[TargetEnvironmentModel]
 
-  def insert(newTarget: TargetModel.CreateInput): F[TargetModel]
+  def insert(newTarget: TargetModel.CreateInput): F[TargetModel.CreateResult]
 
   def edit(edit: TargetModel.EditInput): F[List[TargetModel]]
 
@@ -262,7 +262,7 @@ object TargetRepo {
 
       override def insert(
         newTarget: TargetModel.CreateInput
-      ): F[TargetModel] = {
+      ): F[TargetModel.CreateResult] = {
 
         val create: F[TargetModel] =
           EitherT(
@@ -280,7 +280,7 @@ object TargetRepo {
         for {
           t <- create
           _ <- eventService.publish(TargetEvent(_, Event.EditType.Created, t))
-        } yield t
+        } yield TargetModel.CreateResult(t)
       }
 
       override def edit(editInput: TargetModel.EditInput): F[List[TargetModel]] =

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
@@ -114,7 +114,7 @@ sealed trait TargetRepo[F[_]] extends TopLevelRepo[F, Target.Id, TargetModel] {
 
   def insert(newTarget: TargetModel.CreateInput): F[TargetModel.CreateResult]
 
-  def edit(edit: TargetModel.EditInput): F[List[TargetModel]]
+  def edit(edit: TargetModel.EditInput): F[TargetModel.EditResult]
 
   /**
    * Clones the target referenced by `existingTid`.  Uses the `suggestedTid` for
@@ -283,11 +283,11 @@ object TargetRepo {
         } yield TargetModel.CreateResult(t)
       }
 
-      override def edit(editInput: TargetModel.EditInput): F[List[TargetModel]] =
+      override def edit(editInput: TargetModel.EditInput): F[TargetModel.EditResult] =
         for {
           ts <- databaseRef.modifyState(editInput.editor.flipF).flatMap(_.liftTo[F])
           _  <- ts.traverse(t => eventService.publish(TargetEvent.updated(t)))
-        } yield ts
+        } yield TargetModel.EditResult(ts)
 
       override def clone(
         cloneInput: TargetModel.CloneInput

--- a/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/repo/TargetRepo.scala
@@ -122,7 +122,7 @@ sealed trait TargetRepo[F[_]] extends TopLevelRepo[F, Target.Id, TargetModel] {
    */
   def clone(
     cloneInput: TargetModel.CloneInput
-  ): F[TargetModel]
+  ): F[TargetModel.CloneResult]
 
 }
 
@@ -291,10 +291,10 @@ object TargetRepo {
 
       override def clone(
         cloneInput: TargetModel.CloneInput
-      ): F[TargetModel] =
+      ): F[TargetModel.CloneResult] =
         for {
           t <- databaseRef.modifyState(cloneInput.go.flipF).flatMap(_.liftTo[F])
-          _ <- eventService.publish(TargetEvent.created(t))
+          _ <- eventService.publish(TargetEvent.created(t.newTarget))
         } yield t
 
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/DatasetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/DatasetMutation.scala
@@ -68,9 +68,9 @@ trait DatasetMutation {
       "Parameters for editing existing datasets"
     )
 
-  def EditDatasetResultType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], DatasetModel.EditResult] =
+  def EditDatasetsResultType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], DatasetModel.EditResult] =
     ObjectType(
-      name        = "EditDatasetResult",
+      name        = "EditDatasetsResult",
       description = "The result of editing the selected datasets.",
       fieldsFn    = () => fields(
 
@@ -83,10 +83,10 @@ trait DatasetMutation {
       )
     )
 
-  def editDataset[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
+  def editDatasets[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name      = "editDataset",
-      fieldType = EditDatasetResultType[F],
+      name      = "editDatasets",
+      fieldType = EditDatasetsResultType[F],
       arguments = List(
         ArgumentDatasetEdit
       ),
@@ -95,7 +95,7 @@ trait DatasetMutation {
 
   def allFields[F[_]: Dispatcher: Async: Logger]: List[Field[OdbCtx[F], Unit]] =
     List(
-      editDataset
+      editDatasets
     )
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/DatasetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/DatasetMutation.scala
@@ -5,6 +5,7 @@ package lucuma.odb.api.schema
 
 import cats.effect.Async
 import cats.effect.std.Dispatcher
+import cats.syntax.option._
 import lucuma.odb.api.model.DatasetModel
 import lucuma.odb.api.repo.OdbCtx
 import lucuma.odb.api.schema.syntax.inputobjecttype._
@@ -67,10 +68,25 @@ trait DatasetMutation {
       "Parameters for editing existing datasets"
     )
 
+  def EditDatasetResultType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], DatasetModel.EditResult] =
+    ObjectType(
+      name        = "EditDatasetResult",
+      description = "The result of editing the selected datasets.",
+      fieldsFn    = () => fields(
+
+        Field(
+          name        = "datasets",
+          description = "The edited datasets.".some,
+          fieldType   = ListType(DatasetType[F]),
+          resolve     = _.value.datasets
+        )
+      )
+    )
+
   def editDataset[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
       name      = "editDataset",
-      fieldType = ListType(DatasetType[F]),
+      fieldType = EditDatasetResultType[F],
       arguments = List(
         ArgumentDatasetEdit
       ),

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
@@ -245,10 +245,10 @@ trait ExecutionEventMutation {
       fields      = List[Field[OdbCtx[F], SequenceEvent.Result]](
 
         Field(
-          name        = "newEvent",
+          name        = "event",
           description = "The new sequence event that was added.".some,
           fieldType   = SequenceEventType[F],
-          resolve     = _.value.newEvent
+          resolve     = _.value.event
         )
 
       )
@@ -320,10 +320,10 @@ trait ExecutionEventMutation {
       fields      = List[Field[OdbCtx[F], StepEvent.Result]](
 
         Field(
-          name        = "newEvent",
+          name        = "event",
           description = "The new step event that was added.".some,
           fieldType   = StepEventType[F],
-          resolve     = _.value.newEvent
+          resolve     = _.value.event
         )
 
       )
@@ -384,10 +384,10 @@ trait ExecutionEventMutation {
       fields      = List[Field[OdbCtx[F], DatasetEvent.Result]](
 
         Field(
-          name        = "newEvent",
+          name        = "event",
           description = "The new dataset event that was added.".some,
           fieldType   = DatasetEventType[F],
-          resolve     = _.value.newEvent
+          resolve     = _.value.event
         )
 
       )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ExecutionEventMutation.scala
@@ -199,6 +199,22 @@ trait ExecutionEventMutation {
       InputObjectTypeDescription("SequenceEvent creation parameters")
     )
 
+  def AddSequenceEventResultType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], SequenceEvent.Result] =
+    ObjectType[OdbCtx[F], SequenceEvent.Result](
+      name        = "AddSequenceEventResult",
+      description = "The result of adding a sequence event.",
+      fields      = List[Field[OdbCtx[F], SequenceEvent.Result]](
+
+        Field(
+          name        = "newEvent",
+          description = "The new sequence event that was added.".some,
+          fieldType   = SequenceEventType[F],
+          resolve     = _.value.newEvent
+        )
+
+      )
+    )
+
   val ArgumentSequenceEventAdd: Argument[SequenceEvent.Add] =
     InputObjectTypeSequenceEventAdd.argument(
       name        = "input",
@@ -219,7 +235,7 @@ trait ExecutionEventMutation {
         |will be produced during the execution of a sequence as it is started,
         |paused, continued, etc.
       """.stripMargin.some,
-      fieldType   = SequenceEventType[F],
+      fieldType   = AddSequenceEventResultType[F],
       arguments   = List(ArgumentSequenceEventAdd),
       resolve     = c => c.executionEvent(_.insertSequenceEvent(c.arg(ArgumentSequenceEventAdd)))
     )
@@ -258,6 +274,22 @@ trait ExecutionEventMutation {
       """.stripMargin
     )
 
+  def AddStepEventResultType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], StepEvent.Result] =
+    ObjectType[OdbCtx[F], StepEvent.Result](
+      name        = "AddStepEventResult",
+      description = "The result of adding a step event.",
+      fields      = List[Field[OdbCtx[F], StepEvent.Result]](
+
+        Field(
+          name        = "newEvent",
+          description = "The new step event that was added.".some,
+          fieldType   = StepEventType[F],
+          resolve     = _.value.newEvent
+        )
+
+      )
+    )
+
   def addStepEvent[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
       name        = "addStepEvent",
@@ -266,7 +298,7 @@ trait ExecutionEventMutation {
         |will be produced during the execution of a single step as it
         |transitions through configure and observe stages.
       """.stripMargin.some,
-      fieldType   = StepEventType[F],
+      fieldType   = AddStepEventResultType[F],
       arguments   = List(ArgumentStepEventAdd),
       resolve     = c => c.executionEvent(_.insertStepEvent(c.arg(ArgumentStepEventAdd)))
     )
@@ -306,6 +338,23 @@ trait ExecutionEventMutation {
       """.stripMargin
     )
 
+  def AddDatasetEventResultType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], DatasetEvent.Result] =
+    ObjectType[OdbCtx[F], DatasetEvent.Result](
+      name        = "AddDatasetEventResult",
+      description = "The result of adding a dataset event.",
+      fields      = List[Field[OdbCtx[F], DatasetEvent.Result]](
+
+        Field(
+          name        = "newEvent",
+          description = "The new dataset event that was added.".some,
+          fieldType   = DatasetEventType[F],
+          resolve     = _.value.newEvent
+        )
+
+      )
+    )
+
+
   def addDatasetEvent[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
       name        = "addDatasetEvent",
@@ -314,7 +363,7 @@ trait ExecutionEventMutation {
         |generation of a single dataset will produce multiple events as it
         |transitions through the observe, readout and write stages.
       """.stripMargin.some,
-      fieldType   = DatasetEventType[F],
+      fieldType   = AddDatasetEventResultType[F],
       arguments   = List(ArgumentDatasetEventAdd),
       resolve     = c => c.executionEvent(_.insertDatasetEvent(c.arg(ArgumentDatasetEventAdd)))
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -173,12 +173,12 @@ trait ObservationMutation {
     )
 
   def EditObservationResultType[F[_]: Dispatcher: Async: Logger](
-    operation:      String,
+    name:           String,
     description:    String,
     obsDescription: String
   ): ObjectType[OdbCtx[F], ObservationModel.EditResult] =
     ObjectType(
-      name        = s"${operation.capitalize}ObservationResult",
+      name        = name,
       description = description,
       fieldsFn    = () => fields(
 
@@ -196,7 +196,7 @@ trait ObservationMutation {
     Field(
       name      = "editObservation",
       fieldType = EditObservationResultType[F](
-        "edit",
+        "EditObservationResult",
         "The result of editing select observations.",
         "The edited observations."
       ),
@@ -243,7 +243,11 @@ trait ObservationMutation {
         """Edit asterisms, adding or deleting targets, in (potentially) multiple
           |observations at once.
         """.stripMargin.some,
-      fieldType   = ListType(ObservationType[F]),
+      fieldType   = EditObservationResultType(
+        "EditAsterismResult",
+        "The result of editing the asterism of the selected observations.",
+        "The edited observations."
+      ),
       arguments   = List(ArgumentEditAsterism),
       resolve     = c => c.observation(_.editAsterism(c.arg(ArgumentEditAsterism)))
     )
@@ -271,7 +275,7 @@ trait ObservationMutation {
       name        = s"${name}Observation",
       description = s"${name.capitalize}s all the observations identified by the `select` field".some,
       fieldType   = EditObservationResultType(
-        name,
+        s"${name.capitalize}ObservationResult",
         s"The result of performing an observation $name mutation.",
         s"The ${name}d observations."
       ),

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -164,10 +164,34 @@ trait ObservationMutation {
       resolve   = c => c.observation(_.edit(c.arg(ArgumentObservationEdit)))
     )
 
+  def CloneObservationResultType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], ObservationModel.CloneResult] =
+    ObjectType(
+      name        = "CloneObservationResult",
+      description = "The result of cloning an observation, containing the original and new observations",
+      fieldsFn    = () => fields(
+
+        Field(
+          name        = "originalObservation",
+          description = "The original, unmodified observation which was cloned.".some,
+          fieldType   = ObservationType[F],
+          resolve     = _.value.originalObservation
+        ),
+
+        Field(
+          name        = "newObservation",
+          description = "The new cloned (but possibly modified) observation.".some,
+          fieldType   = ObservationType[F],
+          resolve     = _.value.newObservation
+        )
+
+      )
+    )
+
+
   def clone[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
       name      = "cloneObservation",
-      fieldType = ObservationType[F],
+      fieldType = CloneObservationResultType[F],
       arguments = List(ArgumentObservationCloneInput),
       resolve   = c => c.observation(_.clone(c.arg(ArgumentObservationCloneInput)))
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -155,10 +155,10 @@ trait ObservationMutation {
       fieldsFn    = () => fields(
 
         Field(
-          name        = "newObservation",
+          name        = "observation",
           description = "The newly created observation.".some,
           fieldType   = ObservationType[F],
-          resolve     = _.value.newObservation
+          resolve     = _.value.observation
         )
 
       )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -172,7 +172,7 @@ trait ObservationMutation {
       resolve     = c => c.observation(_.insert(c.arg(ArgumentObservationCreate)))
     )
 
-  def EditObservationResultType[F[_]: Dispatcher: Async: Logger](
+  def EditObservationsResultType[F[_]: Dispatcher: Async: Logger](
     name:           String,
     description:    String,
     obsDescription: String
@@ -192,11 +192,11 @@ trait ObservationMutation {
       )
     )
 
-  def editObservation[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
+  def editObservations[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name      = "editObservation",
-      fieldType = EditObservationResultType[F](
-        "EditObservationResult",
+      name      = "editObservations",
+      fieldType = EditObservationsResultType[F](
+        "EditObservationsResult",
         "The result of editing select observations.",
         "The edited observations."
       ),
@@ -236,15 +236,15 @@ trait ObservationMutation {
       resolve   = c => c.observation(_.clone(c.arg(ArgumentObservationCloneInput)))
     )
 
-  def editAsterism[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
+  def editAsterisms[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name        = "editAsterism",
+      name        = "editAsterisms",
       description =
         """Edit asterisms, adding or deleting targets, in (potentially) multiple
           |observations at once.
         """.stripMargin.some,
-      fieldType   = EditObservationResultType(
-        "EditAsterismResult",
+      fieldType   = EditObservationsResultType(
+        "EditAsterismsResult",
         "The result of editing the asterism of the selected observations.",
         "The edited observations."
       ),
@@ -272,10 +272,10 @@ trait ObservationMutation {
          )
 
     Field(
-      name        = s"${name}Observation",
+      name        = s"${name}Observations",
       description = s"${name.capitalize}s all the observations identified by the `select` field".some,
-      fieldType   = EditObservationResultType(
-        s"${name.capitalize}ObservationResult",
+      fieldType   = EditObservationsResultType(
+        s"${name.capitalize}ObservationsResult",
         s"The result of performing an observation $name mutation.",
         s"The ${name}d observations."
       ),
@@ -287,9 +287,9 @@ trait ObservationMutation {
   def allFields[F[_]: Dispatcher: Async: Logger]: List[Field[OdbCtx[F], Unit]] =
     List(
       create,
-      editObservation,
+      editObservations,
       clone,
-      editAsterism,
+      editAsterisms,
       existenceEditField(Existence.Deleted),
       existenceEditField(Existence.Present),
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -147,10 +147,26 @@ trait ObservationMutation {
       ListInputType(InputObjectTypeEditAsterism)
     )
 
+  def CreateObservationResultType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], ObservationModel.CreateResult] =
+    ObjectType(
+      name        = "CreateObservationResult",
+      description = "The result of creating a new observation.",
+      fieldsFn    = () => fields(
+
+        Field(
+          name        = "newObservation",
+          description = "The newly created observation.".some,
+          fieldType   = ObservationType[F],
+          resolve     = _.value.newObservation
+        )
+
+      )
+    )
+
   def create[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
       name        = "createObservation",
-      fieldType   = ObservationType[F],
+      fieldType   = CreateObservationResultType[F],
       description = "Creates a new observation according to provided parameters".some,
       arguments   = List(ArgumentObservationCreate),
       resolve     = c => c.observation(_.insert(c.arg(ArgumentObservationCreate)))

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -29,7 +29,7 @@ trait ObservationMutation {
   import PosAngleConstraintSchema._
   import ProgramSchema.ProgramIdType
   import RefinedSchema.NonEmptyStringType
-  import TargetMutation.{InputObjectTypeEditAsterism, InputObjectTypeTargetEnvironment}
+  import TargetMutation.{InputObjectTypeEditAsterisms, InputObjectTypeTargetEnvironment}
   import TimeSchema.InstantScalar
   import syntax.inputobjecttype._
 
@@ -74,9 +74,9 @@ trait ObservationMutation {
       )
     )
 
-  val InputObjectTypeObservationEdit: InputObjectType[ObservationModel.EditInput] =
+  val InputObjectTypeObservationsEdit: InputObjectType[ObservationModel.EditInput] =
     InputObjectType[ObservationModel.EditInput](
-      "EditObservationInput",
+      "EditObservationsInput",
       "Observation selection and update description",
       List(
         InputField("select", InputObjectTypeObservationSelect),
@@ -84,15 +84,15 @@ trait ObservationMutation {
       )
     )
 
-  val ArgumentObservationEdit: Argument[ObservationModel.EditInput] =
-    InputObjectTypeObservationEdit.argument(
+  val ArgumentObservationsEdit: Argument[ObservationModel.EditInput] =
+    InputObjectTypeObservationsEdit.argument(
       "input",
       "Parameters for editing existing observations"
     )
 
   def existenceEditInput(name: String): InputObjectType[ObservationModel.EditInput] =
     InputObjectType[ObservationModel.EditInput](
-      s"${name.capitalize}ObservationInput",
+      s"${name.capitalize}ObservationsInput",
       s"Selects the observations for $name",
       List(
         InputField("select", InputObjectTypeObservationSelect)
@@ -126,7 +126,7 @@ trait ObservationMutation {
 
     val io: InputObjectType[BulkEdit[A]] =
       InputObjectType[BulkEdit[A]](
-        name        = s"Edit${name.capitalize}Input",
+        name        = s"Edit${name.capitalize}sInput",
         description =
           """Input for bulk editing multiple observations.  Select observations
             |with the 'select' input and specify the changes in 'edit'.
@@ -141,10 +141,10 @@ trait ObservationMutation {
 
   }
 
-  val ArgumentEditAsterism: Argument[BulkEdit[Seq[EditAsterismPatchInput]]] =
+  val ArgumentEditAsterisms: Argument[BulkEdit[Seq[EditAsterismPatchInput]]] =
     bulkEditArgument[Seq[EditAsterismPatchInput]](
       "asterism",
-      ListInputType(InputObjectTypeEditAsterism)
+      ListInputType(InputObjectTypeEditAsterisms)
     )
 
   def CreateObservationResultType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], ObservationModel.CreateResult] =
@@ -200,8 +200,8 @@ trait ObservationMutation {
         "The result of editing select observations.",
         "The edited observations."
       ),
-      arguments = List(ArgumentObservationEdit),
-      resolve   = c => c.observation(_.edit(c.arg(ArgumentObservationEdit)))
+      arguments = List(ArgumentObservationsEdit),
+      resolve   = c => c.observation(_.edit(c.arg(ArgumentObservationsEdit)))
     )
 
   def CloneObservationResultType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], ObservationModel.CloneResult] =
@@ -248,8 +248,8 @@ trait ObservationMutation {
         "The result of editing the asterism of the selected observations.",
         "The edited observations."
       ),
-      arguments   = List(ArgumentEditAsterism),
-      resolve     = c => c.observation(_.editAsterism(c.arg(ArgumentEditAsterism)))
+      arguments   = List(ArgumentEditAsterisms),
+      resolve     = c => c.observation(_.editAsterism(c.arg(ArgumentEditAsterisms)))
     )
 
   private def existenceEditField[F[_]: Dispatcher: Async: Logger](

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationMutation.scala
@@ -167,12 +167,12 @@ trait ObservationMutation {
   def CloneObservationResultType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], ObservationModel.CloneResult] =
     ObjectType(
       name        = "CloneObservationResult",
-      description = "The result of cloning an observation, containing the original and new observations",
+      description = "The result of cloning an observation, containing the original and new observations.",
       fieldsFn    = () => fields(
 
         Field(
           name        = "originalObservation",
-          description = "The original, unmodified observation which was cloned.".some,
+          description = "The original unmodified observation which was cloned.".some,
           fieldType   = ObservationType[F],
           resolve     = _.value.originalObservation
         ),

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramMutation.scala
@@ -233,10 +233,25 @@ trait ProgramMutation {
       resolve     = c => c.program(_.insert(c.arg(ArgumentProgramCreate)))
     )
 
+  def EditProgramResultType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], ProgramModel.EditResult] =
+    ObjectType(
+      name        = "EditProgramResult",
+      description = "The result of editing the selected program.",
+      fieldsFn    = () => fields(
+
+        Field(
+          name        = "program",
+          description = "The edited program.".some,
+          fieldType   = OptionType(ProgramType[F]),
+          resolve     = _.value.program
+        )
+      )
+    )
+
   def edit[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
       name      = "editProgram",
-      fieldType = OptionType(ProgramType[F]),
+      fieldType = EditProgramResultType[F],
       arguments = List(ArgumentProgramEdit),
       resolve   = c => c.program(_.edit(c.arg(ArgumentProgramEdit)))
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramMutation.scala
@@ -208,10 +208,26 @@ trait ProgramMutation {
       "Parameters for editing an existing program"
     )
 
+   def CreateProgramResultType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], ProgramModel.CreateResult] =
+    ObjectType(
+      name        = "CreateProgramResult",
+      description = "The result of creating a new program.",
+      fieldsFn    = () => fields(
+
+        Field(
+          name        = "newProgram",
+          description = "The newly created program.".some,
+          fieldType   = ProgramType[F],
+          resolve     = _.value.newProgram
+        )
+
+      )
+    )
+
   def create[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
       name        = "createProgram",
-      fieldType   = OptionType(ProgramType[F]),
+      fieldType   = CreateProgramResultType[F],
       description = "Creates a new program according to provided properties".some,
       arguments   = List(ArgumentProgramCreate),
       resolve     = c => c.program(_.insert(c.arg(ArgumentProgramCreate)))

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramMutation.scala
@@ -215,10 +215,10 @@ trait ProgramMutation {
       fieldsFn    = () => fields(
 
         Field(
-          name        = "newProgram",
+          name        = "program",
           description = "The newly created program.".some,
           fieldType   = ProgramType[F],
-          resolve     = _.value.newProgram
+          resolve     = _.value.program
         )
 
       )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
@@ -312,13 +312,13 @@ trait TargetMutation extends TargetScalars {
       }
     )
 
-  def EditTargetResultType[F[_]: Dispatcher: Async: Logger](
+  def EditTargetsResultType[F[_]: Dispatcher: Async: Logger](
     operation:      String,
     description:    String,
     obsDescription: String
   ): ObjectType[OdbCtx[F], TargetModel.EditResult] =
     ObjectType(
-      name        = s"${operation.capitalize}TargetResult",
+      name        = s"${operation.capitalize}TargetsResult",
       description = description,
       fieldsFn    = () => fields(
 
@@ -332,10 +332,10 @@ trait TargetMutation extends TargetScalars {
       )
     )
 
-  def editTarget[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
+  def editTargets[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
-      name        = "editTarget",
-      fieldType   = EditTargetResultType[F](
+      name        = "editTargets",
+      fieldType   = EditTargetsResultType[F](
         "edit",
         "The result of editing select targets.",
         "The edited targets."
@@ -365,9 +365,9 @@ trait TargetMutation extends TargetScalars {
          )
 
     Field(
-      name        = s"${name}Target",
+      name        = s"${name}Targets",
       description = s"${name.capitalize}s all the targets identified by the `select` field".some,
-      fieldType   = EditTargetResultType(
+      fieldType   = EditTargetsResultType(
         name,
         s"The result of performing a target $name mutation.",
         s"The ${name}d targets."
@@ -381,7 +381,7 @@ trait TargetMutation extends TargetScalars {
     List(
       createTarget,
       cloneTarget,
-      editTarget,
+      editTargets,
       existenceEditField(Existence.Deleted),
       existenceEditField(Existence.Present)
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
@@ -312,10 +312,26 @@ trait TargetMutation extends TargetScalars {
       }
     )
 
+  def EditTargetResultType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], TargetModel.EditResult] =
+    ObjectType(
+      name        = "EditTargetResult",
+      description = "The result of editing select targets.",
+      fieldsFn    = () => fields(
+
+        Field(
+          name        = "targets",
+          description = "The edited targets.".some,
+          fieldType   = ListType(TargetType[F]),
+          resolve     = _.value.targets
+        )
+
+      )
+    )
+
   def editTarget[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
       name        = "editTarget",
-      fieldType   = ListType(TargetType[F]),
+      fieldType   = EditTargetResultType[F],
       description = "Edits existing targets".some,
       arguments   = List(ArgumentEditTargetInput),
       resolve     = c => c.target(_.edit(c.arg(ArgumentEditTargetInput)))
@@ -345,7 +361,7 @@ trait TargetMutation extends TargetScalars {
       description = s"${name.capitalize}s all the targets identified by the `select` field".some,
       fieldType   = ListType(TargetType[F]),
       arguments   = List(arg),
-      resolve     = c => c.target(_.edit(c.arg(arg)))
+      resolve     = c => c.target(_.edit(c.arg(arg)).map(_.targets))
     )
   }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
@@ -176,9 +176,9 @@ trait TargetMutation extends TargetScalars {
       )
     )
 
-  implicit val InputObjectTypeEditTarget: InputObjectType[TargetModel.EditInput] =
+  implicit val InputObjectTypeEditTargets: InputObjectType[TargetModel.EditInput] =
     InputObjectType[TargetModel.EditInput](
-      "EditTargetInput",
+      "EditTargetsInput",
       "Target selection and update description.",
       List(
         InputField("select", InputObjectTypeTargetSelect),
@@ -186,15 +186,15 @@ trait TargetMutation extends TargetScalars {
       )
     )
 
-  val ArgumentEditTargetInput: Argument[TargetModel.EditInput] =
-    InputObjectTypeEditTarget.argument(
+  val ArgumentEditTargetsInput: Argument[TargetModel.EditInput] =
+    InputObjectTypeEditTargets.argument(
       "input",
       "Parameters for editing existing targets. "
     )
 
   def existenceEditInput(name: String): InputObjectType[TargetModel.EditInput] =
     InputObjectType[TargetModel.EditInput](
-      s"${name.capitalize}TargetInput",
+      s"${name.capitalize}TargetsInput",
       s"Selects the targets for $name",
       List(
         InputField("select", InputObjectTypeTargetSelect)
@@ -219,9 +219,9 @@ trait TargetMutation extends TargetScalars {
       )
     )
 
-  implicit val InputObjectTypeEditAsterism: InputObjectType[EditAsterismPatchInput] =
+  implicit val InputObjectTypeEditAsterisms: InputObjectType[EditAsterismPatchInput] =
     deriveInputObjectType[EditAsterismPatchInput](
-      InputObjectTypeName("EditAsterismPatchInput"),
+      InputObjectTypeName("EditAsterismsPatchInput"),
       InputObjectTypeDescription("Add or delete targets in an asterism")
     )
 
@@ -341,8 +341,8 @@ trait TargetMutation extends TargetScalars {
         "The edited targets."
       ),
       description = "Edits existing targets".some,
-      arguments   = List(ArgumentEditTargetInput),
-      resolve     = c => c.target(_.edit(c.arg(ArgumentEditTargetInput)))
+      arguments   = List(ArgumentEditTargetsInput),
+      resolve     = c => c.target(_.edit(c.arg(ArgumentEditTargetsInput)))
     )
 
   private def existenceEditField[F[_]: Dispatcher: Async: Logger](

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
@@ -244,10 +244,10 @@ trait TargetMutation extends TargetScalars {
       fieldsFn    = () => fields(
 
         Field(
-          name        = "newTarget",
+          name        = "target",
           description = "The newly created target.".some,
           fieldType   = TargetType[F],
-          resolve     = _.value.newTarget
+          resolve     = _.value.target
         )
 
       )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/TargetMutation.scala
@@ -237,10 +237,26 @@ trait TargetMutation extends TargetScalars {
       "Parameters for cloning an existing target"
     )
 
+   def CreateTargetResultType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], TargetModel.CreateResult] =
+    ObjectType(
+      name        = "CreateTargetResult",
+      description = "The result of creating a new target.",
+      fieldsFn    = () => fields(
+
+        Field(
+          name        = "newTarget",
+          description = "The newly created target.".some,
+          fieldType   = TargetType[F],
+          resolve     = _.value.newTarget
+        )
+
+      )
+    )
+
   def createTarget[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
       name        = "createTarget",
-      fieldType   = TargetType[F],
+      fieldType   = CreateTargetResultType[F],
       description = "Creates a new target according to the provided parameters.  Only one of sidereal or nonsidereal may be specified.".some,
       arguments   = List(ArgumentTargetCreate),
       resolve     = c => c.target(_.insert(c.arg(ArgumentTargetCreate)))

--- a/modules/core/src/test/scala/lucuma/odb/api/repo/ObservationRepoSpec.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/repo/ObservationRepoSpec.scala
@@ -81,7 +81,7 @@ final class ObservationRepoSpec extends ScalaCheckSuite with OdbRepoTest {
         before = tʹ.observations.rows.values.head
 
         // Do the prescribed edit.
-        after <- odb.observation.edit(f(before)).map(_.head)
+        after <- odb.observation.edit(f(before)).map(_.observations.head)
       } yield (before, after)
     }
 

--- a/modules/core/src/test/scala/lucuma/odb/api/repo/ObservationRepoSpec.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/repo/ObservationRepoSpec.scala
@@ -74,7 +74,7 @@ final class ObservationRepoSpec extends ScalaCheckSuite with OdbRepoTest {
       for {
         // Insert a program and observation to insure that at least one exists
         p  <- odb.program.insert(ProgramModel.CreateInput(ProgramModel.PropertiesInput.Empty.some))
-        _  <- odb.observation.insert(ObservationModel.CreateInput.empty(p.newProgram.id))
+        _  <- odb.observation.insert(ObservationModel.CreateInput.empty(p.program.id))
 
         // Pick whatever the first observation may be
         tʹ    <- odb.database.get

--- a/modules/core/src/test/scala/lucuma/odb/api/repo/ObservationRepoSpec.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/repo/ObservationRepoSpec.scala
@@ -74,7 +74,7 @@ final class ObservationRepoSpec extends ScalaCheckSuite with OdbRepoTest {
       for {
         // Insert a program and observation to insure that at least one exists
         p  <- odb.program.insert(ProgramModel.CreateInput(ProgramModel.PropertiesInput.Empty.some))
-        _  <- odb.observation.insert(ObservationModel.CreateInput.empty(p.id))
+        _  <- odb.observation.insert(ObservationModel.CreateInput.empty(p.newProgram.id))
 
         // Pick whatever the first observation may be
         tʹ    <- odb.database.get

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -467,7 +467,7 @@ object Init {
                   proposal.assign
                 ).some
               )
-            )
+            ).map(_.newProgram)
       _  <- repo.program.insert(
               ProgramModel.CreateInput(
                 ProgramModel.PropertiesInput(

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -467,7 +467,7 @@ object Init {
                   proposal.assign
                 ).some
               )
-            ).map(_.newProgram)
+            ).map(_.program)
       _  <- repo.program.insert(
               ProgramModel.CreateInput(
                 ProgramModel.PropertiesInput(
@@ -476,7 +476,7 @@ object Init {
               )
             )
       cs <- targets(p.id).liftTo[F]
-      ts <- cs.traverse(repo.target.insert(_).map(_.newTarget))
+      ts <- cs.traverse(repo.target.insert(_).map(_.target))
       _  <- repo.observation.insert(gmosSouthAutoObs(p.id, ts.headOption))
       _  <- repo.observation.insert(gmosSouthAutoObs(p.id, ts.lastOption))
       _  <- repo.observation.insert(gmosSouthManualObs(p.id, None))

--- a/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
+++ b/modules/service/src/main/scala/lucuma/odb/api/service/Init.scala
@@ -476,7 +476,7 @@ object Init {
               )
             )
       cs <- targets(p.id).liftTo[F]
-      ts <- cs.traverse(repo.target.insert(_))
+      ts <- cs.traverse(repo.target.insert(_).map(_.newTarget))
       _  <- repo.observation.insert(gmosSouthAutoObs(p.id, ts.headOption))
       _  <- repo.observation.insert(gmosSouthAutoObs(p.id, ts.lastOption))
       _  <- repo.observation.insert(gmosSouthManualObs(p.id, None))

--- a/modules/service/src/test/scala/MutationSuite.scala
+++ b/modules/service/src/test/scala/MutationSuite.scala
@@ -426,5 +426,64 @@ class MutationSuite extends OdbSuite {
       """)
   )
 
+  queryTest(
+    query = """
+      mutation CloneObservation($cloneObservationInput: CloneObservationInput!) {
+        cloneObservation(input: $cloneObservationInput) {
+          originalObservation {
+            posAngleConstraint {
+              constraint
+              angle {
+                degrees
+              }
+            }
+          }
+          newObservation {
+            posAngleConstraint {
+              constraint
+              angle {
+                degrees
+              }
+            }
+          }
+        }
+      }
+    """,
+    expected = json"""
+      {
+        "cloneObservation" : {
+          "originalObservation": {
+            "posAngleConstraint": {
+              "constraint": "AVERAGE_PARALLACTIC",
+              "angle": null
+            }
+          },
+          "newObservation": {
+            "posAngleConstraint": {
+              "constraint": "FIXED",
+              "angle": {
+                "degrees": 45
+              }
+            }
+          }
+        }
+      }
+    """,
+    variables = Some(json"""
+      {
+        "cloneObservationInput": {
+          "observationId": "o-3",
+          "patch": {
+            "posAngleConstraint": {
+              "constraint": "FIXED",
+              "angle": {
+                "degrees": 45
+              }
+            }
+          }
+        }
+      }
+    """)
+  )
 
 }

--- a/modules/service/src/test/scala/MutationSuite.scala
+++ b/modules/service/src/test/scala/MutationSuite.scala
@@ -10,7 +10,7 @@ class MutationSuite extends OdbSuite {
   queryTest(
     query = """
       mutation BulkEditConstraints($bulkEditConstraints: EditObservationInput!) {
-        editObservation(input: $bulkEditConstraints) {
+        editObservations(input: $bulkEditConstraints) {
           observations {
             id
             constraintSet {
@@ -22,7 +22,7 @@ class MutationSuite extends OdbSuite {
     """,
     expected = json"""
       {
-        "editObservation" : {
+        "editObservations" : {
           "observations": [
             {
               "id" : "o-3",
@@ -59,7 +59,7 @@ class MutationSuite extends OdbSuite {
   queryTest(
     query = """
       mutation BulkEditScienceMode($bulkEditScienceMode: EditObservationInput!) {
-        editObservation(input: $bulkEditScienceMode) {
+        editObservations(input: $bulkEditScienceMode) {
           observations {
             id
             scienceMode {
@@ -78,7 +78,7 @@ class MutationSuite extends OdbSuite {
     """,
     expected = json"""
       {
-        "editObservation" : {
+        "editObservations" : {
           "observations": [
             {
               "id" : "o-3",
@@ -230,7 +230,7 @@ class MutationSuite extends OdbSuite {
     query =
       """
         mutation BulkEditConstraints($bulkEditConstraints: EditObservationInput!) {
-          editObservation(input: $bulkEditConstraints) {
+          editObservations(input: $bulkEditConstraints) {
             observations {
               id
               constraintSet {
@@ -274,7 +274,7 @@ class MutationSuite extends OdbSuite {
   queryTest(
     query = """
       mutation EditMiscProperties($editObservationInput: EditObservationInput!) {
-        editObservation(input: $editObservationInput) {
+        editObservations(input: $editObservationInput) {
           observations {
             id
             visualizationTime
@@ -288,7 +288,7 @@ class MutationSuite extends OdbSuite {
     """,
     expected = json"""
       {
-        "editObservation" : {
+        "editObservations" : {
           "observations": [
             {
               "id": "o-3",
@@ -327,7 +327,7 @@ class MutationSuite extends OdbSuite {
   queryTest(
     query = """
       mutation RemovePosAngleConstraint($editObservationInput: EditObservationInput!) {
-        editObservation(input: $editObservationInput) {
+        editObservations(input: $editObservationInput) {
           observations {
             id
             posAngleConstraint {
@@ -339,7 +339,7 @@ class MutationSuite extends OdbSuite {
     """,
     expected = json"""
       {
-        "editObservation" : {
+        "editObservations" : {
           "observations": [
             {
               "id": "o-3",
@@ -366,7 +366,7 @@ class MutationSuite extends OdbSuite {
   queryTest(
     query = """
       mutation ToAverageParallactic($editObservationInput: EditObservationInput!) {
-        editObservation(input: $editObservationInput) {
+        editObservations(input: $editObservationInput) {
           observations {
             id
             posAngleConstraint {
@@ -381,7 +381,7 @@ class MutationSuite extends OdbSuite {
     """,
     expected = json"""
       {
-        "editObservation" : {
+        "editObservations" : {
           "observations": [
             {
               "id": "o-3",
@@ -417,7 +417,7 @@ class MutationSuite extends OdbSuite {
     query =
       """
         mutation InvalidPosAngleConstraint($editObservationInput: EditObservationInput!) {
-          editObservation(input: $editObservationInput) {
+          editObservations(input: $editObservationInput) {
             observations {
               id
               posAngleConstraint {

--- a/modules/service/src/test/scala/MutationSuite.scala
+++ b/modules/service/src/test/scala/MutationSuite.scala
@@ -9,7 +9,7 @@ class MutationSuite extends OdbSuite {
 
   queryTest(
     query = """
-      mutation BulkEditConstraints($bulkEditConstraints: EditObservationInput!) {
+      mutation BulkEditConstraints($bulkEditConstraints: EditObservationsInput!) {
         editObservations(input: $bulkEditConstraints) {
           observations {
             id
@@ -58,7 +58,7 @@ class MutationSuite extends OdbSuite {
 
   queryTest(
     query = """
-      mutation BulkEditScienceMode($bulkEditScienceMode: EditObservationInput!) {
+      mutation BulkEditScienceMode($bulkEditScienceMode: EditObservationsInput!) {
         editObservations(input: $bulkEditScienceMode) {
           observations {
             id
@@ -229,7 +229,7 @@ class MutationSuite extends OdbSuite {
   queryTestFailure(
     query =
       """
-        mutation BulkEditConstraints($bulkEditConstraints: EditObservationInput!) {
+        mutation BulkEditConstraints($bulkEditConstraints: EditObservationsInput!) {
           editObservations(input: $bulkEditConstraints) {
             observations {
               id
@@ -273,7 +273,7 @@ class MutationSuite extends OdbSuite {
 
   queryTest(
     query = """
-      mutation EditMiscProperties($editObservationInput: EditObservationInput!) {
+      mutation EditMiscProperties($editObservationInput: EditObservationsInput!) {
         editObservations(input: $editObservationInput) {
           observations {
             id
@@ -326,7 +326,7 @@ class MutationSuite extends OdbSuite {
 
   queryTest(
     query = """
-      mutation RemovePosAngleConstraint($editObservationInput: EditObservationInput!) {
+      mutation RemovePosAngleConstraint($editObservationInput: EditObservationsInput!) {
         editObservations(input: $editObservationInput) {
           observations {
             id
@@ -365,7 +365,7 @@ class MutationSuite extends OdbSuite {
 
   queryTest(
     query = """
-      mutation ToAverageParallactic($editObservationInput: EditObservationInput!) {
+      mutation ToAverageParallactic($editObservationInput: EditObservationsInput!) {
         editObservations(input: $editObservationInput) {
           observations {
             id
@@ -416,7 +416,7 @@ class MutationSuite extends OdbSuite {
   queryTestFailure(
     query =
       """
-        mutation InvalidPosAngleConstraint($editObservationInput: EditObservationInput!) {
+        mutation InvalidPosAngleConstraint($editObservationInput: EditObservationsInput!) {
           editObservations(input: $editObservationInput) {
             observations {
               id

--- a/modules/service/src/test/scala/MutationSuite.scala
+++ b/modules/service/src/test/scala/MutationSuite.scala
@@ -11,29 +11,33 @@ class MutationSuite extends OdbSuite {
     query = """
       mutation BulkEditConstraints($bulkEditConstraints: EditObservationInput!) {
         editObservation(input: $bulkEditConstraints) {
-          id
-          constraintSet {
-            skyBackground
+          observations {
+            id
+            constraintSet {
+              skyBackground
+            }
           }
         }
       }
     """,
     expected = json"""
       {
-        "editObservation" : [
-          {
-            "id" : "o-3",
-            "constraintSet" : {
-              "skyBackground" : "GRAY"
+        "editObservation" : {
+          "observations": [
+            {
+              "id" : "o-3",
+              "constraintSet" : {
+                "skyBackground" : "GRAY"
+              }
+            },
+            {
+              "id" : "o-4",
+              "constraintSet" : {
+                "skyBackground" : "GRAY"
+              }
             }
-          },
-          {
-            "id" : "o-4",
-            "constraintSet" : {
-              "skyBackground" : "GRAY"
-            }
-          }
-        ]
+          ]
+        }
       }
     """,
     variables = Some(json"""
@@ -56,14 +60,16 @@ class MutationSuite extends OdbSuite {
     query = """
       mutation BulkEditScienceMode($bulkEditScienceMode: EditObservationInput!) {
         editObservation(input: $bulkEditScienceMode) {
-          id
-          scienceMode {
-            gmosSouthLongSlit {
-              basic {
-                grating
-              }
-              advanced {
-                overrideGrating
+          observations {
+            id
+            scienceMode {
+              gmosSouthLongSlit {
+                basic {
+                  grating
+                }
+                advanced {
+                  overrideGrating
+                }
               }
             }
           }
@@ -72,34 +78,36 @@ class MutationSuite extends OdbSuite {
     """,
     expected = json"""
       {
-        "editObservation" : [
-          {
-            "id" : "o-3",
-            "scienceMode": {
-              "gmosSouthLongSlit": {
-                "basic": {
-                  "grating": "B600_G5323"
-                },
-                "advanced": {
-                  "overrideGrating": "R600_G5324"
+        "editObservation" : {
+          "observations": [
+            {
+              "id" : "o-3",
+              "scienceMode": {
+                "gmosSouthLongSlit": {
+                  "basic": {
+                    "grating": "B600_G5323"
+                  },
+                  "advanced": {
+                    "overrideGrating": "R600_G5324"
+                  }
+                }
+              }
+            },
+            {
+              "id" : "o-4",
+              "scienceMode": {
+                "gmosSouthLongSlit": {
+                  "basic": {
+                    "grating": "B600_G5323"
+                  },
+                  "advanced": {
+                    "overrideGrating": "R600_G5324"
+                  }
                 }
               }
             }
-          },
-          {
-            "id" : "o-4",
-            "scienceMode": {
-              "gmosSouthLongSlit": {
-                "basic": {
-                  "grating": "B600_G5323"
-                },
-                "advanced": {
-                  "overrideGrating": "R600_G5324"
-                }
-              }
-            }
-          }
-        ]
+          ]
+        }
       }
     """,
     variables = Some(json"""
@@ -223,13 +231,15 @@ class MutationSuite extends OdbSuite {
       """
         mutation BulkEditConstraints($bulkEditConstraints: EditObservationInput!) {
           editObservation(input: $bulkEditConstraints) {
-            id
-            constraintSet {
-              skyBackground
-              elevationRange {
-                airMass {
-                  min
-                  max
+            observations {
+              id
+              constraintSet {
+                skyBackground
+                elevationRange {
+                  airMass {
+                    min
+                    max
+                  }
                 }
               }
             }
@@ -265,29 +275,33 @@ class MutationSuite extends OdbSuite {
     query = """
       mutation EditMiscProperties($editObservationInput: EditObservationInput!) {
         editObservation(input: $editObservationInput) {
-          id
-          visualizationTime
-          posAngleConstraint {
-            constraint
-            angle { degrees }
+          observations {
+            id
+            visualizationTime
+            posAngleConstraint {
+              constraint
+              angle { degrees }
+            }
           }
         }
       }
     """,
     expected = json"""
       {
-        "editObservation" : [
-          {
-            "id": "o-3",
-            "visualizationTime": "2017-02-16T20:30:00Z",
-            "posAngleConstraint": {
-              "constraint": "ALLOW_FLIP",
-              "angle": {
-                "degrees": 123.45
+        "editObservation" : {
+          "observations": [
+            {
+              "id": "o-3",
+              "visualizationTime": "2017-02-16T20:30:00Z",
+              "posAngleConstraint": {
+                "constraint": "ALLOW_FLIP",
+                "angle": {
+                  "degrees": 123.45
+                }
               }
             }
-          }
-        ]
+          ]
+        }
       }
     """,
     variables = Some(json"""
@@ -314,21 +328,25 @@ class MutationSuite extends OdbSuite {
     query = """
       mutation RemovePosAngleConstraint($editObservationInput: EditObservationInput!) {
         editObservation(input: $editObservationInput) {
-          id
-          posAngleConstraint {
-            constraint
+          observations {
+            id
+            posAngleConstraint {
+              constraint
+            }
           }
         }
       }
     """,
     expected = json"""
       {
-        "editObservation" : [
-          {
-            "id": "o-3",
-            "posAngleConstraint": null
-          }
-        ]
+        "editObservation" : {
+          "observations": [
+            {
+              "id": "o-3",
+              "posAngleConstraint": null
+            }
+          ]
+        }
       }
     """,
     variables = Some(json"""
@@ -349,11 +367,13 @@ class MutationSuite extends OdbSuite {
     query = """
       mutation ToAverageParallactic($editObservationInput: EditObservationInput!) {
         editObservation(input: $editObservationInput) {
-          id
-          posAngleConstraint {
-            constraint
-            angle {
-              degrees
+          observations {
+            id
+            posAngleConstraint {
+              constraint
+              angle {
+                degrees
+              }
             }
           }
         }
@@ -361,15 +381,17 @@ class MutationSuite extends OdbSuite {
     """,
     expected = json"""
       {
-        "editObservation" : [
-          {
-            "id": "o-3",
-            "posAngleConstraint": {
-              "constraint": "AVERAGE_PARALLACTIC",
-              "angle": null
+        "editObservation" : {
+          "observations": [
+            {
+              "id": "o-3",
+              "posAngleConstraint": {
+                "constraint": "AVERAGE_PARALLACTIC",
+                "angle": null
+              }
             }
-          }
-        ]
+          ]
+        }
       }
     """,
     variables = Some(json"""
@@ -396,13 +418,15 @@ class MutationSuite extends OdbSuite {
       """
         mutation InvalidPosAngleConstraint($editObservationInput: EditObservationInput!) {
           editObservation(input: $editObservationInput) {
-            id
-          posAngleConstraint {
-            constraint
-            angle {
-              degrees
+            observations {
+              id
+              posAngleConstraint {
+                constraint
+                angle {
+                  degrees
+                }
+              }
             }
-          }
           }
         }
       """,

--- a/modules/service/src/test/scala/ObservationEditSubscriptionSuite.scala
+++ b/modules/service/src/test/scala/ObservationEditSubscriptionSuite.scala
@@ -20,7 +20,7 @@ class ObservationEditSubscriptionSuite extends OdbSuite {
   // A parameterized mutation for observations
   val mutation: String = """
     mutation UpdateObservation($editObservation: EditObservationInput!) {
-      editObservation(input: $editObservation) { observations { id } }
+      editObservations(input: $editObservation) { observations { id } }
     }
   """
 

--- a/modules/service/src/test/scala/ObservationEditSubscriptionSuite.scala
+++ b/modules/service/src/test/scala/ObservationEditSubscriptionSuite.scala
@@ -19,7 +19,7 @@ class ObservationEditSubscriptionSuite extends OdbSuite {
 
   // A parameterized mutation for observations
   val mutation: String = """
-    mutation UpdateObservation($editObservation: EditObservationInput!) {
+    mutation UpdateObservation($editObservation: EditObservationsInput!) {
       editObservations(input: $editObservation) { observations { id } }
     }
   """

--- a/modules/service/src/test/scala/ObservationEditSubscriptionSuite.scala
+++ b/modules/service/src/test/scala/ObservationEditSubscriptionSuite.scala
@@ -20,7 +20,7 @@ class ObservationEditSubscriptionSuite extends OdbSuite {
   // A parameterized mutation for observations
   val mutation: String = """
     mutation UpdateObservation($editObservation: EditObservationInput!) {
-      editObservation(input: $editObservation) { id }
+      editObservation(input: $editObservation) { observations { id } }
     }
   """
 

--- a/modules/service/src/test/scala/test/GroupIncludeDeletedSuite.scala
+++ b/modules/service/src/test/scala/test/GroupIncludeDeletedSuite.scala
@@ -12,17 +12,21 @@ class GroupIncludeDeletedSuite extends OdbSuite {
     query ="""
       mutation DeleteObservation($deleteObservationInput: DeleteObservationInput!) {
         deleteObservation(input: $deleteObservationInput) {
-          id
+          observations {
+            id
+          }
         }
       }
     """,
     expected = json"""
       {
-        "deleteObservation": [
-          {
-            "id": "o-5"
-          }
-        ]
+        "deleteObservation": {
+          "observations": [
+            {
+              "id": "o-5"
+            }
+          ]
+        }
       }
     """,
     variables =json"""

--- a/modules/service/src/test/scala/test/GroupIncludeDeletedSuite.scala
+++ b/modules/service/src/test/scala/test/GroupIncludeDeletedSuite.scala
@@ -11,7 +11,7 @@ class GroupIncludeDeletedSuite extends OdbSuite {
   queryTest(
     query ="""
       mutation DeleteObservation($deleteObservationInput: DeleteObservationInput!) {
-        deleteObservation(input: $deleteObservationInput) {
+        deleteObservations(input: $deleteObservationInput) {
           observations {
             id
           }
@@ -20,7 +20,7 @@ class GroupIncludeDeletedSuite extends OdbSuite {
     """,
     expected = json"""
       {
-        "deleteObservation": {
+        "deleteObservations": {
           "observations": [
             {
               "id": "o-5"

--- a/modules/service/src/test/scala/test/GroupIncludeDeletedSuite.scala
+++ b/modules/service/src/test/scala/test/GroupIncludeDeletedSuite.scala
@@ -10,7 +10,7 @@ class GroupIncludeDeletedSuite extends OdbSuite {
 
   queryTest(
     query ="""
-      mutation DeleteObservation($deleteObservationInput: DeleteObservationInput!) {
+      mutation DeleteObservation($deleteObservationInput: DeleteObservationsInput!) {
         deleteObservations(input: $deleteObservationInput) {
           observations {
             id

--- a/modules/service/src/test/scala/test/ProgramMutationSuite.scala
+++ b/modules/service/src/test/scala/test/ProgramMutationSuite.scala
@@ -15,10 +15,12 @@ class ProgramMutationSuite extends OdbSuite {
     expected = json"""
       {
         "createProgram": {
-          "id": "p-4",
-          "name": null,
-          "existence": "PRESENT",
-          "proposal": null
+          "program": {
+            "id": "p-4",
+            "name": null,
+            "existence": "PRESENT",
+            "proposal": null
+          }
         }
       }
     """,
@@ -34,7 +36,7 @@ class ProgramMutationSuite extends OdbSuite {
   queryTestFailure(
     query = """
       mutation EditProgramNewProposalError($programEdit: EditProgramInput!) {
-        editProgram(input: $programEdit) 
+        editProgram(input: $programEdit)
     """ + programQuery + "}",
     errors = List(
       "No minPercentTime definition provided",
@@ -65,28 +67,30 @@ class ProgramMutationSuite extends OdbSuite {
   queryTest(
     query = """
       mutation EditProgramNewProposal($programEdit: EditProgramInput!) {
-        editProgram(input: $programEdit) 
+        editProgram(input: $programEdit)
     """ + programQuery + "}",
     expected = json"""
       {
         "editProgram": {
-          "id": "p-3",
-          "name": "Jack",
-          "existence": "PRESENT",
-          "proposal": {
-            "title": "Classy Proposal",
-            "proposalClass": {
-              "__typename": "LargeProgram",
-              "minPercentTime": 77,
-              "minPercentTotalTime": 88,
-              "totalTime": {
-                "seconds": 660.000000
-              }
-            },
-            "category": null,
-            "toOActivation": "STANDARD",
-            "abstract": null,
-            "partnerSplits": []
+          "program": {
+            "id": "p-3",
+            "name": "Jack",
+            "existence": "PRESENT",
+            "proposal": {
+              "title": "Classy Proposal",
+              "proposalClass": {
+                "__typename": "LargeProgram",
+                "minPercentTime": 77,
+                "minPercentTotalTime": 88,
+                "totalTime": {
+                  "seconds": 660.000000
+                }
+              },
+              "category": null,
+              "toOActivation": "STANDARD",
+              "abstract": null,
+              "partnerSplits": []
+            }
           }
         }
       }
@@ -118,37 +122,39 @@ class ProgramMutationSuite extends OdbSuite {
   queryTest(
     query = """
       mutation EditProgramExisting($programEdit: EditProgramInput!) {
-        editProgram(input: $programEdit) 
+        editProgram(input: $programEdit)
     """ + programQuery + "}",
     expected = json"""
       {
         "editProgram": {
-          "id": "p-3",
-          "name": "Jack",
-          "existence": "PRESENT",
-          "proposal": {
-            "title": "Classy Proposal",
-            "proposalClass": {
-              "__typename": "LargeProgram",
-              "minPercentTime": 77,
-              "minPercentTotalTime": 96,
-              "totalTime": {
-                "seconds": 660.000000
-              }
-            },
-            "category": null,
-            "toOActivation": "STANDARD",
-            "abstract": null,
-            "partnerSplits": [
-              {
-                "partner": "CL",
-                "percent": 60
+          "program": {
+            "id": "p-3",
+            "name": "Jack",
+            "existence": "PRESENT",
+            "proposal": {
+              "title": "Classy Proposal",
+              "proposalClass": {
+                "__typename": "LargeProgram",
+                "minPercentTime": 77,
+                "minPercentTotalTime": 96,
+                "totalTime": {
+                  "seconds": 660.000000
+                }
               },
-              {
-                "partner": "UH",
-                "percent": 40
-              }
-            ]
+              "category": null,
+              "toOActivation": "STANDARD",
+              "abstract": null,
+              "partnerSplits": [
+                {
+                  "partner": "CL",
+                  "percent": 60
+                },
+                {
+                  "partner": "UH",
+                  "percent": 40
+                }
+              ]
+            }
           }
         }
       }
@@ -183,33 +189,35 @@ class ProgramMutationSuite extends OdbSuite {
 
   private lazy val programQuery = """
   {
-    id
-    name
-    existence
-    proposal {
-      title
-      proposalClass {
-        __typename
-        minPercentTime
-        ... on LargeProgram {
-          minPercentTotalTime
-          totalTime {
-            seconds
+    program {
+      id
+      name
+      existence
+      proposal {
+        title
+        proposalClass {
+          __typename
+          minPercentTime
+          ... on LargeProgram {
+            minPercentTotalTime
+            totalTime {
+              seconds
+            }
+          }
+          ... on Intensive {
+            minPercentTotalTime
+            totalTime {
+              seconds
+            }
           }
         }
-        ... on Intensive {
-          minPercentTotalTime
-          totalTime {
-            seconds
-          }
+        category
+        toOActivation
+        abstract
+        partnerSplits {
+          partner
+          percent
         }
-      }
-      category
-      toOActivation
-      abstract
-      partnerSplits {
-        partner
-        percent
       }
     }
   }

--- a/modules/service/src/test/scala/test/TestInit.scala
+++ b/modules/service/src/test/scala/test/TestInit.scala
@@ -472,7 +472,7 @@ object TestInit {
               )
             ).map(_.newProgram)
       cs <- targets(p.id).liftTo[F]
-      ts <- cs.init.traverse(repo.target.insert(_))
+      ts <- cs.init.traverse(repo.target.insert(_).map(_.newTarget))
       _  <- repo.observation.insert(obs(p.id, ts.headOption.toList)) // 2
       _  <- repo.observation.insert(obs(p.id, ts.lastOption.toList)) // 3
       _  <- repo.observation.insert(obs(p.id, ts.lastOption.toList)) // 4

--- a/modules/service/src/test/scala/test/TestInit.scala
+++ b/modules/service/src/test/scala/test/TestInit.scala
@@ -462,7 +462,7 @@ object TestInit {
                   proposal.assign
                 ).some
               )
-            )
+            ).map(_.newProgram)
 
       p3 <- repo.program.insert(
               ProgramModel.CreateInput(
@@ -470,13 +470,13 @@ object TestInit {
                   NonEmptyString.unsafeFrom("An Empty Placeholder Program").assign
                 ).some
               )
-            )
+            ).map(_.newProgram)
       cs <- targets(p.id).liftTo[F]
       ts <- cs.init.traverse(repo.target.insert(_))
       _  <- repo.observation.insert(obs(p.id, ts.headOption.toList)) // 2
       _  <- repo.observation.insert(obs(p.id, ts.lastOption.toList)) // 3
       _  <- repo.observation.insert(obs(p.id, ts.lastOption.toList)) // 4
-      o  <- repo.observation.insert(obs(p.id, ts.lastOption.toList)) // 5
+      o  <- repo.observation.insert(obs(p.id, ts.lastOption.toList)).map(_.newObservation) // 5
 
       // Add an explicit base to the last observation's target environment
       _  <- repo.observation.edit(

--- a/modules/service/src/test/scala/test/TestInit.scala
+++ b/modules/service/src/test/scala/test/TestInit.scala
@@ -462,7 +462,7 @@ object TestInit {
                   proposal.assign
                 ).some
               )
-            ).map(_.newProgram)
+            ).map(_.program)
 
       p3 <- repo.program.insert(
               ProgramModel.CreateInput(
@@ -470,13 +470,13 @@ object TestInit {
                   NonEmptyString.unsafeFrom("An Empty Placeholder Program").assign
                 ).some
               )
-            ).map(_.newProgram)
+            ).map(_.program)
       cs <- targets(p.id).liftTo[F]
-      ts <- cs.init.traverse(repo.target.insert(_).map(_.newTarget))
+      ts <- cs.init.traverse(repo.target.insert(_).map(_.target))
       _  <- repo.observation.insert(obs(p.id, ts.headOption.toList)) // 2
       _  <- repo.observation.insert(obs(p.id, ts.lastOption.toList)) // 3
       _  <- repo.observation.insert(obs(p.id, ts.lastOption.toList)) // 4
-      o  <- repo.observation.insert(obs(p.id, ts.lastOption.toList)).map(_.newObservation) // 5
+      o  <- repo.observation.insert(obs(p.id, ts.lastOption.toList)).map(_.observation) // 5
 
       // Add an explicit base to the last observation's target environment
       _  <- repo.observation.edit(
@@ -496,8 +496,8 @@ object TestInit {
       // Add an unused target (t-5 NGC 4749)
       _  <- repo.target.insert(cs.last)
 
-      _  <- repo.observation.insert(obs(p.id, ts))                   // 6
-      _  <- repo.observation.insert(obs(p.id, Nil))                  // 7
+      _  <- repo.observation.insert(obs(p.id, ts)) // 6
+      _  <- repo.observation.insert(obs(p.id, Nil)) // 7
 
       // Add an unused target for the otherwise empty program. (t-6)
       _  <- repo.target.insert(cs.last.copy(programId = p3.id))

--- a/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
+++ b/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
@@ -274,7 +274,7 @@ class VisitSuite extends OdbSuite {
   queryTest(
     query = """
       mutation EditDataset($editDatasetInput: EditDatasetInput!) {
-        editDataset(input: $editDatasetInput) {
+        editDatasets(input: $editDatasetInput) {
           datasets {
             id {
               observationId
@@ -289,7 +289,7 @@ class VisitSuite extends OdbSuite {
     """,
     expected =json"""
       {
-        "editDataset": {
+        "editDatasets": {
           "datasets": [
             {
               "id": {

--- a/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
+++ b/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
@@ -56,7 +56,7 @@ class VisitSuite extends OdbSuite {
     query = s"""
       mutation AddSequenceEvent($$eventInput: AddSequenceEventInput!) {
         addSequenceEvent(input: $$eventInput) {
-          newEvent {
+          event {
             payload {
               command
             }
@@ -67,7 +67,7 @@ class VisitSuite extends OdbSuite {
     expected =json"""
       {
         "addSequenceEvent": {
-          "newEvent": {
+          "event": {
             "payload": {
               "command": "START"
             }
@@ -152,7 +152,7 @@ class VisitSuite extends OdbSuite {
     query = s"""
       mutation AddStepEvent($$eventInput: AddStepEventInput!) {
         addStepEvent(input: $$eventInput) {
-          newEvent {
+          event {
             payload {
               stage
             }
@@ -163,7 +163,7 @@ class VisitSuite extends OdbSuite {
     expected =json"""
       {
         "addStepEvent": {
-          "newEvent": {
+          "event": {
             "payload": {
               "stage": "START_STEP"
             }
@@ -194,7 +194,7 @@ class VisitSuite extends OdbSuite {
     query = s"""
       mutation AddDatasetEvent($$eventInput: AddDatasetEventInput!) {
         addDatasetEvent(input: $$eventInput) {
-          newEvent {
+          event {
             payload {
               stage
             }
@@ -205,7 +205,7 @@ class VisitSuite extends OdbSuite {
     expected =json"""
       {
         "addDatasetEvent": {
-          "newEvent": {
+          "event": {
             "payload": {
                "stage": "START_OBSERVE"
              }

--- a/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
+++ b/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
@@ -21,14 +21,18 @@ class VisitSuite extends OdbSuite {
     query = s"""
       mutation RecordGmosSouthVisit($$recordInput: RecordGmosSouthVisitInput!) {
         recordGmosSouthVisit(input: $$recordInput, visitId: "$vid") {
-          id
+          visitRecord {
+            id
+          }
         }
       }
     """,
     expected =json"""
       {
         "recordGmosSouthVisit": {
-          "id": ${vid.toString}
+          "visitRecord": {
+            "id": ${vid.toString}
+          }
         }
       }
     """,

--- a/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
+++ b/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
@@ -267,29 +267,33 @@ class VisitSuite extends OdbSuite {
     query = """
       mutation EditDataset($editDatasetInput: EditDatasetInput!) {
         editDataset(input: $editDatasetInput) {
-          id {
-            observationId
-            stepId
-            index
+          datasets {
+            id {
+              observationId
+              stepId
+              index
+            }
+            filename
+            qaState
           }
-          filename
-          qaState
         }
       }
     """,
     expected =json"""
       {
-        "editDataset": [
-          {
-            "id": {
-              "observationId": "o-2",
-              "stepId": ${sid.toString},
-              "index": 1
-            },
-            "filename": "S20220504S0001.fits",
-            "qaState": "PASS"
-          }
-        ]
+        "editDataset": {
+          "datasets": [
+            {
+              "id": {
+                "observationId": "o-2",
+                "stepId": ${sid.toString},
+                "index": 1
+              },
+              "filename": "S20220504S0001.fits",
+              "qaState": "PASS"
+            }
+          ]
+        }
       }
     """,
     variables =json"""

--- a/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
+++ b/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
@@ -52,8 +52,10 @@ class VisitSuite extends OdbSuite {
     query = s"""
       mutation AddSequenceEvent($$eventInput: AddSequenceEventInput!) {
         addSequenceEvent(input: $$eventInput) {
-          payload {
-            command
+          newEvent {
+            payload {
+              command
+            }
           }
         }
       }
@@ -61,8 +63,10 @@ class VisitSuite extends OdbSuite {
     expected =json"""
       {
         "addSequenceEvent": {
-          "payload": {
-            "command": "START"
+          "newEvent": {
+            "payload": {
+              "command": "START"
+            }
           }
         }
       }
@@ -140,8 +144,10 @@ class VisitSuite extends OdbSuite {
     query = s"""
       mutation AddStepEvent($$eventInput: AddStepEventInput!) {
         addStepEvent(input: $$eventInput) {
-          payload {
-            stage
+          newEvent {
+            payload {
+              stage
+            }
           }
         }
       }
@@ -149,8 +155,10 @@ class VisitSuite extends OdbSuite {
     expected =json"""
       {
         "addStepEvent": {
-          "payload": {
-            "stage": "START_STEP"
+          "newEvent": {
+            "payload": {
+              "stage": "START_STEP"
+            }
           }
         }
       }
@@ -178,8 +186,10 @@ class VisitSuite extends OdbSuite {
     query = s"""
       mutation AddDatasetEvent($$eventInput: AddDatasetEventInput!) {
         addDatasetEvent(input: $$eventInput) {
-          payload {
-            stage
+          newEvent {
+            payload {
+              stage
+            }
           }
         }
       }
@@ -187,8 +197,10 @@ class VisitSuite extends OdbSuite {
     expected =json"""
       {
         "addDatasetEvent": {
-          "payload": {
-             "stage": "START_OBSERVE"
+          "newEvent": {
+            "payload": {
+               "stage": "START_OBSERVE"
+             }
            }
         }
       }

--- a/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
+++ b/modules/service/src/test/scala/test/seqexec/VisitSuite.scala
@@ -96,14 +96,18 @@ class VisitSuite extends OdbSuite {
     query = s"""
       mutation RecordGmosSouthStep($$recordInput: RecordGmosSouthStepInput!) {
         recordGmosSouthStep(input: $$recordInput, stepId: "$sid") {
-          id
+          stepRecord {
+            id
+          }
         }
       }
     """,
     expected =json"""
       {
         "recordGmosSouthStep": {
-          "id": ${sid.toString}
+          "stepRecord": {
+            "id": ${sid.toString}
+          }
         }
       }
     """,

--- a/modules/service/src/test/scala/test/targets/AsterismMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/AsterismMutationSuite.scala
@@ -26,10 +26,12 @@ class AsterismMutationSuite extends OdbSuite {
     query ="""
       mutation ReplaceTargets($listEdit: EditAsterismInput!) {
         editAsterism(input: $listEdit) {
-          id
-          targetEnvironment {
-            asterism {
-              name
+          observations {
+            id
+            targetEnvironment {
+              asterism {
+                name
+              }
             }
           }
         }
@@ -37,28 +39,30 @@ class AsterismMutationSuite extends OdbSuite {
     """,
     expected =json"""
       {
-        "editAsterism": [
-          {
-            "id": "o-3",
-            "targetEnvironment": {
-              "asterism": [
-                {
-                  "name": "NGC 5949"
-                }
-              ]
+        "editAsterism": {
+          "observations": [
+            {
+              "id": "o-3",
+              "targetEnvironment": {
+                "asterism": [
+                  {
+                    "name": "NGC 5949"
+                  }
+                ]
+              }
+            },
+            {
+              "id": "o-4",
+              "targetEnvironment": {
+                "asterism": [
+                  {
+                    "name": "NGC 5949"
+                  }
+                ]
+              }
             }
-          },
-          {
-            "id": "o-4",
-            "targetEnvironment": {
-              "asterism": [
-                {
-                  "name": "NGC 5949"
-                }
-              ]
-            }
-          }
-        ]
+          ]
+        }
       }
     """,
     variables =json"""

--- a/modules/service/src/test/scala/test/targets/AsterismMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/AsterismMutationSuite.scala
@@ -24,7 +24,7 @@ class AsterismMutationSuite extends OdbSuite {
   // Replace NGC 3312 (t-4) in o-3 and o-4 with NGC 5949 (t-2)
   queryTest(
     query ="""
-      mutation ReplaceTargets($listEdit: EditAsterismInput!) {
+      mutation ReplaceTargets($listEdit: EditAsterismsInput!) {
         editAsterisms(input: $listEdit) {
           observations {
             id

--- a/modules/service/src/test/scala/test/targets/AsterismMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/AsterismMutationSuite.scala
@@ -25,7 +25,7 @@ class AsterismMutationSuite extends OdbSuite {
   queryTest(
     query ="""
       mutation ReplaceTargets($listEdit: EditAsterismInput!) {
-        editAsterism(input: $listEdit) {
+        editAsterisms(input: $listEdit) {
           observations {
             id
             targetEnvironment {
@@ -39,7 +39,7 @@ class AsterismMutationSuite extends OdbSuite {
     """,
     expected =json"""
       {
-        "editAsterism": {
+        "editAsterisms": {
           "observations": [
             {
               "id": "o-3",

--- a/modules/service/src/test/scala/test/targets/SourceProfileSuite.scala
+++ b/modules/service/src/test/scala/test/targets/SourceProfileSuite.scala
@@ -16,16 +16,18 @@ class SourceProfileSuite extends OdbSuite {
     query     = """
       mutation EditMagnitude($targetEdit: EditTargetInput!) {
         editTarget(input: $targetEdit) {
-          id
-          name
-          sourceProfile {
-            point {
-              bandNormalized {
-                brightnesses {
-                  band
-                  value
-                  units
-                  error
+          targets {
+            id
+            name
+            sourceProfile {
+              point {
+                bandNormalized {
+                  brightnesses {
+                    band
+                    value
+                    units
+                    error
+                  }
                 }
               }
             }
@@ -35,62 +37,64 @@ class SourceProfileSuite extends OdbSuite {
     """,
     expected  = json"""
       {
-        "editTarget": [
-          {
-            "id": "t-3",
-            "name": "NGC 3269",
-            "sourceProfile": {
-              "point": {
-                "bandNormalized": {
-                  "brightnesses": [
-                    {
-                      "band": "U",
-                      "value": 10,
-                      "units": "VEGA_MAGNITUDE",
-                      "error": null
-                    },
-                    {
-                      "band": "B",
-                      "value": 13.240,
-                      "units": "VEGA_MAGNITUDE",
-                      "error": null
-                    },
-                    {
-                      "band": "V",
-                      "value": 13.510,
-                      "units": "VEGA_MAGNITUDE",
-                      "error": null
-                    },
-                    {
-                      "band": "R",
-                      "value": 11.730,
-                      "units": "VEGA_MAGNITUDE",
-                      "error": null
-                    },
-                    {
-                      "band": "J",
-                      "value": 42,
-                      "units": "VEGA_MAGNITUDE",
-                      "error": 0.018
-                    },
-                    {
-                      "band": "H",
-                      "value": 9.387,
-                      "units": "VEGA_MAGNITUDE",
-                      "error": null
-                    },
-                    {
-                      "band": "K",
-                      "value": 9.055,
-                      "units": "VEGA_MAGNITUDE",
-                      "error": 0.031
-                    }
-                  ]
+        "editTarget": {
+          "targets": [
+            {
+              "id": "t-3",
+              "name": "NGC 3269",
+              "sourceProfile": {
+                "point": {
+                  "bandNormalized": {
+                    "brightnesses": [
+                      {
+                        "band": "U",
+                        "value": 10,
+                        "units": "VEGA_MAGNITUDE",
+                        "error": null
+                      },
+                      {
+                        "band": "B",
+                        "value": 13.240,
+                        "units": "VEGA_MAGNITUDE",
+                        "error": null
+                      },
+                      {
+                        "band": "V",
+                        "value": 13.510,
+                        "units": "VEGA_MAGNITUDE",
+                        "error": null
+                      },
+                      {
+                        "band": "R",
+                        "value": 11.730,
+                        "units": "VEGA_MAGNITUDE",
+                        "error": null
+                      },
+                      {
+                        "band": "J",
+                        "value": 42,
+                        "units": "VEGA_MAGNITUDE",
+                        "error": 0.018
+                      },
+                      {
+                        "band": "H",
+                        "value": 9.387,
+                        "units": "VEGA_MAGNITUDE",
+                        "error": null
+                      },
+                      {
+                        "band": "K",
+                        "value": 9.055,
+                        "units": "VEGA_MAGNITUDE",
+                        "error": 0.031
+                      }
+                    ]
+                  }
                 }
               }
             }
-          }
-        ]
+          ]
+        }
       }
     """,
     variables = json"""
@@ -133,16 +137,18 @@ class SourceProfileSuite extends OdbSuite {
     query     = """
       mutation EditMagnitude($targetEdit: EditTargetInput!) {
         editTarget(input: $targetEdit) {
-          id
-          name
-          sourceProfile {
-            point {
-              bandNormalized {
-                brightnesses {
-                  band
-                  value
-                  units
-                  error
+          targets {
+            id
+            name
+            sourceProfile {
+              point {
+                bandNormalized {
+                  brightnesses {
+                    band
+                    value
+                    units
+                    error
+                  }
                 }
               }
             }
@@ -152,26 +158,28 @@ class SourceProfileSuite extends OdbSuite {
     """,
     expected  = json"""
       {
-        "editTarget": [
-          {
-            "id": "t-2",
-            "name": "NGC 5949",
-            "sourceProfile": {
-              "point": {
-                "bandNormalized": {
-                  "brightnesses": [
-                    {
-                      "band": "U",
-                      "value": 10,
-                      "units": "VEGA_MAGNITUDE",
-                      "error": null
-                    }
-                  ]
+        "editTarget": {
+          "targets": [
+            {
+              "id": "t-2",
+              "name": "NGC 5949",
+              "sourceProfile": {
+                "point": {
+                  "bandNormalized": {
+                    "brightnesses": [
+                      {
+                        "band": "U",
+                        "value": 10,
+                        "units": "VEGA_MAGNITUDE",
+                        "error": null
+                      }
+                    ]
+                  }
                 }
               }
             }
-          }
-        ]
+          ]
+        }
       }
     """,
     variables = json"""
@@ -206,16 +214,18 @@ class SourceProfileSuite extends OdbSuite {
     query     = """
       mutation EditMagnitude($targetEdit: EditTargetInput!) {
         editTarget(input: $targetEdit) {
-          id
-          name
-          sourceProfile {
-            point {
-              bandNormalized {
-                brightnesses {
-                  band
-                  value
-                  units
-                  error
+          targets {
+            id
+            name
+            sourceProfile {
+              point {
+                bandNormalized {
+                  brightnesses {
+                    band
+                    value
+                    units
+                    error
+                  }
                 }
               }
             }
@@ -225,26 +235,28 @@ class SourceProfileSuite extends OdbSuite {
     """,
     expected  = json"""
       {
-        "editTarget": [
-          {
-            "id": "t-4",
-            "name": "NGC 3312",
-            "sourceProfile": {
-              "point": {
-                "bandNormalized": {
-                  "brightnesses": [
-                    {
-                      "band": "V",
-                      "value": 13.960,
-                      "units": "VEGA_MAGNITUDE",
-                      "error": 10
-                    }
-                  ]
+        "editTarget": {
+          "targets": [
+            {
+              "id": "t-4",
+              "name": "NGC 3312",
+              "sourceProfile": {
+                "point": {
+                  "bandNormalized": {
+                    "brightnesses": [
+                      {
+                        "band": "V",
+                        "value": 13.960,
+                        "units": "VEGA_MAGNITUDE",
+                        "error": 10
+                      }
+                    ]
+                  }
                 }
               }
             }
-          }
-        ]
+          ]
+        }
       }
     """,
     variables = json"""

--- a/modules/service/src/test/scala/test/targets/SourceProfileSuite.scala
+++ b/modules/service/src/test/scala/test/targets/SourceProfileSuite.scala
@@ -15,7 +15,7 @@ class SourceProfileSuite extends OdbSuite {
   queryTest(
     query     = """
       mutation EditMagnitude($targetEdit: EditTargetInput!) {
-        editTarget(input: $targetEdit) {
+        editTargets(input: $targetEdit) {
           targets {
             id
             name
@@ -37,7 +37,7 @@ class SourceProfileSuite extends OdbSuite {
     """,
     expected  = json"""
       {
-        "editTarget": {
+        "editTargets": {
           "targets": [
             {
               "id": "t-3",
@@ -136,7 +136,7 @@ class SourceProfileSuite extends OdbSuite {
   queryTest(
     query     = """
       mutation EditMagnitude($targetEdit: EditTargetInput!) {
-        editTarget(input: $targetEdit) {
+        editTargets(input: $targetEdit) {
           targets {
             id
             name
@@ -158,7 +158,7 @@ class SourceProfileSuite extends OdbSuite {
     """,
     expected  = json"""
       {
-        "editTarget": {
+        "editTargets": {
           "targets": [
             {
               "id": "t-2",
@@ -213,7 +213,7 @@ class SourceProfileSuite extends OdbSuite {
   queryTest(
     query     = """
       mutation EditMagnitude($targetEdit: EditTargetInput!) {
-        editTarget(input: $targetEdit) {
+        editTargets(input: $targetEdit) {
           targets {
             id
             name
@@ -235,7 +235,7 @@ class SourceProfileSuite extends OdbSuite {
     """,
     expected  = json"""
       {
-        "editTarget": {
+        "editTargets": {
           "targets": [
             {
               "id": "t-4",

--- a/modules/service/src/test/scala/test/targets/SourceProfileSuite.scala
+++ b/modules/service/src/test/scala/test/targets/SourceProfileSuite.scala
@@ -14,7 +14,7 @@ class SourceProfileSuite extends OdbSuite {
   // Add new U entry
   queryTest(
     query     = """
-      mutation EditMagnitude($targetEdit: EditTargetInput!) {
+      mutation EditMagnitude($targetEdit: EditTargetsInput!) {
         editTargets(input: $targetEdit) {
           targets {
             id
@@ -135,7 +135,7 @@ class SourceProfileSuite extends OdbSuite {
   // Replace all magnitudes with one U entry
   queryTest(
     query     = """
-      mutation EditMagnitude($targetEdit: EditTargetInput!) {
+      mutation EditMagnitude($targetEdit: EditTargetsInput!) {
         editTargets(input: $targetEdit) {
           targets {
             id
@@ -212,7 +212,7 @@ class SourceProfileSuite extends OdbSuite {
   // Delete all but V, set its error to 10
   queryTest(
     query     = """
-      mutation EditMagnitude($targetEdit: EditTargetInput!) {
+      mutation EditMagnitude($targetEdit: EditTargetsInput!) {
         editTargets(input: $targetEdit) {
           targets {
             id

--- a/modules/service/src/test/scala/test/targets/TargetCloneSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetCloneSuite.scala
@@ -14,16 +14,20 @@ class TargetCloneSuite extends OdbSuite {
     query ="""
       mutation CloneTarget($cloneInput: CloneTargetInput!) {
         cloneTarget(input: $cloneInput) {
-          name
-          existence
+          newTarget {
+            name
+            existence
+          }
         }
       }
     """,
     expected =json"""
       {
         "cloneTarget": {
-          "name": "Biff",
-          "existence": "PRESENT"
+          "newTarget": {
+            "name": "Biff",
+            "existence": "PRESENT"
+          }
         }
       }
     """,
@@ -45,14 +49,18 @@ class TargetCloneSuite extends OdbSuite {
     query ="""
       mutation CloneAndReplaceTarget($cloneInput: CloneTargetInput!) {
         cloneTarget(input: $cloneInput) {
-          name
+          newTarget {
+            name
+          }
         }
       }
     """,
     expected =json"""
       {
         "cloneTarget": {
-          "name": "NGC 3312 (2)"
+          "newTarget": {
+            "name": "NGC 3312 (2)"
+          }
         }
       }
     """,

--- a/modules/service/src/test/scala/test/targets/TargetEnvironmentMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetEnvironmentMutationSuite.scala
@@ -24,7 +24,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
   queryTest(
     query ="""
       mutation UpdateTargetEnvironment($envEdit: EditObservationInput!) {
-        editObservation(input: $envEdit) {
+        editObservations(input: $envEdit) {
           observations {
             id
             targetEnvironment {
@@ -38,7 +38,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
     """,
     expected =json"""
       {
-        "editObservation": {
+        "editObservations": {
           "observations": [
             {
               "id": "o-3",
@@ -74,7 +74,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
   queryTestFailure(
     query ="""
       mutation UpdateTargetEnvironment($envEdit: EditObservationInput!) {
-        editObservation(input: $envEdit) {
+        editObservations(input: $envEdit) {
           observations {
             id
             targetEnvironment {
@@ -108,7 +108,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
   queryTest(
     query ="""
       mutation UpdateTargetEnvironment($envEdit: EditObservationInput!) {
-        editObservation(input: $envEdit) {
+        editObservations(input: $envEdit) {
           observations {
             id
             targetEnvironment {
@@ -123,7 +123,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
     """,
     expected =json"""
       {
-        "editObservation": {
+        "editObservations": {
           "observations": [
             {
               "id": "o-3",

--- a/modules/service/src/test/scala/test/targets/TargetEnvironmentMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetEnvironmentMutationSuite.scala
@@ -25,10 +25,12 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
     query ="""
       mutation UpdateTargetEnvironment($envEdit: EditObservationInput!) {
         editObservation(input: $envEdit) {
-          id
-          targetEnvironment {
-            asterism {
-              name
+          observations {
+            id
+            targetEnvironment {
+              asterism {
+                name
+              }
             }
           }
         }
@@ -36,18 +38,20 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
     """,
     expected =json"""
       {
-        "editObservation": [
-          {
-            "id": "o-3",
-            "targetEnvironment": {
-              "asterism": [
-                {
-                  "name": "NGC 5949"
-                }
-              ]
+        "editObservation": {
+          "observations": [
+            {
+              "id": "o-3",
+              "targetEnvironment": {
+                "asterism": [
+                  {
+                    "name": "NGC 5949"
+                  }
+                ]
+              }
             }
-          }
-        ]
+          ]
+        }
       }
     """,
     variables =json"""
@@ -71,10 +75,12 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
     query ="""
       mutation UpdateTargetEnvironment($envEdit: EditObservationInput!) {
         editObservation(input: $envEdit) {
-          id
-          targetEnvironment {
-            asterism {
-              name
+          observations {
+            id
+            targetEnvironment {
+              asterism {
+                name
+              }
             }
           }
         }
@@ -103,11 +109,13 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
     query ="""
       mutation UpdateTargetEnvironment($envEdit: EditObservationInput!) {
         editObservation(input: $envEdit) {
-          id
-          targetEnvironment {
-            explicitBase {
-              ra { hms }
-              dec { dms }
+          observations {
+            id
+            targetEnvironment {
+              explicitBase {
+                ra { hms }
+                dec { dms }
+              }
             }
           }
         }
@@ -115,21 +123,23 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
     """,
     expected =json"""
       {
-        "editObservation": [
-          {
-            "id": "o-3",
-            "targetEnvironment": {
-              "explicitBase": {
-                "ra": {
-                  "hms": "01:00:00.000000"
-                },
-                "dec": {
-                  "dms": "+02:00:00.000000"
+        "editObservation": {
+          "observations": [
+            {
+              "id": "o-3",
+              "targetEnvironment": {
+                "explicitBase": {
+                  "ra": {
+                    "hms": "01:00:00.000000"
+                  },
+                  "dec": {
+                    "dms": "+02:00:00.000000"
+                  }
                 }
               }
             }
-          }
-        ]
+          ]
+        }
       }
     """,
     variables =json"""

--- a/modules/service/src/test/scala/test/targets/TargetEnvironmentMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetEnvironmentMutationSuite.scala
@@ -23,7 +23,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
   // In o-3, replace NGC 3312 with NGC 5949
   queryTest(
     query ="""
-      mutation UpdateTargetEnvironment($envEdit: EditObservationInput!) {
+      mutation UpdateTargetEnvironment($envEdit: EditObservationsInput!) {
         editObservations(input: $envEdit) {
           observations {
             id
@@ -73,7 +73,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
   //
   queryTestFailure(
     query ="""
-      mutation UpdateTargetEnvironment($envEdit: EditObservationInput!) {
+      mutation UpdateTargetEnvironment($envEdit: EditObservationsInput!) {
         editObservations(input: $envEdit) {
           observations {
             id
@@ -107,7 +107,7 @@ class TargetEnvironmentMutationSuite extends OdbSuite {
   // Add an explicit base to o-3
   queryTest(
     query ="""
-      mutation UpdateTargetEnvironment($envEdit: EditObservationInput!) {
+      mutation UpdateTargetEnvironment($envEdit: EditObservationsInput!) {
         editObservations(input: $envEdit) {
           observations {
             id

--- a/modules/service/src/test/scala/test/targets/TargetGroupIncludeDeletedSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetGroupIncludeDeletedSuite.scala
@@ -23,7 +23,7 @@ class TargetGroupIncludeDeletedSuite extends OdbSuite {
   // Delete NGC 3269 (t-3)
   queryTest(
     query ="""
-      mutation DeleteTarget($deleteTargetInput: DeleteTargetInput!) {
+      mutation DeleteTarget($deleteTargetInput: DeleteTargetsInput!) {
         deleteTargets(input: $deleteTargetInput) {
           targets {
             id

--- a/modules/service/src/test/scala/test/targets/TargetGroupIncludeDeletedSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetGroupIncludeDeletedSuite.scala
@@ -24,7 +24,7 @@ class TargetGroupIncludeDeletedSuite extends OdbSuite {
   queryTest(
     query ="""
       mutation DeleteTarget($deleteTargetInput: DeleteTargetInput!) {
-        deleteTarget(input: $deleteTargetInput) {
+        deleteTargets(input: $deleteTargetInput) {
           targets {
             id
           }
@@ -33,7 +33,7 @@ class TargetGroupIncludeDeletedSuite extends OdbSuite {
     """,
     expected = json"""
       {
-        "deleteTarget": {
+        "deleteTargets": {
           "targets": [
             {
               "id": "t-3"

--- a/modules/service/src/test/scala/test/targets/TargetGroupIncludeDeletedSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetGroupIncludeDeletedSuite.scala
@@ -25,17 +25,21 @@ class TargetGroupIncludeDeletedSuite extends OdbSuite {
     query ="""
       mutation DeleteTarget($deleteTargetInput: DeleteTargetInput!) {
         deleteTarget(input: $deleteTargetInput) {
-          id
+          targets {
+            id
+          }
         }
       }
     """,
     expected = json"""
       {
-        "deleteTarget": [
-          {
-            "id": "t-3"
-          }
-        ]
+        "deleteTarget": {
+          "targets": [
+            {
+              "id": "t-3"
+            }
+          ]
+        }
       }
     """,
     variables = json"""

--- a/modules/service/src/test/scala/test/targets/TargetMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetMutationSuite.scala
@@ -14,25 +14,29 @@ class TargetMutationSuite extends OdbSuite {
     query = """
       mutation UpdateScienceTarget($targetEdit: EditTargetInput!) {
         editTarget(input: $targetEdit) {
-          id
-          name
-          sidereal {
-            parallax { microarcseconds }
+          targets {
+            id
+            name
+            sidereal {
+              parallax { microarcseconds }
+            }
           }
         }
       }
     """,
     expected = json"""
       {
-        "editTarget": [
-          {
-            "id": "t-4",
-            "name": "NGC 3312",
-            "sidereal": {
-              "parallax": null
+        "editTarget": {
+          "targets": [
+            {
+              "id": "t-4",
+              "name": "NGC 3312",
+              "sidereal": {
+                "parallax": null
+              }
             }
-          }
-        ]
+          ]
+        }
       }
     """,
     variables = json"""

--- a/modules/service/src/test/scala/test/targets/TargetMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetMutationSuite.scala
@@ -13,7 +13,7 @@ class TargetMutationSuite extends OdbSuite {
   queryTest(
     query = """
       mutation UpdateScienceTarget($targetEdit: EditTargetInput!) {
-        editTarget(input: $targetEdit) {
+        editTargets(input: $targetEdit) {
           targets {
             id
             name
@@ -26,7 +26,7 @@ class TargetMutationSuite extends OdbSuite {
     """,
     expected = json"""
       {
-        "editTarget": {
+        "editTargets": {
           "targets": [
             {
               "id": "t-4",
@@ -59,7 +59,7 @@ class TargetMutationSuite extends OdbSuite {
   queryTest(
     query = """
       mutation DeleteTarget($deleteTargetInput: DeleteTargetInput!) {
-        deleteTarget(input: $deleteTargetInput) {
+        deleteTargets(input: $deleteTargetInput) {
           targets {
             id
             name
@@ -70,7 +70,7 @@ class TargetMutationSuite extends OdbSuite {
     """,
     expected = json"""
       {
-        "deleteTarget": {
+        "deleteTargets": {
           "targets": [
             {
               "id": "t-4",

--- a/modules/service/src/test/scala/test/targets/TargetMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetMutationSuite.scala
@@ -90,16 +90,20 @@ class TargetMutationSuite extends OdbSuite {
     query ="""
       mutation CloneTarget($cloneInput: CloneTargetInput!) {
         cloneTarget(input: $cloneInput) {
-          name
-          existence
+          newTarget {
+            name
+            existence
+          }
         }
       }
     """,
     expected =json"""
       {
         "cloneTarget": {
-          "name": "NGC 3312",
-          "existence": "PRESENT"
+          "newTarget": {
+            "name": "NGC 3312",
+            "existence": "PRESENT"
+          }
         }
       }
     """,

--- a/modules/service/src/test/scala/test/targets/TargetMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetMutationSuite.scala
@@ -12,7 +12,7 @@ class TargetMutationSuite extends OdbSuite {
   // Edit NGC 3312 to remove parallax altogether.
   queryTest(
     query = """
-      mutation UpdateScienceTarget($targetEdit: EditTargetInput!) {
+      mutation UpdateScienceTarget($targetEdit: EditTargetsInput!) {
         editTargets(input: $targetEdit) {
           targets {
             id
@@ -58,7 +58,7 @@ class TargetMutationSuite extends OdbSuite {
   // Delete a target by id.  No need to specify a target environment.
   queryTest(
     query = """
-      mutation DeleteTarget($deleteTargetInput: DeleteTargetInput!) {
+      mutation DeleteTarget($deleteTargetInput: DeleteTargetsInput!) {
         deleteTargets(input: $deleteTargetInput) {
           targets {
             id

--- a/modules/service/src/test/scala/test/targets/TargetMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetMutationSuite.scala
@@ -60,21 +60,25 @@ class TargetMutationSuite extends OdbSuite {
     query = """
       mutation DeleteTarget($deleteTargetInput: DeleteTargetInput!) {
         deleteTarget(input: $deleteTargetInput) {
-          id
-          name
-          existence
+          targets {
+            id
+            name
+            existence
+          }
         }
       }
     """,
     expected = json"""
       {
-        "deleteTarget": [
-          {
-            "id": "t-4",
-            "name": "NGC 3312",
-            "existence": "DELETED"
-          }
-        ]
+        "deleteTarget": {
+          "targets": [
+            {
+              "id": "t-4",
+              "name": "NGC 3312",
+              "existence": "DELETED"
+            }
+          ]
+        }
       }
     """,
     variables = json"""

--- a/modules/service/src/test/scala/test/targets/TargetRenameMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetRenameMutationSuite.scala
@@ -13,7 +13,7 @@ class TargetRenameMutationSuite extends OdbSuite {
   queryTest(
     query ="""
       mutation UpdateTarget($renameEdit: EditTargetInput!) {
-        editTarget(input: $renameEdit) {
+        editTargets(input: $renameEdit) {
           targets {
             id
             name
@@ -23,7 +23,7 @@ class TargetRenameMutationSuite extends OdbSuite {
     """,
     expected = json"""
       {
-        "editTarget": {
+        "editTargets": {
           "targets": [
             {
               "id": "t-4",

--- a/modules/service/src/test/scala/test/targets/TargetRenameMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetRenameMutationSuite.scala
@@ -14,19 +14,23 @@ class TargetRenameMutationSuite extends OdbSuite {
     query ="""
       mutation UpdateTarget($renameEdit: EditTargetInput!) {
         editTarget(input: $renameEdit) {
-          id
-          name
+          targets {
+            id
+            name
+          }
         }
       }
     """,
     expected = json"""
       {
-        "editTarget": [
-          {
-            "id": "t-4",
-            "name": "NGC 3312*"
-          }
-        ]
+        "editTarget": {
+          "targets": [
+            {
+              "id": "t-4",
+              "name": "NGC 3312*"
+            }
+          ]
+        }
       }
     """,
     variables = json"""

--- a/modules/service/src/test/scala/test/targets/TargetRenameMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetRenameMutationSuite.scala
@@ -12,7 +12,7 @@ class TargetRenameMutationSuite extends OdbSuite {
   // Rename target "NGC 3312" to "NGC 3312*".
   queryTest(
     query ="""
-      mutation UpdateTarget($renameEdit: EditTargetInput!) {
+      mutation UpdateTarget($renameEdit: EditTargetsInput!) {
         editTargets(input: $renameEdit) {
           targets {
             id


### PR DESCRIPTION
Adds a `Result` type wrapper around all mutation results.  All mutations now follow the pattern:

1. Verb name `doFoo`
2. Accepting a `DoFooInput!`
3. Returning a `DoFooResult`

At this point for the most part the result just has a field that is the same as the previous return value.  Clone mutations now include the original and the new (possibly edited) clone.

Since several of the mutations work on multiple objects at once, they were pluralized. For example, instead of `editObservation` it is `editObservations` with an `EditObservationsInput!` and an `EditObservationsResult`.