### PR TITLE
Nix Paging WIP

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/WhereProgram.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/WhereProgram.scala
@@ -9,14 +9,14 @@ import lucuma.core.model.Program
 import lucuma.odb.api.model.query.{WhereCombinator, WhereEq, WhereOptionString, WhereOrder}
 
 final case class WhereProgram(
+  AND:       Option[List[WhereProgram]],
+  OR:        Option[List[WhereProgram]],
+  NOT:       Option[WhereProgram],
+
   id:        Option[WhereOrder[Program.Id]],
   name:      Option[WhereOptionString],
   existence: Option[WhereEq[Existence]],
-  proposal:  Option[WhereProposal],
-
-  and:       Option[List[WhereProgram]],
-  or:        Option[List[WhereProgram]],
-  not:       Option[WhereProgram]
+  proposal:  Option[WhereProposal]
 ) extends WhereCombinator[ProgramModel] {
 
   override def matches(a: ProgramModel): Boolean =

--- a/modules/core/src/main/scala/lucuma/odb/api/model/WhereProgram.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/WhereProgram.scala
@@ -20,11 +20,11 @@ final case class WhereProgram(
 ) extends WhereCombinator[ProgramModel] {
 
   override def matches(a: ProgramModel): Boolean =
-    id.forall(_.matches(a.id))                    &&
+    super.matches(a)                              &&
+      id.forall(_.matches(a.id))                  &&
       name.forall(_.matches(a.name.map(_.value))) &&
       existence.forall(_.matches(a.existence))    &&
-      proposal.forall(_.matches(a.proposal))      &&
-      combinatorMatch(a)
+      proposal.forall(_.matches(a.proposal))
 
 }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/WhereProgram.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/WhereProgram.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import lucuma.core.model.Program
+import lucuma.odb.api.model.query.{WhereCombinator, WhereEq, WhereOptionString, WhereOrder}
+
+final case class WhereProgram(
+  id:        Option[WhereOrder[Program.Id]],
+  name:      Option[WhereOptionString],
+  existence: Option[WhereEq[Existence]],
+  proposal:  Option[WhereProposal],
+
+  and:       Option[List[WhereProgram]],
+  or:        Option[List[WhereProgram]],
+  not:       Option[WhereProgram]
+) extends WhereCombinator[ProgramModel] {
+
+  override def matches(a: ProgramModel): Boolean =
+    id.forall(_.matches(a.id))                    &&
+      name.forall(_.matches(a.name.map(_.value))) &&
+      existence.forall(_.matches(a.existence))    &&
+      proposal.forall(_.matches(a.proposal))      &&
+      combinatorMatch(a)
+
+}
+
+object WhereProgram {
+
+  implicit val DecoderProgramWhere: Decoder[WhereProgram] =
+    deriveDecoder[WhereProgram]
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/WhereProposal.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/WhereProposal.scala
@@ -11,15 +11,15 @@ import lucuma.odb.api.model.query.{WhereCombinator, WhereEq, WhereOptionEq, Wher
 
 
 final case class WhereProposal(
+  AND:           Option[List[WhereProposal]],
+  OR:            Option[List[WhereProposal]],
+  NOT:           Option[WhereProposal],
+  IS_NULL:       Option[Boolean],
+
   title:         Option[WhereOptionString],
   category:      Option[WhereOptionEq[TacCategory]],
   toOActivation: Option[WhereEq[ToOActivation]],
-  abstrakt:      Option[WhereOptionString],
-  isNull:        Option[Boolean],
-
-  and:           Option[List[WhereProposal]],
-  or:            Option[List[WhereProposal]],
-  not:           Option[WhereProposal]
+  abstrakt:      Option[WhereOptionString]
 ) extends WhereCombinator[Option[Proposal]] {
 
     override def matches(a: Option[Proposal]): Boolean = {
@@ -27,7 +27,7 @@ final case class WhereProposal(
       def whenEmpty: Boolean =
         title.isEmpty && category.isEmpty && toOActivation.isEmpty && abstrakt.isEmpty
 
-      isNull.forall(_ === a.isEmpty) &&
+      IS_NULL.forall(_ === a.isEmpty) &&
         a.fold(whenEmpty) { aʹ =>
           title.forall(_.matchesNonEmpty(aʹ.title))           &&
             category.forall(_.matches(aʹ.category))           &&

--- a/modules/core/src/main/scala/lucuma/odb/api/model/WhereProposal.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/WhereProposal.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import cats.syntax.eq._
+import io.circe.Decoder
+import lucuma.core.`enum`.{TacCategory, ToOActivation}
+import lucuma.core.model.Proposal
+import lucuma.odb.api.model.query.{WhereCombinator, WhereEq, WhereOptionEq, WhereOptionString}
+
+
+final case class WhereProposal(
+  title:         Option[WhereOptionString],
+  category:      Option[WhereOptionEq[TacCategory]],
+  toOActivation: Option[WhereEq[ToOActivation]],
+  abstrakt:      Option[WhereOptionString],
+  isNull:        Option[Boolean],
+
+  and:           Option[List[WhereProposal]],
+  or:            Option[List[WhereProposal]],
+  not:           Option[WhereProposal]
+) extends WhereCombinator[Option[Proposal]] {
+
+    override def matches(a: Option[Proposal]): Boolean = {
+
+      def whenEmpty: Boolean =
+        title.isEmpty && category.isEmpty && toOActivation.isEmpty && abstrakt.isEmpty
+
+      isNull.forall(_ === a.isEmpty) &&
+        a.fold(whenEmpty) { aʹ =>
+          title.forall(_.matchesNonEmpty(aʹ.title))           &&
+            category.forall(_.matches(aʹ.category))           &&
+            toOActivation.forall(_.matches(aʹ.toOActivation)) &&
+            abstrakt.forall(_.matchesNonEmpty(aʹ.abstrakt))
+        } && combinatorMatch(a)
+    }
+
+}
+
+object WhereProposal {
+
+  import io.circe.generic.extras.semiauto._
+  import io.circe.generic.extras.Configuration
+  implicit val customConfig: Configuration =
+    Configuration.default.withDefaults
+      .copy(transformMemberNames = {
+         case "abstrakt" => "abstract"
+          case other => other
+        })
+
+
+  implicit val DecoderProposalWhere: Decoder[WhereProposal] =
+    deriveConfiguredDecoder[WhereProposal]
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/SelectResult.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/SelectResult.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model.query
+
+import eu.timepit.refined.types.all.NonNegInt
+
+trait SelectResult[A] {
+  def matches:    List[A]
+  def totalCount: NonNegInt
+  def hasMore:    Boolean
+}
+
+object SelectResult {
+
+  final case class Standard[A](
+    matches:    List[A],
+    totalCount: NonNegInt
+  ) extends SelectResult[A] {
+
+    override def hasMore: Boolean =
+      matches.size < totalCount.value
+
+  }
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereCombinator.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereCombinator.scala
@@ -14,9 +14,10 @@ trait WhereCombinator[A] extends WherePredicate[A] {
 
   def NOT: Option[WhereCombinator[A]]
 
-  protected def combinatorMatch(a: A): Boolean =
-    AND.forall(_.forall(_.matches(a)))  &&
-      OR.forall(_.exists(_.matches(a))) &&
+  override def matches(a: A): Boolean =
+    super.matches(a)                      &&
+      AND.forall(_.forall(_.matches(a)))  &&
+      OR.forall(_.exists(_.matches(a)))   &&
       NOT.forall(!_.matches(a))
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereCombinator.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereCombinator.scala
@@ -8,15 +8,15 @@ package lucuma.odb.api.model.query
  */
 trait WhereCombinator[A] extends WherePredicate[A] {
 
-  def and: Option[List[WhereCombinator[A]]]
+  def AND: Option[List[WhereCombinator[A]]]
 
-  def or: Option[List[WhereCombinator[A]]]
+  def OR: Option[List[WhereCombinator[A]]]
 
-  def not: Option[WhereCombinator[A]]
+  def NOT: Option[WhereCombinator[A]]
 
   protected def combinatorMatch(a: A): Boolean =
-    and.forall(_.forall(_.matches(a)))  &&
-      or.forall(_.exists(_.matches(a))) &&
-      not.forall(!_.matches(a))
+    AND.forall(_.forall(_.matches(a)))  &&
+      OR.forall(_.exists(_.matches(a))) &&
+      NOT.forall(!_.matches(a))
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereCombinator.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereCombinator.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model.query
+
+/**
+ *
+ */
+trait WhereCombinator[A] extends WherePredicate[A] {
+
+  def and: Option[List[WhereCombinator[A]]]
+
+  def or: Option[List[WhereCombinator[A]]]
+
+  def not: Option[WhereCombinator[A]]
+
+  protected def combinatorMatch(a: A): Boolean =
+    and.forall(_.forall(_.matches(a)))  &&
+      or.forall(_.exists(_.matches(a))) &&
+      not.forall(!_.matches(a))
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereEq.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereEq.scala
@@ -9,17 +9,17 @@ import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 
 final case class WhereEq[A: Eq](
-  eq:  Option[A],
-  neq: Option[A],
-  in:  Option[List[A]],
-  nin: Option[List[A]]
+  EQ:  Option[A],
+  NEQ: Option[A],
+  IN:  Option[List[A]],
+  NIN: Option[List[A]]
 ) extends WherePredicate[A] {
 
   def matches(a: A): Boolean =
-    eq.forall(_ === a)           &&
-      neq.forall(_ =!= a)        &&
-      in.forall(_.contains(a))   &&
-      nin.forall(!_.contains(a))
+    EQ.forall(_ === a)           &&
+      NEQ.forall(_ =!= a)        &&
+      IN.forall(_.contains(a))   &&
+      NIN.forall(!_.contains(a))
 
 }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereEq.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereEq.scala
@@ -15,8 +15,9 @@ final case class WhereEq[A: Eq](
   NIN: Option[List[A]]
 ) extends WherePredicate[A] {
 
-  def matches(a: A): Boolean =
-    EQ.forall(_ === a)           &&
+  override def matches(a: A): Boolean =
+    super.matches(a)             &&
+      EQ.forall(_ === a)         &&
       NEQ.forall(_ =!= a)        &&
       IN.forall(_.contains(a))   &&
       NIN.forall(!_.contains(a))

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereEq.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereEq.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model.query
+
+import cats.Eq
+import cats.syntax.eq._
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+final case class WhereEq[A: Eq](
+  eq:  Option[A],
+  neq: Option[A],
+  in:  Option[List[A]],
+  nin: Option[List[A]]
+) extends WherePredicate[A] {
+
+  def matches(a: A): Boolean =
+    eq.forall(_ === a)           &&
+      neq.forall(_ =!= a)        &&
+      in.forall(_.contains(a))   &&
+      nin.forall(!_.contains(a))
+
+}
+
+object WhereEq {
+
+  implicit def DecoderWhereEq[A: Decoder: Eq]: Decoder[WhereEq[A]] =
+    deriveDecoder[WhereEq[A]]
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOption.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOption.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model.query
+
+import cats.syntax.eq._
+
+trait WhereOption[A] extends WherePredicate[Option[A]] {
+
+  def IS_NULL: Option[Boolean]
+
+  def whenEmpty: Boolean
+  def whenNonEmpty: WherePredicate[A]
+
+  override def matches(a: Option[A]): Boolean =
+    super.matches(a)                           &&
+      IS_NULL.forall(_ === a.isEmpty)          &&
+      a.fold(whenEmpty)(whenNonEmpty.matches)
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOptionEq.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOptionEq.scala
@@ -4,27 +4,23 @@
 package lucuma.odb.api.model.query
 
 import cats.Eq
-import cats.syntax.eq._
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 
 
 final case class WhereOptionEq[A: Eq](
+  IS_NULL: Option[Boolean],
   EQ:      Option[A],
   NEQ:     Option[A],
   IN:      Option[List[A]],
   NIN:     Option[List[A]],
-  IS_NULL: Option[Boolean]
-) extends WherePredicate[Option[A]] {
+) extends WhereOption[A] {
 
-  def matches(a: Option[A]): Boolean = {
+  def whenEmpty: Boolean =
+    EQ.isEmpty && IN.forall(_.isEmpty) && NIN.forall(_.nonEmpty)
 
-    def whenEmpty: Boolean =
-      EQ.isEmpty && IN.forall(_.isEmpty) && NIN.forall(_.nonEmpty)
-
-    IS_NULL.forall(_ === a.isEmpty)                 &&
-      a.fold(whenEmpty)(WhereEq(EQ, NEQ, IN, NIN).matches)
-  }
+  def whenNonEmpty: WherePredicate[A] =
+    WhereEq(EQ, NEQ, IN, NIN)
 
 }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOptionEq.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOptionEq.scala
@@ -10,20 +10,20 @@ import io.circe.generic.semiauto.deriveDecoder
 
 
 final case class WhereOptionEq[A: Eq](
-  eq:     Option[A],
-  neq:    Option[A],
-  in:     Option[List[A]],
-  nin:    Option[List[A]],
-  isNull: Option[Boolean]
+  EQ:      Option[A],
+  NEQ:     Option[A],
+  IN:      Option[List[A]],
+  NIN:     Option[List[A]],
+  IS_NULL: Option[Boolean]
 ) extends WherePredicate[Option[A]] {
 
   def matches(a: Option[A]): Boolean = {
 
     def whenEmpty: Boolean =
-      eq.isEmpty && in.forall(_.isEmpty) && nin.forall(_.nonEmpty)
+      EQ.isEmpty && IN.forall(_.isEmpty) && NIN.forall(_.nonEmpty)
 
-    isNull.forall(_ === a.isEmpty)                 &&
-      a.fold(whenEmpty)(WhereEq(eq, neq, in, nin).matches)
+    IS_NULL.forall(_ === a.isEmpty)                 &&
+      a.fold(whenEmpty)(WhereEq(EQ, NEQ, IN, NIN).matches)
   }
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOptionEq.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOptionEq.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model.query
+
+import cats.Eq
+import cats.syntax.eq._
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+
+final case class WhereOptionEq[A: Eq](
+  eq:     Option[A],
+  neq:    Option[A],
+  in:     Option[List[A]],
+  nin:    Option[List[A]],
+  isNull: Option[Boolean]
+) extends WherePredicate[Option[A]] {
+
+  def matches(a: Option[A]): Boolean = {
+
+    def whenEmpty: Boolean =
+      eq.isEmpty && in.forall(_.isEmpty) && nin.forall(_.nonEmpty)
+
+    isNull.forall(_ === a.isEmpty)                 &&
+      a.fold(whenEmpty)(WhereEq(eq, neq, in, nin).matches)
+  }
+
+}
+
+object WhereOptionEq {
+
+  implicit def DecoderWhereOptionEq[A: Decoder: Eq]: Decoder[WhereOptionEq[A]] =
+    deriveDecoder[WhereOptionEq[A]]
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOptionString.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOptionString.scala
@@ -3,7 +3,6 @@
 
 package lucuma.odb.api.model.query
 
-import cats.syntax.eq._
 import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Decoder
 import io.circe.refined._
@@ -18,19 +17,15 @@ final case class WhereOptionString(
   LIKE:       Option[NonEmptyString],
   NLIKE:      Option[NonEmptyString],
   MATCH_CASE: Boolean = true
-) extends WherePredicate[Option[String]] {
+) extends WhereOption[String] {
 
-  def matches(s: Option[String]): Boolean = {
+  def whenEmpty: Boolean =
+    EQ.isEmpty && IN.forall(_.isEmpty) && NIN.forall(_.nonEmpty) && LIKE.isEmpty
 
-    def whenEmpty: Boolean =
-      EQ.isEmpty && IN.forall(_.isEmpty) && NIN.forall(_.nonEmpty) && LIKE.isEmpty
+  def whenNonEmpty: WherePredicate[String] =
+    WhereString(EQ, NEQ, IN, NIN, LIKE, NLIKE, MATCH_CASE)
 
-    IS_NULL.forall(_ === s.isEmpty) &&
-      s.fold(whenEmpty)(WhereString(EQ, NEQ, IN, NIN, LIKE, NLIKE, MATCH_CASE).matches)
-
-  }
-
-  def matchesNonEmpty(s: Option[NonEmptyString]): Boolean =
+  def matchesNonEmptyString(s: Option[NonEmptyString]): Boolean =
     matches(s.map(_.value))
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOptionString.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOptionString.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model.query
+
+import cats.syntax.eq._
+import eu.timepit.refined.types.string.NonEmptyString
+import io.circe.Decoder
+import io.circe.refined._
+import io.circe.generic.semiauto.deriveDecoder
+
+final case class WhereOptionString(
+  eq:        Option[NonEmptyString],
+  neq:       Option[NonEmptyString],
+  in:        Option[List[NonEmptyString]],
+  nin:       Option[List[NonEmptyString]],
+  like:      Option[NonEmptyString],
+  nlike:     Option[NonEmptyString],
+  isNull:    Option[Boolean],
+  matchCase: Boolean = true
+) extends WherePredicate[Option[String]] {
+
+  def matches(s: Option[String]): Boolean = {
+
+    def whenEmpty: Boolean =
+      eq.isEmpty && in.forall(_.isEmpty) && nin.forall(_.nonEmpty) && like.isEmpty
+
+    isNull.forall(_ === s.isEmpty) &&
+      s.fold(whenEmpty)(WhereString(eq, neq, in, nin, like, nlike, matchCase).matches)
+
+  }
+
+  def matchesNonEmpty(s: Option[NonEmptyString]): Boolean =
+    matches(s.map(_.value))
+
+}
+
+object WhereOptionString {
+
+  implicit val DecoderWhereOptionString: Decoder[WhereOptionString] =
+    deriveDecoder[WhereOptionString]
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOptionString.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOptionString.scala
@@ -10,23 +10,23 @@ import io.circe.refined._
 import io.circe.generic.semiauto.deriveDecoder
 
 final case class WhereOptionString(
-  eq:        Option[NonEmptyString],
-  neq:       Option[NonEmptyString],
-  in:        Option[List[NonEmptyString]],
-  nin:       Option[List[NonEmptyString]],
-  like:      Option[NonEmptyString],
-  nlike:     Option[NonEmptyString],
-  isNull:    Option[Boolean],
-  matchCase: Boolean = true
+  IS_NULL:    Option[Boolean],
+  EQ:         Option[NonEmptyString],
+  NEQ:        Option[NonEmptyString],
+  IN:         Option[List[NonEmptyString]],
+  NIN:        Option[List[NonEmptyString]],
+  LIKE:       Option[NonEmptyString],
+  NLIKE:      Option[NonEmptyString],
+  MATCH_CASE: Boolean = true
 ) extends WherePredicate[Option[String]] {
 
   def matches(s: Option[String]): Boolean = {
 
     def whenEmpty: Boolean =
-      eq.isEmpty && in.forall(_.isEmpty) && nin.forall(_.nonEmpty) && like.isEmpty
+      EQ.isEmpty && IN.forall(_.isEmpty) && NIN.forall(_.nonEmpty) && LIKE.isEmpty
 
-    isNull.forall(_ === s.isEmpty) &&
-      s.fold(whenEmpty)(WhereString(eq, neq, in, nin, like, nlike, matchCase).matches)
+    IS_NULL.forall(_ === s.isEmpty) &&
+      s.fold(whenEmpty)(WhereString(EQ, NEQ, IN, NIN, LIKE, NLIKE, MATCH_CASE).matches)
 
   }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOrder.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOrder.scala
@@ -9,25 +9,25 @@ import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 
 final case class WhereOrder[A: Order](
-  eq:  Option[A],
-  neq: Option[A],
-  gt:  Option[A],
-  lt:  Option[A],
-  gte: Option[A],
-  lte: Option[A],
-  in:  Option[List[A]],
-  nin: Option[List[A]]
+  EQ:  Option[A],
+  NEQ: Option[A],
+  GT:  Option[A],
+  LT:  Option[A],
+  GTE: Option[A],
+  LTE: Option[A],
+  IN:  Option[List[A]],
+  NIN: Option[List[A]]
 ) extends WherePredicate[A] {
 
   def matches(a: A): Boolean =
-    eq.forall(a === _)         &&
-      neq.forall(a =!= _)      &&
-      gt.forall(a > _)         &&
-      lt.forall(a < _)         &&
-      gte.forall(a >= _)       &&
-      lte.forall(a <= _)       &&
-      in.forall(_.contains(a)) &&
-      nin.forall(!_.contains(a))
+    EQ.forall(a === _)         &&
+      NEQ.forall(a =!= _)      &&
+      GT.forall(a > _)         &&
+      LT.forall(a < _)         &&
+      GTE.forall(a >= _)       &&
+      LTE.forall(a <= _)       &&
+      IN.forall(_.contains(a)) &&
+      NIN.forall(!_.contains(a))
 
 }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOrder.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOrder.scala
@@ -19,8 +19,9 @@ final case class WhereOrder[A: Order](
   NIN: Option[List[A]]
 ) extends WherePredicate[A] {
 
-  def matches(a: A): Boolean =
-    EQ.forall(a === _)         &&
+  override def matches(a: A): Boolean =
+    super.matches(a)           &&
+      EQ.forall(a === _)       &&
       NEQ.forall(a =!= _)      &&
       GT.forall(a > _)         &&
       LT.forall(a < _)         &&

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOrder.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereOrder.scala
@@ -1,0 +1,39 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model.query
+
+import cats.Order
+import cats.syntax.order._
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+final case class WhereOrder[A: Order](
+  eq:  Option[A],
+  neq: Option[A],
+  gt:  Option[A],
+  lt:  Option[A],
+  gte: Option[A],
+  lte: Option[A],
+  in:  Option[List[A]],
+  nin: Option[List[A]]
+) extends WherePredicate[A] {
+
+  def matches(a: A): Boolean =
+    eq.forall(a === _)         &&
+      neq.forall(a =!= _)      &&
+      gt.forall(a > _)         &&
+      lt.forall(a < _)         &&
+      gte.forall(a >= _)       &&
+      lte.forall(a <= _)       &&
+      in.forall(_.contains(a)) &&
+      nin.forall(!_.contains(a))
+
+}
+
+object WhereOrder {
+
+  implicit def DecoderOrderFilter[A: Decoder: Order]: Decoder[WhereOrder[A]] =
+    deriveDecoder[WhereOrder[A]]
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WherePredicate.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WherePredicate.scala
@@ -3,8 +3,12 @@
 
 package lucuma.odb.api.model.query
 
+import scala.annotation.nowarn
+
 trait WherePredicate[A] {
 
-  def matches(a: A): Boolean
+  @nowarn
+  def matches(a: A): Boolean =
+    true
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WherePredicate.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WherePredicate.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model.query
+
+trait WherePredicate[A] {
+
+  def matches(a: A): Boolean
+
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereString.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereString.scala
@@ -9,29 +9,29 @@ import eu.timepit.refined.types.string.NonEmptyString
 import scala.util.matching.Regex
 
 final case class WhereString(
-  eq:        Option[NonEmptyString],
-  neq:       Option[NonEmptyString],
-  in:        Option[List[NonEmptyString]],
-  nin:       Option[List[NonEmptyString]],
-  like:      Option[NonEmptyString],
-  nlike:     Option[NonEmptyString],
-  matchCase: Boolean = true
+  EQ:         Option[NonEmptyString],
+  NEQ:        Option[NonEmptyString],
+  IN:         Option[List[NonEmptyString]],
+  NIN:        Option[List[NonEmptyString]],
+  LIKE:       Option[NonEmptyString],
+  NLIKE:      Option[NonEmptyString],
+  MATCH_CASE: Boolean = true
 ) extends WherePredicate[String] {
 
   private def forMatching(s: NonEmptyString): String =
-    if (matchCase) s.value else s.value.toLowerCase
+    if (MATCH_CASE) s.value else s.value.toLowerCase
 
   private val eqʹ: Option[String] =
-    eq.map(forMatching)
+    EQ.map(forMatching)
 
   private val neqʹ: Option[String] =
-    neq.map(forMatching)
+    NEQ.map(forMatching)
 
   private val inʹ: Option[List[String]] =
-    in.map(_.map(forMatching))
+    IN.map(_.map(forMatching))
 
   private val ninʹ: Option[List[String]] =
-    nin.map(_.map(forMatching))
+    NIN.map(_.map(forMatching))
 
   // Want to ignore Regex symbols in the input stream and only work on those
   // that we'll be adding.
@@ -67,14 +67,14 @@ final case class WhereString(
   }
 
   private val likeʹ: Option[Regex] =
-    like.map(wildcardToRegex)
+    LIKE.map(wildcardToRegex)
 
   private val nlikeʹ: Option[Regex] =
-    nlike.map(wildcardToRegex)
+    NLIKE.map(wildcardToRegex)
 
   def matches(s: String): Boolean = {
 
-    val sʹ = if (matchCase) s else s.toLowerCase
+    val sʹ = if (MATCH_CASE) s else s.toLowerCase
 
     eqʹ.forall(_ === sʹ)           &&
       neqʹ.forall(_ =!= sʹ)        &&

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereString.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereString.scala
@@ -72,11 +72,12 @@ final case class WhereString(
   private val nlikeʹ: Option[Regex] =
     NLIKE.map(wildcardToRegex)
 
-  def matches(s: String): Boolean = {
+  override def matches(s: String): Boolean = {
 
     val sʹ = if (MATCH_CASE) s else s.toLowerCase
 
-    eqʹ.forall(_ === sʹ)           &&
+    super.matches(s)               &&
+      eqʹ.forall(_ === sʹ)         &&
       neqʹ.forall(_ =!= sʹ)        &&
       inʹ.forall(_.contains(sʹ))   &&
       ninʹ.forall(!_.contains(sʹ)) &&
@@ -84,8 +85,9 @@ final case class WhereString(
       nlikeʹ.forall(!_.matches(sʹ))
   }
 
-  def matchesNonEmpty(s: NonEmptyString): Boolean =
+  def matchesNonEmptyString(s: NonEmptyString): Boolean =
     matches(s.value)
+
 }
 
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereString.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/query/WhereString.scala
@@ -1,0 +1,91 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model.query
+
+import cats.syntax.eq._
+import eu.timepit.refined.types.string.NonEmptyString
+
+import scala.util.matching.Regex
+
+final case class WhereString(
+  eq:        Option[NonEmptyString],
+  neq:       Option[NonEmptyString],
+  in:        Option[List[NonEmptyString]],
+  nin:       Option[List[NonEmptyString]],
+  like:      Option[NonEmptyString],
+  nlike:     Option[NonEmptyString],
+  matchCase: Boolean = true
+) extends WherePredicate[String] {
+
+  private def forMatching(s: NonEmptyString): String =
+    if (matchCase) s.value else s.value.toLowerCase
+
+  private val eqʹ: Option[String] =
+    eq.map(forMatching)
+
+  private val neqʹ: Option[String] =
+    neq.map(forMatching)
+
+  private val inʹ: Option[List[String]] =
+    in.map(_.map(forMatching))
+
+  private val ninʹ: Option[List[String]] =
+    nin.map(_.map(forMatching))
+
+  // Want to ignore Regex symbols in the input stream and only work on those
+  // that we'll be adding.
+  private val Symbols: Regex    = "[\\{\\}\\(\\)\\[\\]\\.\\+\\*\\?\\^\\$\\|]".r
+
+  // Match % if not preceded by \
+  private val MatchMany: Regex  = "(?<!\\\\)%".r
+
+  // Match _ if not preceded by \
+  private val MatchOne: Regex   = "(?<!\\\\)_".r
+
+  // Match \%
+  private val EscapeMany: Regex = raw"\\%".r
+
+  // Match \_
+  private val EscapeOne: Regex  = raw"\\_".r
+
+  def wildcardToRegex(wild: NonEmptyString): Regex = {
+    val wildʹ = forMatching(wild)
+    val regex =
+      EscapeOne.replaceAllIn(
+        MatchOne.replaceAllIn(
+          EscapeMany.replaceAllIn(
+            MatchMany.replaceAllIn(Symbols.replaceAllIn(wildʹ, "\\\\$0"), ".*"),
+            "%"
+          ),
+          "."
+        ),
+        "_"
+      )
+
+    (s"^$regex$$").r
+  }
+
+  private val likeʹ: Option[Regex] =
+    like.map(wildcardToRegex)
+
+  private val nlikeʹ: Option[Regex] =
+    nlike.map(wildcardToRegex)
+
+  def matches(s: String): Boolean = {
+
+    val sʹ = if (matchCase) s else s.toLowerCase
+
+    eqʹ.forall(_ === sʹ)           &&
+      neqʹ.forall(_ =!= sʹ)        &&
+      inʹ.forall(_.contains(sʹ))   &&
+      ninʹ.forall(!_.contains(sʹ)) &&
+      likeʹ.forall(_.matches(sʹ))  &&
+      nlikeʹ.forall(!_.matches(sʹ))
+  }
+
+  def matchesNonEmpty(s: NonEmptyString): Boolean =
+    matches(s.value)
+}
+
+

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/GeneralSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/GeneralSchema.scala
@@ -5,6 +5,8 @@ package lucuma.odb.api.schema
 
 import lucuma.odb.api.model.{Existence, PlannedTimeSummaryModel}
 import cats.syntax.all._
+import lucuma.odb.api.model.query.WhereEq
+import sangria.macros.derive.{InputObjectTypeName, deriveInputObjectType}
 import sangria.schema._
 import sangria.validation.ValueCoercionViolation
 
@@ -21,6 +23,11 @@ object GeneralSchema {
     EnumType.fromEnumerated(
       "Existence",
       "State of being: either Deleted or Present"
+    )
+
+  implicit val InputObjectTypeWhereEqExistence: InputObjectType[WhereEq[Existence]] =
+    deriveInputObjectType[WhereEq[Existence]](
+      InputObjectTypeName("WhereExistence")
     )
 
   val ArgumentIncludeDeleted: Argument[Boolean] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramQuery.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramQuery.scala
@@ -25,17 +25,17 @@ trait ProgramQuery {
     Argument(
       name         = "WHERE",
       argumentType = OptionInputType(InputObjectWhereProgram),
-      description  = "Filter the selection of programs using the where argument."
+      description  = "Filters the selection of programs."
     )
 
   implicit def ProgramSelectResult[F[_]: Dispatcher: Async: Logger]: ObjectType[Any, SelectResult[ProgramModel]] =
-    SelectResultType[ProgramModel]("ProgramSelectResult", ProgramType[F])
+    SelectResultType[ProgramModel]("program", ProgramType[F])
 
   def programs[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
     Field(
       name        = "programs",
       fieldType   = ProgramSelectResult[F],
-      description = Some("Pages through all requested programs (or all programs if no ids are given)."),
+      description = Some("Selects the first `LIMIT` matching programs based on the provided `WHERE` parameter, if any."),
       arguments   = List(ArgumentOptionWhereProgram, ArgumentLimit),
       resolve = c => c.program(_.selectWhere(c.arg(ArgumentOptionWhereProgram), c.arg(ArgumentLimit).getOrElse(DefaultLimit)))
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramQuery.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramQuery.scala
@@ -23,7 +23,7 @@ trait ProgramQuery {
 
   implicit val ArgumentOptionWhereProgram: Argument[Option[WhereProgram]] =
     Argument(
-      name         = "where",
+      name         = "WHERE",
       argumentType = OptionInputType(InputObjectWhereProgram),
       description  = "Filter the selection of programs using the where argument."
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
@@ -3,25 +3,28 @@
 
 package lucuma.odb.api.schema
 
-import lucuma.odb.api.model.{PlannedTimeSummaryModel, ProgramModel}
+import lucuma.odb.api.model.{PlannedTimeSummaryModel, ProgramModel, WhereProgram}
 import lucuma.core.model.Program
 import cats.effect.Async
 import cats.effect.std.Dispatcher
 import cats.syntax.foldable._
 import cats.syntax.functor._
+import lucuma.odb.api.model.query.WhereOrder
 import lucuma.odb.api.repo.OdbCtx
 import org.typelevel.log4cats.Logger
+import sangria.macros.derive.{InputObjectTypeName, deriveInputObjectType}
 import sangria.schema._
 
 import scala.collection.immutable.Seq
 
 object ProgramSchema {
 
-  import GeneralSchema.{ArgumentIncludeDeleted, EnumTypeExistence, PlannedTimeSummaryType}
+  import GeneralSchema.{ArgumentIncludeDeleted, EnumTypeExistence, InputObjectTypeWhereEqExistence, PlannedTimeSummaryType}
   import ObservationSchema.ObservationConnectionType
-  import ProposalSchema.ProposalType
+  import ProposalSchema.{ProposalType, InputObjectWhereProposal}
   import Paging._
   import RefinedSchema.NonEmptyStringType
+  import QuerySchema._
   import context._
 
   implicit val ProgramIdType: ScalarType[Program.Id] =
@@ -41,11 +44,21 @@ object ProgramSchema {
       description  = "Program ID"
     )
 
+  implicit val InputObjectWhereOrderProgramId: InputObjectType[WhereOrder[Program.Id]] =
+    deriveInputObjectType[WhereOrder[Program.Id]](
+      InputObjectTypeName("WhereProgramId")
+    )
+
   val OptionalListProgramIdArgument: Argument[Option[Seq[Program.Id]]] =
     Argument(
       name         = "programIds",
       argumentType = OptionInputType(ListInputType(ProgramIdType)),
       description  = "Program Ids"
+    )
+
+  implicit val InputObjectWhereProgram: InputObjectType[WhereProgram] =
+    deriveInputObjectType[WhereProgram](
+      InputObjectTypeName("WhereProgram")
     )
 
   def ProgramType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], ProgramModel] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
@@ -12,7 +12,7 @@ import cats.syntax.functor._
 import lucuma.odb.api.model.query.WhereOrder
 import lucuma.odb.api.repo.OdbCtx
 import org.typelevel.log4cats.Logger
-import sangria.macros.derive.{InputObjectTypeName, deriveInputObjectType}
+import sangria.macros.derive.{DocumentInputField, InputObjectTypeDescription, InputObjectTypeName, deriveInputObjectType}
 import sangria.schema._
 
 import scala.collection.immutable.Seq
@@ -58,7 +58,11 @@ object ProgramSchema {
 
   implicit val InputObjectWhereProgram: InputObjectType[WhereProgram] =
     deriveInputObjectType[WhereProgram](
-      InputObjectTypeName("WhereProgram")
+      InputObjectTypeName("WhereProgram"),
+      InputObjectTypeDescription("Program filter options.  All specified items must match."),
+      DocumentInputField("AND", document.andField("program")),
+      DocumentInputField("OR",  document.orField("program")),
+      DocumentInputField("NOT", document.notField("program"))
     )
 
   def ProgramType[F[_]: Dispatcher: Async: Logger]: ObjectType[OdbCtx[F], ProgramModel] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProposalSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProposalSchema.scala
@@ -5,29 +5,47 @@ package lucuma.odb.api.schema
 
 import lucuma.core.enum.{TacCategory, ToOActivation}
 import lucuma.core.model.{Partner, Proposal}
-import lucuma.odb.api.model.PartnerSplit
-
+import lucuma.odb.api.model.{PartnerSplit, WhereProposal}
+import lucuma.odb.api.model.query.{WhereEq, WhereOptionEq}
+import sangria.macros.derive.{InputObjectTypeName, ReplaceInputField, deriveInputObjectType}
 import sangria.schema._
 
 object ProposalSchema {
 
   import ProposalClassSchema.ProposalClassType
   import RefinedSchema.{IntPercentType, NonEmptyStringType}
+  import QuerySchema._
   import syntax.all._
 
   implicit val EnumTypePartner: EnumType[Partner] =
     EnumType.fromEnumerated("Partner", "Partner")
 
-  implicit val EnumTypeTacCategory: EnumType[TacCategory] = 
+  implicit val EnumTypeTacCategory: EnumType[TacCategory] =
     EnumType.fromEnumerated("TacCategory", "TAC Category")
 
   implicit val EnumTypeToOActivation: EnumType[ToOActivation] =
     EnumType.fromEnumerated("ToOActivation", "ToO Activation")
 
+  implicit val InputObjectWhereEqTacCategory: InputObjectType[WhereOptionEq[TacCategory]] =
+    deriveInputObjectType(
+      InputObjectTypeName("WhereTacCategory")
+    )
+
+  implicit val InputObjectWhereEqToOActivation: InputObjectType[WhereEq[ToOActivation]] =
+    deriveInputObjectType(
+      InputObjectTypeName("WhereToOActivation")
+    )
+
+  implicit val InputObjectWhereProposal: InputObjectType[WhereProposal] =
+    deriveInputObjectType[WhereProposal](
+      InputObjectTypeName("WhereProposal"),
+      ReplaceInputField("abstrakt", InputObjectWhereOptionString.optionField("abstract"))
+    )
+
   implicit val PartnerSplitType: ObjectType[Any, PartnerSplit] =
     ObjectType(
       name   = "PartnerSplit",
-      fieldsFn = () => 
+      fieldsFn = () =>
         fields(
           Field(
             name        = "partner",

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProposalSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProposalSchema.scala
@@ -7,7 +7,7 @@ import lucuma.core.enum.{TacCategory, ToOActivation}
 import lucuma.core.model.{Partner, Proposal}
 import lucuma.odb.api.model.{PartnerSplit, WhereProposal}
 import lucuma.odb.api.model.query.{WhereEq, WhereOptionEq}
-import sangria.macros.derive.{InputObjectTypeName, ReplaceInputField, deriveInputObjectType}
+import sangria.macros.derive.{DocumentInputField, InputObjectTypeDescription, InputObjectTypeName, ReplaceInputField, deriveInputObjectType}
 import sangria.schema._
 
 object ProposalSchema {
@@ -39,7 +39,12 @@ object ProposalSchema {
   implicit val InputObjectWhereProposal: InputObjectType[WhereProposal] =
     deriveInputObjectType[WhereProposal](
       InputObjectTypeName("WhereProposal"),
-      ReplaceInputField("abstrakt", InputObjectWhereOptionString.optionField("abstract"))
+      InputObjectTypeDescription("Proposal filter options.  All specified items must match."),
+      ReplaceInputField("abstrakt", InputObjectWhereOptionString.optionField("abstract")),
+      DocumentInputField("AND",     document.andField("proposal")),
+      DocumentInputField("OR",      document.orField("proposal")),
+      DocumentInputField("NOT",     document.notField("proposal")),
+      DocumentInputField("IS_NULL", document.isNullField("proposal"))
     )
 
   implicit val PartnerSplitType: ObjectType[Any, PartnerSplit] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/QuerySchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/QuerySchema.scala
@@ -1,0 +1,71 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.schema
+
+import cats.syntax.option._
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.all.NonNegInt
+import io.circe.refined._
+import lucuma.odb.api.model.query.{SelectResult, WhereOptionString, WhereString}
+import sangria.marshalling.circe._
+import sangria.macros.derive.{InputObjectTypeName, deriveInputObjectType}
+import sangria.schema._
+
+object QuerySchema {
+
+  import RefinedSchema._
+
+  val DefaultLimit: NonNegInt =
+    1000
+
+  val ArgumentLimit: Argument[Option[NonNegInt]] =
+    Argument(
+      name         = "limit",
+      argumentType =  OptionInputType(NonNegIntType.copy(description = "foo".some)),
+      description  = s"Limits the result to at most this number of matches (but never more than $DefaultLimit)."
+    )
+
+  implicit val InputObjectWhereString: InputObjectType[WhereString] =
+    deriveInputObjectType[WhereString](
+      InputObjectTypeName("WhereString")
+    )
+
+  implicit val InputObjectWhereOptionString: InputObjectType[WhereOptionString] =
+    deriveInputObjectType[WhereOptionString](
+      InputObjectTypeName("WhereOptionString")
+    )
+
+  def SelectResultType[A](
+    name:  String,
+    aType: OutputType[A]
+  ): ObjectType[Any, SelectResult[A]] =
+    ObjectType(
+      name        = name,
+      description = "Selection results",
+
+      fieldsFn    = () => List(
+
+        Field(
+          name        = "matches",
+          description = s"Matching objects up to the return size limit of $DefaultLimit".some,
+          fieldType   = ListType(aType),
+          resolve     = _.value.matches
+        ),
+
+        Field(
+          name        = "totalCount",
+          description = "Total match count, including any those that are past the return size cutoff limit.".some,
+          fieldType   = ListType(aType),
+          resolve     = _.value.matches
+        ),
+
+        Field(
+          name        = "hasMore",
+          description = "`true` when there were additional matches that were not returned.".some,
+          fieldType   = BooleanType,
+          resolve     = _.value.hasMore
+        )
+      )
+    )
+}

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/QuerySchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/QuerySchema.scala
@@ -88,8 +88,8 @@ object QuerySchema {
         Field(
           name        = "totalCount",
           description = "Total match count, including any those that are past the return size cutoff limit.".some,
-          fieldType   = ListType(aType),
-          resolve     = _.value.matches
+          fieldType   = NonNegIntType,
+          resolve     = _.value.totalCount
         ),
 
         Field(

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/QuerySchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/QuerySchema.scala
@@ -21,7 +21,7 @@ object QuerySchema {
 
   val ArgumentLimit: Argument[Option[NonNegInt]] =
     Argument(
-      name         = "limit",
+      name         = "LIMIT",
       argumentType =  OptionInputType(NonNegIntType.copy(description = "foo".some)),
       description  = s"Limits the result to at most this number of matches (but never more than $DefaultLimit)."
     )

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/QuerySchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/QuerySchema.scala
@@ -9,7 +9,7 @@ import eu.timepit.refined.types.all.NonNegInt
 import io.circe.refined._
 import lucuma.odb.api.model.query.{SelectResult, WhereOptionString, WhereString}
 import sangria.marshalling.circe._
-import sangria.macros.derive.{InputObjectTypeName, deriveInputObjectType}
+import sangria.macros.derive.{DocumentInputField, InputObjectTypeDescription, InputObjectTypeName, deriveInputObjectType}
 import sangria.schema._
 
 object QuerySchema {
@@ -28,27 +28,59 @@ object QuerySchema {
 
   implicit val InputObjectWhereString: InputObjectType[WhereString] =
     deriveInputObjectType[WhereString](
-      InputObjectTypeName("WhereString")
+      InputObjectTypeName("WhereString"),
+      InputObjectTypeDescription("String matching options."),
+      DocumentInputField("LIKE",       document.like),
+      DocumentInputField("NLIKE",      document.nlike),
+      DocumentInputField("MATCH_CASE", document.matchCase)
     )
 
   implicit val InputObjectWhereOptionString: InputObjectType[WhereOptionString] =
     deriveInputObjectType[WhereOptionString](
-      InputObjectTypeName("WhereOptionString")
+      InputObjectTypeName("WhereOptionString"),
+      InputObjectTypeDescription("String matching options."),
+      DocumentInputField("IS_NULL",    document.isNullField("string")),
+      DocumentInputField("LIKE",       document.like),
+      DocumentInputField("NLIKE",      document.nlike),
+      DocumentInputField("MATCH_CASE", document.matchCase)
     )
 
+  object document {
+    def andField(n: String): String =
+      s"A list of nested $n filters that all must match in order for the AND group as a whole to match."
+
+    def orField(n: String): String =
+      s"A list of nested $n filters where any one match causes the entire OR group as a whole to match."
+
+    def notField(n: String): String =
+      s"A nested $n filter that must not match in order for the NOT itself to match."
+
+    def isNullField(n: String): String =
+      s"When `true` the $n must not be defined.  When `false` the $n must be defined."
+
+    val like: String =
+      "Performs string matching with wildcard patterns.  The entire string must be matched.  Use % to match a sequence of any characters and _ to match any single character."
+
+    val nlike: String =
+      "Performs string matching with wildcard patterns.  The entire string must not match.  Use % to match a sequence of any characters and _ to match any single character."
+
+    val matchCase: String =
+      "Set to `true` (the default) for case sensitive matches, `false` to ignore case."
+  }
+
   def SelectResultType[A](
-    name:  String,
-    aType: OutputType[A]
+    prefix: String,
+    aType:  OutputType[A]
   ): ObjectType[Any, SelectResult[A]] =
     ObjectType(
-      name        = name,
-      description = "Selection results",
+      name        = s"${prefix.capitalize}SelectResult",
+      description = s"The matching $prefix results, limited to a maximum of $DefaultLimit entries.",
 
       fieldsFn    = () => List(
 
         Field(
           name        = "matches",
-          description = s"Matching objects up to the return size limit of $DefaultLimit".some,
+          description = s"Matching ${prefix}s up to the return size limit of $DefaultLimit".some,
           fieldType   = ListType(aType),
           resolve     = _.value.matches
         ),

--- a/modules/service/src/test/scala/QuerySuite.scala
+++ b/modules/service/src/test/scala/QuerySuite.scala
@@ -10,7 +10,7 @@ class QuerySuite extends OdbSuite {
   queryTest(
     query = """
       query Programs {
-        programs(where: { id: { in: ["p-2", "p-3", "p-4"] } } ) {
+        programs(WHERE: { id: { IN: ["p-2", "p-3", "p-4"] } } ) {
           matches {
             id
             name

--- a/modules/service/src/test/scala/QuerySuite.scala
+++ b/modules/service/src/test/scala/QuerySuite.scala
@@ -10,8 +10,8 @@ class QuerySuite extends OdbSuite {
   queryTest(
     query = """
       query Programs {
-        programs(programIds: ["p-2", "p-3", "p-4"]) {
-          nodes {
+        programs(where: { id: { in: ["p-2", "p-3", "p-4"] } } ) {
+          matches {
             id
             name
             proposal {
@@ -24,7 +24,7 @@ class QuerySuite extends OdbSuite {
                   totalTime {
                     seconds
                   }
-                } 
+                }
                 ... on Intensive {
                   minPercentTotalTime
                   totalTime {
@@ -43,11 +43,12 @@ class QuerySuite extends OdbSuite {
           }
         }
       }
+
     """,
     expected = json"""
       {
         "programs" : {
-          "nodes" : [
+          "matches": [
             {
               "id" : "p-2",
               "name" : "The real dark matter was the friends we made along the way",


### PR DESCRIPTION
This is a work-in-progress on transforming to a paging-free API.  It's easy to remove paging and instead return a list of results, but I wanted to offer at least a hint at ways that we might filter those results.  Looking at other APIs there are a couple of approaches.  One is to write a DSL query string, [like Shopify does](https://shopify.dev/api/usage/search-syntax).  For example

```graphql
{
  products(first: 5, query: "(title:Caramel Apple) OR (inventory_total:>500 inventory_total:<=1000)" ) {
    ...
  }
}
```

A drawback would be that there's nothing to guide a user in writing these search strings, though perhaps they are easy enough to figure out?  I'm skeptical of introducing a DSL, but would listen to anybody who thinks this is a good approach.

Another approach is [adding custom directives](https://dgraph.io/docs/graphql/queries/search-filtering/), but that seems complicated and I didn't seriously consider it.

[Hasura](https://hasura.io/docs/latest/graphql/core/databases/postgres/queries/query-filters/), generates an API that closely follows SQL.  I'm not sure how intuitive this is for non-programmers but it seemed straightforward enough to me so I adopted a poor-man's query filtering based on it.

This draft PR partially transforms a single query, `programs`.  If we were to adopt this then I think all the mutation `select` objects should probably accept the same `WHERE` filters.

![Screen Shot 2022-06-10 at 15 55 27](https://user-images.githubusercontent.com/4906023/173141305-c5502df3-bff9-42d9-a0aa-cf98308bdaf9.png)

`WHERE` and `LIMIT` are capitalized, along with everything else SQL-ish to make it stand apart from the fields in the actual objects like `title` or TAC `category`.  There's a query results wrapper, `ProgramSelectResult`, that holds the actual matching programs, a count of all the matches even beyond those in the capped `matches` list and a `hasMore` boolean that lets you know whether there are additional items you're not getting.

![Screen Shot 2022-06-10 at 13 08 40](https://user-images.githubusercontent.com/4906023/173117097-77f0383f-30ba-4dda-95b1-a7b5549a62c9.png)

`WhereProgram` can have nested `AND`, `OR` or `NOT` filters and the nesting is unlimited.  I think we can cap the depth of queries though and we should probably do that to protect ourselves.   By default if you specify multiple items then they must all match.  For example,

```json
{
  "whereProgram": {
    "name": {
      "LIKE": "%dark%friends%"
    },
    "id": {
      "IN": [ "p-2", "p-3", "p-4" ]
    }
  }
}
```

requires the name to match the pattern _and_ for the ID to be one of those provided.

To do this in a type-safe way requires creating a lot of type-specific input objects.  For example, the TAC category matcher shouldn't match on just any string but on real TAC categories.

<img width="581" alt="Screen Shot 2022-06-10 at 13 17 33" src="https://user-images.githubusercontent.com/4906023/173118487-05a13970-b831-4547-81bc-1cab715191e9.png">

Here is a silly `WHERE` that puts some of these things together

```json
{
  "whereProgram": {
    "name": { "LIKE": "%dark%friends%" },
    "proposal": { 
      "OR": [
        { "IS_NULL": true },
        {
          "category": {
            "EQ": "SMALL_BODIES"
          }
        }
      ]
    }
  }
```

This will match programs whose name is defined and matching the given `LIKE` pattern while also either having no proposal or a proposal with TAC category `SMALL_BODIES`.

Does anybody have better ideas?  Is this too dumb?  The query fields and definitions are wide open in Sangria at least. For example, I could add a `text` field that doesn't exist anywhere in the model and instead matches on the program name, proposal title and abstract. Would this be hard to implement with Grackle? 