### PR TITLE
Wavelength dithers decimal nm

### DIFF
--- a/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosLongSlit.scala
+++ b/modules/core/src/main/scala/lucuma/gen/gmos/longslit/GmosLongSlit.scala
@@ -87,10 +87,10 @@ object GmosLongSlit {
   val DefaultSampling: PosDouble =
     2.5
 
-  def wavelengthDither(λ: Wavelength, Δ: Quantity[Int, Nanometer]): Wavelength =
+  def wavelengthDither(λ: Wavelength, Δ: Quantity[BigDecimal, Nanometer]): Wavelength =
     Wavelength
       .fromPicometers
-      .getOption(λ.toPicometers.value + Δ.value * 1000)
+      .getOption(λ.toPicometers.value + Δ.value.underlying.movePointRight(3).intValue)
       .getOrElse(Wavelength.Min)
 
   final case class Input[M](

--- a/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/AdvancedConfig.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/AdvancedConfig.scala
@@ -21,18 +21,18 @@ import monocle.{Focus, Lens}
  */
 final case class AdvancedConfig[G, F, U](
   name:                     Option[NonEmptyString],
-  overrideWavelength:       Option[Wavelength]                             = None,
-  overrideGrating:          Option[G]                                      = None,
-  overrideFilter:           Option[Option[F]]                              = None,
-  overrideFpu:              Option[U]                                      = None,
-  overrideExposureTimeMode: Option[ExposureTimeMode]                       = None,
-  explicitXBin:             Option[GmosXBinning]                           = None,  // calculated from effective slit and sampling by default
-  explicitYBin:             Option[GmosYBinning]                           = None,
-  explicitAmpReadMode:      Option[GmosAmpReadMode]                        = None,
-  explicitAmpGain:          Option[GmosAmpGain]                            = None,
-  explicitRoi:              Option[GmosRoi]                                = None,
-  explicitλDithers:         Option[NonEmptyList[Quantity[Int, Nanometer]]] = None,
-  explicitSpatialOffsets:   Option[NonEmptyList[Offset.Q]]                 = None
+  overrideWavelength:       Option[Wavelength]                                    = None,
+  overrideGrating:          Option[G]                                             = None,
+  overrideFilter:           Option[Option[F]]                                     = None,
+  overrideFpu:              Option[U]                                             = None,
+  overrideExposureTimeMode: Option[ExposureTimeMode]                              = None,
+  explicitXBin:             Option[GmosXBinning]                                  = None,  // calculated from effective slit and sampling by default
+  explicitYBin:             Option[GmosYBinning]                                  = None,
+  explicitAmpReadMode:      Option[GmosAmpReadMode]                               = None,
+  explicitAmpGain:          Option[GmosAmpGain]                                   = None,
+  explicitRoi:              Option[GmosRoi]                                       = None,
+  explicitλDithers:         Option[NonEmptyList[Quantity[BigDecimal, Nanometer]]] = None,
+  explicitSpatialOffsets:   Option[NonEmptyList[Offset.Q]]                        = None
 )
 
 object AdvancedConfig extends AdvancedConfigOptics {
@@ -40,8 +40,8 @@ object AdvancedConfig extends AdvancedConfigOptics {
   val Q15: Offset.Q =
     Offset.Q(Angle.arcseconds.reverseGet(15))
 
-  val zeroNm: Quantity[Int, Nanometer] =
-    Quantity[Int, Nanometer](0)
+  val zeroNm: Quantity[BigDecimal, Nanometer] =
+    Quantity[BigDecimal, Nanometer](BigDecimal(0))
 
   val DefaultYBinning: GmosYBinning =
     GmosYBinning.Two
@@ -59,7 +59,7 @@ object AdvancedConfig extends AdvancedConfigOptics {
     grating: G
   )(
     implicit calc: DeltaWavelengthCalculator[G]
-  ): NonEmptyList[Quantity[Int, Nanometer]] = {
+  ): NonEmptyList[Quantity[BigDecimal, Nanometer]] = {
     val deltaNm = calc.Δλ(grating)
     NonEmptyList.of(zeroNm, deltaNm, deltaNm, zeroNm)
   }
@@ -121,7 +121,7 @@ sealed trait AdvancedConfigOptics { self: AdvancedConfig.type =>
   def explicitRoi[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[GmosRoi]] =
     Focus[AdvancedConfig[G, F, U]](_.explicitRoi)
 
-  def explicitλDithers[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[NonEmptyList[Quantity[Int, Nanometer]]]] =
+  def explicitλDithers[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[NonEmptyList[Quantity[BigDecimal, Nanometer]]]] =
     Focus[AdvancedConfig[G, F, U]](_.explicitλDithers)
 
   def explicitSpatialOffsets[G, F, U]: Lens[AdvancedConfig[G, F, U], Option[NonEmptyList[Offset.Q]]] =

--- a/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/AdvancedConfigInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/AdvancedConfigInput.scala
@@ -27,19 +27,19 @@ import lucuma.odb.api.model.syntax.lens._
 
 
 final case class AdvancedConfigInput[G, F, U](
-  name:                      Input[NonEmptyString]                   = Input.ignore,
-  overrideWavelength:        Input[WavelengthInput]                  = Input.ignore,
-  overrideGrating:           Input[G]                                = Input.ignore,
-  overrideFilter:            Input[Option[F]]                        = Input.ignore,
-  overrideFpu:               Input[U]                                = Input.ignore,
-  overrideExposureTimeMode:  Input[ExposureModeInput]                = Input.ignore,
-  explicitXBin:              Input[GmosXBinning]                     = Input.ignore,
-  explicitYBin:              Input[GmosYBinning]                     = Input.ignore,
-  explicitAmpReadMode:       Input[GmosAmpReadMode]                  = Input.ignore,
-  explicitAmpGain:           Input[GmosAmpGain]                      = Input.ignore,
-  explicitRoi:               Input[GmosRoi]                          = Input.ignore,
-  explicitWavelengthDithers: Input[List[Int]]                        = Input.ignore,
-  explicitSpatialOffsets:    Input[List[OffsetModel.ComponentInput]] = Input.ignore
+  name:                        Input[NonEmptyString]                   = Input.ignore,
+  overrideWavelength:          Input[WavelengthInput]                  = Input.ignore,
+  overrideGrating:             Input[G]                                = Input.ignore,
+  overrideFilter:              Input[Option[F]]                        = Input.ignore,
+  overrideFpu:                 Input[U]                                = Input.ignore,
+  overrideExposureTimeMode:    Input[ExposureModeInput]                = Input.ignore,
+  explicitXBin:                Input[GmosXBinning]                     = Input.ignore,
+  explicitYBin:                Input[GmosYBinning]                     = Input.ignore,
+  explicitAmpReadMode:         Input[GmosAmpReadMode]                  = Input.ignore,
+  explicitAmpGain:             Input[GmosAmpGain]                      = Input.ignore,
+  explicitRoi:                 Input[GmosRoi]                          = Input.ignore,
+  explicitWavelengthDithersNm: Input[List[BigDecimal]]                 = Input.ignore,
+  explicitSpatialOffsets:      Input[List[OffsetModel.ComponentInput]] = Input.ignore
 ) extends EditorInput[AdvancedConfig[G, F, U]] {
 
   override val create: ValidatedInput[AdvancedConfig[G, F, U]] =
@@ -59,7 +59,7 @@ final case class AdvancedConfigInput[G, F, U](
         explicitAmpReadMode      = explicitAmpReadMode.toOption,
         explicitAmpGain          = explicitAmpGain.toOption,
         explicitRoi              = explicitRoi.toOption,
-        explicitλDithers         = NonEmptyList.fromList(explicitWavelengthDithers.toOption.toList.flatten.map(i => Quantity[Int, Nanometer](i))),
+        explicitλDithers         = NonEmptyList.fromList(explicitWavelengthDithersNm.toOption.toList.flatten.map(d => Quantity[BigDecimal, Nanometer](d))),
         explicitSpatialOffsets   = NonEmptyList.fromList(os)
       )
     }
@@ -83,11 +83,11 @@ final case class AdvancedConfigInput[G, F, U](
       _ <- AdvancedConfig.explicitAmpGain               := explicitAmpGain.toOptionOption
       _ <- AdvancedConfig.explicitRoi                   := explicitRoi.toOptionOption
       _ <- AdvancedConfig.explicitλDithers              :<
-        explicitWavelengthDithers.fold(
-          StateT.empty[EitherInput, Option[NonEmptyList[Quantity[Int, Nanometer]]], Unit],
-          StateT.setF(Option.empty[NonEmptyList[Quantity[Int, Nanometer]]].rightNec[InputError]),
+        explicitWavelengthDithersNm.fold(
+          StateT.empty[EitherInput, Option[NonEmptyList[Quantity[BigDecimal, Nanometer]]], Unit],
+          StateT.setF(Option.empty[NonEmptyList[Quantity[BigDecimal, Nanometer]]].rightNec[InputError]),
           deltas => StateT.setF(
-            NonEmptyList.fromList(deltas.map(i => Quantity[Int, Nanometer](i))).rightNec[InputError]
+            NonEmptyList.fromList(deltas.map(d => Quantity[BigDecimal, Nanometer](d))).rightNec[InputError]
           )
         ).some
       _ <- AdvancedConfig.explicitSpatialOffsets       :<
@@ -126,7 +126,7 @@ object AdvancedConfigInput {
       a.explicitAmpReadMode,
       a.explicitAmpGain,
       a.explicitRoi,
-      a.explicitWavelengthDithers,
+      a.explicitWavelengthDithersNm,
       a.explicitSpatialOffsets
     )}
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/DeltaWavelengthCalculator.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/DeltaWavelengthCalculator.scala
@@ -9,7 +9,7 @@ import lucuma.core.math.units.Nanometer
 
 trait DeltaWavelengthCalculator[G] {
 
-  def Δλ(g: G): Quantity[Int, Nanometer]
+  def Δλ(g: G): Quantity[BigDecimal, Nanometer]
 
 }
 

--- a/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/GmosLongslitMath.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/GmosLongslitMath.scala
@@ -82,11 +82,11 @@ trait GmosSiteSpecificLongslitMath extends GmosLongslitMath {
    *
    * @param dispersion - dispersion in nm/pix (see https://www.gemini.edu/sciops/instruments/gmos/spectroscopy-overview/gratings)
    */
-  def Δλ(dispersion: Quantity[Rational, NanometersPerPixel]): Quantity[Int, Nanometer] = {
+  def Δλ(dispersion: Quantity[Rational, NanometersPerPixel]): Quantity[BigDecimal, Nanometer] = {
     val d = dispersion.value.toDouble
     val g = gapSize.value.value
     val v = d * g * 2.0             // raw value, which we round to nearest 5 nm
-    ((v/5.0).round * 5.0).toInt.withUnit[Nanometer]
+    BigDecimal(((v/5.0).round * 5.0).toInt).withUnit[Nanometer]
   }
 
 }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/LongSlit.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/gmos/longslit/LongSlit.scala
@@ -50,7 +50,7 @@ trait LongSlit[G, F, U] {
   def roi: GmosRoi =
     explicitOr(_.explicitRoi, AdvancedConfig.DefaultRoi)
 
-  def λDithers(implicit calc: DeltaWavelengthCalculator[G]): NonEmptyList[Quantity[Int, Nanometer]] =
+  def λDithers(implicit calc: DeltaWavelengthCalculator[G]): NonEmptyList[Quantity[BigDecimal, Nanometer]] =
     explicitOr(_.explicitλDithers, AdvancedConfig.defaultλDithers(grating))
 
   def spatialOffsets: NonEmptyList[Offset.Q] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceModeMutation.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceModeMutation.scala
@@ -4,7 +4,7 @@
 package lucuma.odb.api.schema
 
 import lucuma.core.`enum`.{GmosNorthFilter, GmosNorthFpu, GmosNorthGrating, GmosSouthFilter, GmosSouthFpu, GmosSouthGrating}
-import lucuma.odb.api.model.gmos.longslit.{AdvancedConfig, BasicConfigInput}
+import lucuma.odb.api.model.gmos.longslit.{AdvancedConfigInput, BasicConfigInput}
 import lucuma.odb.api.model.{ExposureTimeMode, ScienceMode, ScienceModeInput}
 import lucuma.odb.api.model.ExposureTimeMode.{FixedExposureInput, SignalToNoiseInput}
 import sangria.schema._
@@ -83,8 +83,8 @@ trait ScienceModeMutation {
     gratingEnum: EnumType[G],
     filterEnum:  EnumType[F],
     fpuEnum:     EnumType[U]
-  ): InputObjectType[AdvancedConfig[G, F, U]] =
-    InputObjectType[AdvancedConfig[G, F, U]](
+  ): InputObjectType[AdvancedConfigInput[G, F, U]] =
+    InputObjectType[AdvancedConfigInput[G, F, U]](
       s"Gmos${siteName.capitalize}LongSlitAdvancedConfigInput",
       s"Edit or create GMOS ${siteName.capitalize} Long Slit advanced configuration",
       List(
@@ -98,12 +98,12 @@ trait ScienceModeMutation {
         EnumTypeGmosAmpReadMode.nullableField("explicitAmpReadMode"),
         EnumTypeGmosAmpGain.nullableField("explicitAmpGain"),
         EnumTypeGmosRoi.nullableField("explicitRoi"),
-        ListInputType(IntType).nullableField("explicitWavelengthDithers"),
+        ListInputType(BigDecimalType).nullableField("explicitWavelengthDithersNm"),
         ListInputType(OffsetSchema.InputObjectTypeOffsetComponentInput).nullableField("explicitSpatialOffsets")
       )
     )
 
-  implicit val InputObjectTypeGmosNorthLongSlitAdvancedConfig: InputObjectType[AdvancedConfig[GmosNorthGrating, GmosNorthFilter, GmosNorthFpu]] =
+  implicit val InputObjectTypeGmosNorthLongSlitAdvancedConfig: InputObjectType[AdvancedConfigInput[GmosNorthGrating, GmosNorthFilter, GmosNorthFpu]] =
     inputObjectTypeGmosLongSlitAdvancedConfig(
       "north",
       EnumTypeGmosNorthGrating,
@@ -111,7 +111,7 @@ trait ScienceModeMutation {
       EnumTypeGmosNorthFpu
     )
 
-  implicit val InputObjectTypeGmosSouthLongSlitAdvancedConfig: InputObjectType[AdvancedConfig[GmosSouthGrating, GmosSouthFilter, GmosSouthFpu]] =
+  implicit val InputObjectTypeGmosSouthLongSlitAdvancedConfig: InputObjectType[AdvancedConfigInput[GmosSouthGrating, GmosSouthFilter, GmosSouthFpu]] =
     inputObjectTypeGmosLongSlitAdvancedConfig(
       "south",
       EnumTypeGmosSouthGrating,

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceModeSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ScienceModeSchema.scala
@@ -234,8 +234,8 @@ object ScienceModeSchema {
         ),
 
         Field(
-          name        = "explicitWavelengthDithers",
-          fieldType   = OptionType(ListType(IntType)),
+          name        = "explicitWavelengthDithersNm",
+          fieldType   = OptionType(ListType(BigDecimalType)),
           description = s"Explicitly specified wavelength dithers required to fill in the chip gaps (in nm), taking the place of the calculated value based on the grating dispersion".some,
           resolve     = _.value.explicitλDithers.map(_.toList.map(_.value))
         ),


### PR DESCRIPTION
Switches to decimal wavelength dithers in advanced config, adds `Nm` to the name to clarify the units, and fixes a bug in creating the advanced config input type.