### PR TITLE
Fix targets query result type bug

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationGroupSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationGroupSchema.scala
@@ -81,7 +81,7 @@ object ObservationGroupSchema {
       )
 
     val selectResultType =
-      SelectResultType[ObservationModel.Group[A]](name, groupType)
+      SelectResultType[ObservationModel.Group[A]](s"${name}Group", groupType)
 
     Field(
       name        = s"${name}Group",

--- a/modules/service/src/test/scala/test/targets/TargetQuerySuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetQuerySuite.scala
@@ -19,6 +19,44 @@ class TargetQuerySuite extends OdbSuite {
   // o-7: <none>
   //
 
+  // Fetch all science targets.  There is a t-6 but for p-3 so we skip it.
+  queryTest(
+    query ="""
+      query AllTargets {
+        targets(WHERE: { programId: { EQ: "p-2" } }) {
+          matches {
+            id
+            name
+          }
+        }
+      }
+    """,
+    expected = json"""
+      {
+        "targets": {
+          "matches": [
+            {
+              "id": "t-2",
+              "name": "NGC 5949"
+            },
+            {
+              "id": "t-3",
+              "name": "NGC 3269"
+            },
+            {
+              "id": "t-4",
+              "name": "NGC 3312"
+            },
+            {
+              "id": "t-5",
+              "name": "NGC 4749"
+            }
+          ]
+        }
+      }
+    """
+  )
+
   // Fetch all science targets for o-6.
   queryTest(
     query ="""


### PR DESCRIPTION
I made a mistake in naming the return type of the `targets` query and the `targetGroup` query.  They were both `TargetSelectResult` but contained different items. I'm surprised this didn't generate an error since there were two definitions of the same GraphQL type.

I fixed this by making all the grouping query results contain the word "Group".  For example, `targetGroup` now returns a `TargetGroupSelectResult` and `scienceModeGroup` returns a `ScienceModeGroupSelectResult`.

I'm sorry for the inconvenience this causes.  Removing grouping and adding filters was a huge change so unfortunately we may uncover more of these.