### PR TITLE
Improve mutli-item update error messages

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/TopLevelUpdateInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/TopLevelUpdateInput.scala
@@ -1,0 +1,67 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.api.model
+
+import cats.data.{NonEmptyChain, StateT}
+import cats.syntax.either._
+import cats.syntax.foldable._
+import cats.syntax.functor._
+import cats.syntax.traverse._
+import eu.timepit.refined.types.all.NonNegInt
+import lucuma.odb.api.model.query.{SizeLimitedResult, WherePredicate}
+
+/**
+ * An input for updating a top-level item (program, observation, target).
+ */
+trait TopLevelUpdateInput[I, A] {
+
+  def typeName: String
+
+  def editOne: StateT[EitherInput, A, Unit]
+
+  def WHERE: Option[WherePredicate[A]]
+
+  def LIMIT: Option[NonNegInt]
+
+  def state: DatabaseState[I, A]
+
+  def filteredValues: StateT[EitherInput, Database, List[A]] =
+    StateT.inspect[EitherInput, Database, List[A]] { db =>
+      val all = state.lens.get(db).rows.values
+      WHERE.fold(all)(where => all.filter(where.matches)).toList
+    }
+
+  def editAll(as: List[A])(implicit ev: TopLevelModel[I, A]): StateT[EitherInput, Database, List[A]] =
+    StateT.liftF[EitherInput, Database, List[A]] {
+      as.traverse { a =>
+        // If there are errors, we want to keep up with the associated ids.
+        // Turn this into validated as well in order to not short-circuit
+        editOne.runS(a).leftMap(_.tupleRight(ev.id(a))).toValidated
+      }.leftMap { nec =>
+        NonEmptyChain.fromNonEmptyList(
+          nec
+            .zipWithIndex // want to keep up with the order that the errors were found
+            .map { case ((error, id), index) => (error.message, (id, index)) }
+            .groupMap(_._1)(_._2) // make a Map keyed by error message -> Nec((id, index))
+            .toNel
+            .sortBy(_._2.head._2) // order by first time error appeared
+            .map { case (msg, idsAndIdxs) =>
+              val idList   = idsAndIdxs.toList.map(_._1) // we just want the ids
+              val idString = idList.take(10).mkString("", ", ", if (idList.sizeIs >  10) " ..." else "")
+              val prefix   = s"$typeName${if (idList.sizeIs == 1) "" else "s"}"
+              InputError.fromMessage(s"$prefix $idString: $msg")
+            }
+        )
+      }.toEither
+    }
+
+
+  def editor(implicit ev: TopLevelModel[I, A]): StateT[EitherInput, Database, SizeLimitedResult.Update[A]] =
+    for {
+      as  <- filteredValues
+      asʹ <- editAll(as)
+      _   <- asʹ.traverse(a => state.update(ev.id(a), a))
+    } yield SizeLimitedResult.Update.fromAll(asʹ, LIMIT)
+
+}

--- a/modules/service/src/test/scala/MutationSuite.scala
+++ b/modules/service/src/test/scala/MutationSuite.scala
@@ -247,7 +247,7 @@ class MutationSuite extends OdbSuite {
         }
       """,
     errors = List(
-      "'min' out of range: must be 1.0 <= min <= 3.0"
+      "observations o-3, o-4: 'min' out of range: must be 1.0 <= min <= 3.0"
     ),
     variables = Some(json"""
       {
@@ -431,7 +431,7 @@ class MutationSuite extends OdbSuite {
         }
       """,
     errors = List(
-      "FIXED constraints require an associated `angle` value"
+      "observation o-3: FIXED constraints require an associated `angle` value"
     ),
     variables = Some(json"""
       {

--- a/modules/service/src/test/scala/test/ProgramMutationSuite.scala
+++ b/modules/service/src/test/scala/test/ProgramMutationSuite.scala
@@ -39,10 +39,10 @@ class ProgramMutationSuite extends OdbSuite {
         updatePrograms(input: $updatePrograms)
     """ + programQuery("programs") + "}",
     errors = List(
-      "No minPercentTime definition provided",
-      "No totalTime definition provided",
-      "No toOActivation definition provided",
-      "No partnerSplits definition provided"
+      "program p-3: No minPercentTime definition provided",
+      "program p-3: No totalTime definition provided",
+      "program p-3: No toOActivation definition provided",
+      "program p-3: No partnerSplits definition provided"
     ),
     variables = json"""
       {

--- a/modules/service/src/test/scala/test/targets/TargetMutationSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetMutationSuite.scala
@@ -189,8 +189,8 @@ class TargetMutationSuite extends OdbSuite {
       }
     """,
     errors = List(
-      "No sidereal 'ra' definition provided",
-      "No sidereal 'dec' definition provided"
+      "target t-8: No sidereal 'ra' definition provided",
+      "target t-8: No sidereal 'dec' definition provided"
     ),
     variables = json"""
       {


### PR DESCRIPTION
When updating programs, observations or targets errors may be reported.  They may occur in one or more items but previously there was no way of knowing which ones generated each issue.  This update will prepend the type (`program`, `observation`, or `target` along with (up to 10 of) the ids of the associated problematic values.  See updated test cases for examples.