### PR TITLE
includeDeleted

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ObservationModel.scala
@@ -250,7 +250,8 @@ object ObservationModel extends ObservationOptics {
   final case class UpdateInput(
     SET:   PropertiesInput,
     WHERE: Option[WhereObservationInput],
-    LIMIT: Option[NonNegInt]
+    LIMIT: Option[NonNegInt],
+    includeDeleted: Boolean = false
   ) extends TopLevelUpdateInput[Observation.Id, ObservationModel] {
 
     override def typeName: String =
@@ -272,7 +273,8 @@ object ObservationModel extends ObservationOptics {
       Eq.by { a => (
         a.SET,
         a.WHERE,
-        a.LIMIT
+        a.LIMIT,
+        a.includeDeleted
       )}
 
   }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/ProgramModel.scala
@@ -127,7 +127,8 @@ object ProgramModel extends ProgramOptics {
   final case class UpdateInput(
     SET:   PropertiesInput,
     WHERE: Option[WhereProgramInput],
-    LIMIT: Option[NonNegInt]
+    LIMIT: Option[NonNegInt],
+    includeDeleted: Boolean = false
   ) extends TopLevelUpdateInput[Program.Id, ProgramModel] {
 
     override def typeName: String =
@@ -150,7 +151,8 @@ object ProgramModel extends ProgramOptics {
       Eq.by { a => (
         a.SET,
         a.WHERE,
-        a.LIMIT
+        a.LIMIT,
+        a.includeDeleted
       )}
 
   }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/WhereObservationInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/WhereObservationInput.scala
@@ -10,7 +10,7 @@ import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
 import lucuma.core.enums.{ObsActiveStatus, ObsStatus}
 import lucuma.core.model.{Observation, Program}
-import lucuma.odb.api.model.query.{WhereCombinator, WhereEqInput, WhereOptionStringInput, WhereOrderInput}
+import lucuma.odb.api.model.query.{WhereCombinator, WhereOptionStringInput, WhereOrderInput}
 
 final case class WhereObservationInput(
   AND:          Option[List[WhereObservationInput]]      = None,
@@ -21,8 +21,7 @@ final case class WhereObservationInput(
   programId:    Option[WhereOrderInput[Program.Id]]      = None,
   subtitle:     Option[WhereOptionStringInput]           = None,
   status:       Option[WhereOrderInput[ObsStatus]]       = None,
-  activeStatus: Option[WhereOrderInput[ObsActiveStatus]] = None,
-  existence:    Option[WhereEqInput[Existence]]          = WhereEqInput.EQ(Existence.Present: Existence).some
+  activeStatus: Option[WhereOrderInput[ObsActiveStatus]] = None
 ) extends WhereCombinator[ObservationModel] {
 
   override def matches(a: ObservationModel): Boolean =
@@ -31,8 +30,7 @@ final case class WhereObservationInput(
       programId.forall(_.matches(a.programId))             &&
       subtitle.forall(_.matchesNonEmptyString(a.subtitle)) &&
       status.forall(_.matches(a.status))                   &&
-      activeStatus.forall(_.matches(a.activeStatus))       &&
-      existence.forall(_.matches(a.existence))
+      activeStatus.forall(_.matches(a.activeStatus))
 
   def withId(id: Observation.Id): WhereObservationInput =
     copy(id = WhereOrderInput.EQ(id).some)
@@ -43,18 +41,12 @@ final case class WhereObservationInput(
   def withProgramId(pid: Program.Id): WhereObservationInput =
     copy(programId = WhereOrderInput.EQ(pid).some)
 
-  def includeDeleted: WhereObservationInput =
-    copy(existence = None)
-
 }
 
 object WhereObservationInput {
 
-  val MatchPresent: WhereObservationInput =
-    WhereObservationInput()
-
   val MatchAll: WhereObservationInput =
-    MatchPresent.includeDeleted
+    WhereObservationInput()
 
   implicit val customConfig: Configuration =
     Configuration.default.withDefaults

--- a/modules/core/src/main/scala/lucuma/odb/api/model/WhereProgramInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/WhereProgramInput.scala
@@ -9,7 +9,7 @@ import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
 import io.circe.Decoder
 import lucuma.core.model.Program
-import lucuma.odb.api.model.query.{WhereCombinator, WhereEqInput, WhereOptionStringInput, WhereOrderInput}
+import lucuma.odb.api.model.query.{WhereCombinator, WhereOptionStringInput, WhereOrderInput}
 
 final case class WhereProgramInput(
   AND:       Option[List[WhereProgramInput]]     = None,
@@ -18,16 +18,14 @@ final case class WhereProgramInput(
 
   id:        Option[WhereOrderInput[Program.Id]] = None,
   name:      Option[WhereOptionStringInput]      = None,
-  proposal:  Option[WhereProposalInput]          = None,
-  existence: Option[WhereEqInput[Existence]]     = WhereEqInput.EQ(Existence.Present: Existence).some
+  proposal:  Option[WhereProposalInput]          = None
 ) extends WhereCombinator[ProgramModel] {
 
   override def matches(a: ProgramModel): Boolean =
     combinatorMatches(a)                          &&
       id.forall(_.matches(a.id))                  &&
       name.forall(_.matches(a.name.map(_.value))) &&
-      proposal.forall(_.matches(a.proposal))      &&
-      existence.forall(_.matches(a.existence))
+      proposal.forall(_.matches(a.proposal))
 
   def withId(id: Program.Id): WhereProgramInput =
     copy(id = WhereOrderInput.EQ(id).some)
@@ -35,17 +33,12 @@ final case class WhereProgramInput(
   def withIds(ids: List[Program.Id]): WhereProgramInput =
     copy(id = WhereOrderInput.IN(ids).some)
 
-  def includeDeleted: WhereProgramInput =
-    copy(existence = None)
 }
 
 object WhereProgramInput {
 
-  val MatchPresent: WhereProgramInput =
-    WhereProgramInput()
-
   val MatchAll: WhereProgramInput =
-    MatchPresent.includeDeleted
+    WhereProgramInput()
 
   implicit val customConfig: Configuration =
     Configuration.default.withDefaults

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/TargetModel.scala
@@ -202,7 +202,8 @@ object TargetModel extends TargetModelOptics {
   final case class UpdateInput(
     SET:   PropertiesInput,
     WHERE: Option[WhereTargetInput],
-    LIMIT: Option[NonNegInt]
+    LIMIT: Option[NonNegInt],
+    includeDeleted: Boolean = false
   ) extends TopLevelUpdateInput[Target.Id, TargetModel] {
 
     override def typeName: String =
@@ -225,7 +226,8 @@ object TargetModel extends TargetModelOptics {
       Eq.by { a => (
         a.SET,
         a.WHERE,
-        a.LIMIT
+        a.LIMIT,
+        a.includeDeleted
       )}
 
   }

--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/WhereTargetInput.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/WhereTargetInput.scala
@@ -9,8 +9,7 @@ import io.circe.Decoder
 import io.circe.generic.extras.Configuration
 import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
 import lucuma.core.model.{Program, Target}
-import lucuma.odb.api.model.Existence
-import lucuma.odb.api.model.query.{WhereCombinator, WhereEqInput, WhereOrderInput, WhereStringInput}
+import lucuma.odb.api.model.query.{WhereCombinator, WhereOrderInput, WhereStringInput}
 
 final case class WhereTargetInput(
   AND:       Option[List[WhereTargetInput]]      = None,
@@ -19,16 +18,14 @@ final case class WhereTargetInput(
 
   id:        Option[WhereOrderInput[Target.Id]]  = None,
   programId: Option[WhereOrderInput[Program.Id]] = None,
-  name:      Option[WhereStringInput]            = None,
-  existence: Option[WhereEqInput[Existence]]     = WhereEqInput.EQ(Existence.Present: Existence).some
+  name:      Option[WhereStringInput]            = None
 ) extends WhereCombinator[TargetModel] {
 
   override def matches(a: TargetModel): Boolean =
     combinatorMatches(a)                           &&
       id.forall(_.matches(a.id))                   &&
       programId.forall(_.matches(a.programId))     &&
-      name.forall(_.matchesNonEmptyString(a.name)) &&
-      existence.forall(_.matches(a.existence))
+      name.forall(_.matchesNonEmptyString(a.name))
 
   def withId(id: Target.Id): WhereTargetInput =
     copy(id = WhereOrderInput.EQ(id).some)
@@ -39,17 +36,12 @@ final case class WhereTargetInput(
   def withProgramId(pid: Program.Id): WhereTargetInput =
     copy(programId = WhereOrderInput.EQ(pid).some)
 
-  def includeDeleted: WhereTargetInput =
-    copy(existence = None)
 }
 
 object WhereTargetInput {
 
-  val MatchPresent: WhereTargetInput =
-    WhereTargetInput()
-
   val MatchAll: WhereTargetInput =
-    MatchPresent.includeDeleted
+    WhereTargetInput()
 
   implicit val customConfig: Configuration =
     Configuration.default.withDefaults

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationGroupSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationGroupSchema.scala
@@ -70,7 +70,7 @@ object ObservationGroupSchema {
     name:        String,
     description: String,
     outType:     OutputType[A],
-    lookupAll:   (ObservationRepo[F], Program.Id, Option[WhereObservationInput]) => F[List[ObservationModel.Group[A]]]
+    lookupAll:   (ObservationRepo[F], Program.Id, Option[WhereObservationInput], Boolean) => F[List[ObservationModel.Group[A]]]
   ): Field[OdbCtx[F], Unit] = {
 
     val groupType =
@@ -90,10 +90,11 @@ object ObservationGroupSchema {
       arguments   = List(
         ArgumentProgramId,
         ArgumentOptionWhereObservation,
-        ArgumentOptionLimit
+        ArgumentOptionLimit,
+        ArgumentIncludeDeleted
       ),
       resolve    = c => c.unsafeToFuture {
-        lookupAll(c.ctx.odbRepo.observation, c.programId, c.arg(ArgumentOptionWhereObservation)).map { gs =>
+        lookupAll(c.ctx.odbRepo.observation, c.programId, c.arg(ArgumentOptionWhereObservation), c.includeDeleted).map { gs =>
           SizeLimitedResult.Select.fromAll(gs, c.arg(ArgumentOptionLimit))
         }
       }

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
@@ -554,7 +554,7 @@ object ObservationSchema {
       (c: HCursor) => for {
         where <- c.downField("WHERE").as[Option[WhereObservationInput]]
         limit <- c.downField("LIMIT").as[Option[NonNegInt]]
-      } yield ObservationModel.UpdateInput(set, where, limit)
+      } yield ObservationModel.UpdateInput(set, where, limit, includeDeleted = to.isPresent)
 
     val arg   =
       to.fold(InputObjectTypeObservationDelete, InputObjectTypeObservationUndelete)

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ObservationSchema.scala
@@ -15,7 +15,7 @@ import lucuma.core.model.{ConstraintSet, Observation}
 import lucuma.odb.api.model.{Existence, ObservationModel, PlannedTimeSummaryModel, ScienceMode, ScienceRequirements, WhereObservationInput}
 import lucuma.odb.api.model.ObservationModel.BulkEdit
 import lucuma.odb.api.model.targetModel.{EditAsterismPatchInput, TargetEnvironmentModel, TargetModel}
-import lucuma.odb.api.model.query.{SizeLimitedResult, WhereEqInput, WhereOrderInput}
+import lucuma.odb.api.model.query.{SizeLimitedResult, WhereOrderInput}
 import lucuma.odb.api.repo.OdbCtx
 import lucuma.odb.api.schema.TargetSchema.TargetEnvironmentType
 import org.typelevel.log4cats.Logger
@@ -30,7 +30,7 @@ object ObservationSchema {
   import ScienceModeSchema._
   import ExecutionSchema.ExecutionType
   import ItcSchema.ItcSuccessType
-  import GeneralSchema.{ArgumentIncludeDeleted, EnumTypeExistence, InputObjectTypeWhereEqExistence, PlannedTimeSummaryType}
+  import GeneralSchema.{ArgumentIncludeDeleted, EnumTypeExistence, PlannedTimeSummaryType}
   import PosAngleConstraintSchema._
   import ProgramSchema.{ProgramIdType, ProgramType, InputObjectWhereOrderProgramId}
   import RefinedSchema.{NonEmptyStringType, NonNegIntType}
@@ -80,8 +80,7 @@ object ObservationSchema {
             InputObjectWhereOrderProgramId.optionField("programId", "Matches the id of the program associated with this observation."),
             InputObjectWhereOptionString.optionField("subtitle", "Matches the subtitle of the observation."),
             InputObjectWhereOrderObsStatus.optionField("status", "Matches the observation status."),
-            InputObjectWhereOrderObsActiveStatus.optionField("activeStatus", "Matches the observation active status."),
-            InputField("existence", OptionInputType(InputObjectTypeWhereEqExistence), "By default matching is limited to PRESENT observations.  Use this filter to include DELETED observations as well, for example.", WhereEqInput.EQ(Existence.Present: Existence).some)
+            InputObjectWhereOrderObsActiveStatus.optionField("activeStatus", "Matches the observation active status.")
           )
     )
 
@@ -273,13 +272,14 @@ object ObservationSchema {
       arguments   = List(
         ArgumentOptionWhereObservation,
         ArgumentOptionOffsetObservation,
-        ArgumentOptionLimit
+        ArgumentOptionLimit,
+        ArgumentIncludeDeleted
       ),
       resolve     = c => {
-        val where = c.arg(ArgumentOptionWhereObservation).getOrElse(WhereObservationInput.MatchPresent)
+        val where = c.arg(ArgumentOptionWhereObservation).getOrElse(WhereObservationInput.MatchAll)
         val off   = c.arg(ArgumentOptionOffsetObservation)
         val limit = c.resultSetLimit
-        c.observation(_.selectWhere(where, off, limit))
+        c.observation(_.selectWhere(where, off, limit, c.includeDeleted))
       }
     )
 
@@ -288,8 +288,8 @@ object ObservationSchema {
       name        = "observation",
       fieldType   = OptionType(ObservationType[F]),
       description = "Returns the observation with the given id, if any.".some,
-      arguments   = List(ArgumentObservationId, ArgumentIncludeDeleted),
-      resolve     = c => c.observation(_.select(c.observationId, c.includeDeleted))
+      arguments   = List(ArgumentObservationId),
+      resolve     = c => c.observation(_.select(c.observationId, includeDeleted = true))
     )
 
   def groupByTarget[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
@@ -298,7 +298,7 @@ object ObservationSchema {
       "target",
       "Observations grouped by commonly held targets",
       TargetType[F],
-      (repo, pid, where) => repo.groupByTargetInstantiated(pid, where)
+      (repo, pid, where, inc) => repo.groupByTargetInstantiated(pid, where, inc)
     )
 
   def groupByAsterism[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
@@ -307,7 +307,7 @@ object ObservationSchema {
       "asterism",
       "Observations grouped by commonly held science asterisms",
       ListType(TargetType[F]),
-      (repo, pid, where) => repo.groupByAsterismInstantiated(pid, where)
+      (repo, pid, where, inc) => repo.groupByAsterismInstantiated(pid, where, inc)
     )
 
   def groupByTargetEnvironment[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
@@ -316,7 +316,7 @@ object ObservationSchema {
       "targetEnvironment",
       "Observations grouped by common target environment",
       TargetEnvironmentType[F],
-      (repo, pid, where) => repo.groupByTargetEnvironment(pid, where)
+      (repo, pid, where, inc) => repo.groupByTargetEnvironment(pid, where, inc)
     )
 
   def groupByConstraintSet[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
@@ -325,7 +325,7 @@ object ObservationSchema {
       "constraintSet",
       "Observations grouped by commonly held constraints",
       ConstraintSetType,
-      (repo, pid, where) => repo.groupByConstraintSet(pid, where)
+      (repo, pid, where, inc) => repo.groupByConstraintSet(pid, where, inc)
     )
 
   def groupByScienceMode[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
@@ -334,7 +334,7 @@ object ObservationSchema {
       "scienceMode",
       "Observations grouped by commonly held science mode",
       OptionType(ScienceModeType),
-      (repo, pid, where) => repo.groupByScienceMode(pid, where)
+      (repo, pid, where, inc) => repo.groupByScienceMode(pid, where, inc)
     )
 
   def groupByScienceRequirements[F[_]: Dispatcher: Async: Logger]: Field[OdbCtx[F], Unit] =
@@ -343,7 +343,7 @@ object ObservationSchema {
       "scienceRequirements",
       "Observations grouped by commonly held science requirements",
       ScienceRequirementsType[F],
-      (repo, pid, where) => repo.groupByScienceRequirements(pid, where)
+      (repo, pid, where, inc) => repo.groupByScienceRequirements(pid, where, inc)
     )
 
   def queryFields[F[_]: Dispatcher: Async: Logger]: List[Field[OdbCtx[F], Unit]] =
@@ -395,7 +395,8 @@ object ObservationSchema {
       List(
         InputField("SET",  InputObjectTypeObservationProperties, "Describes the observation values to modify."),
         InputObjectWhereObservation.optionField("WHERE", "Filters the observations to be updated according to those that match the given constraints."),
-        NonNegIntType.optionField("LIMIT", "Caps the number of results returned to the given value (if additional observations match the WHERE clause they will be updated but not returned).")
+        NonNegIntType.optionField("LIMIT", "Caps the number of results returned to the given value (if additional observations match the WHERE clause they will be updated but not returned)."),
+        InputField("includeDeleted", OptionInputType(BooleanType), "Set to `true` to include deleted observations.", false.some)
       )
     )
 

--- a/modules/core/src/test/scala/lucuma/odb/api/repo/ObservationRepoSpec.scala
+++ b/modules/core/src/test/scala/lucuma/odb/api/repo/ObservationRepoSpec.scala
@@ -8,9 +8,9 @@ import cats.kernel.instances.order._
 import clue.data.Input
 import eu.timepit.refined.types.numeric.NonNegInt
 import eu.timepit.refined.types.string.NonEmptyString
-import lucuma.odb.api.model.{Database, Existence, ObservationModel, ProgramModel, WhereObservationInput}
+import lucuma.odb.api.model.{Database, ObservationModel, ProgramModel, WhereObservationInput}
 import lucuma.odb.api.model.arb.ArbDatabase
-import lucuma.odb.api.model.query.{WhereEqInput, WhereOrderInput}
+import lucuma.odb.api.model.query.WhereOrderInput
 import org.scalacheck.Prop.forAll
 import munit.ScalaCheckSuite
 
@@ -57,11 +57,11 @@ final class ObservationRepoSpec extends ScalaCheckSuite with OdbRepoTest {
       val obtained = runTest(t) {
         _.observation.selectWhere(
           WhereObservationInput(
-            id        = WhereOrderInput.IN(expected).some,
-            existence = WhereEqInput.ANY[Existence].some
+            id        = WhereOrderInput.IN(expected).some
           ),
           None,
-          None
+          None,
+          includeDeleted = true
         )
       }.limitedValues.map(_.id)
 
@@ -119,7 +119,8 @@ final class ObservationRepoSpec extends ScalaCheckSuite with OdbRepoTest {
             subtitle = Input(NonEmptyString.unsafeFrom("Biff"))
           ),
           WhereObservationInput.MatchAll.withId(o.id).some,
-          None
+          None,
+          includeDeleted = true
         )
       }
       assert(obs.subtitle.contains(NonEmptyString.unsafeFrom("Biff")))
@@ -135,7 +136,8 @@ final class ObservationRepoSpec extends ScalaCheckSuite with OdbRepoTest {
             subtitle = o.subtitle.fold(Input.ignore[NonEmptyString])(n => Input(n))
           ),
           WhereObservationInput.MatchAll.withId(o.id).some,
-          None
+          None,
+          includeDeleted = true
         )
       }
       assertEquals(after, before)

--- a/modules/service/src/test/scala/test/GroupIncludeDeletedSuite.scala
+++ b/modules/service/src/test/scala/test/GroupIncludeDeletedSuite.scala
@@ -74,7 +74,7 @@ class GroupIncludeDeletedSuite extends OdbSuite {
   queryTest(
     query = """
       query ObservationsByConstraintSet {
-        constraintSetGroup(programId:"p-2", WHERE: { existence: { IN: [ PRESENT, DELETED ] } } ) {
+        constraintSetGroup(programId:"p-2", includeDeleted: true) {
           matches {
             observationIds
           }

--- a/modules/service/src/test/scala/test/ObservationUndeleteSuite.scala
+++ b/modules/service/src/test/scala/test/ObservationUndeleteSuite.scala
@@ -1,0 +1,195 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package test
+
+import cats.syntax.option._
+import io.circe.literal._
+
+class ObservationUndeleteSuite extends OdbSuite {
+
+  // Delete o-6
+  queryTest(
+    query ="""
+      mutation DeleteObservations($deleteObservationsInput: DeleteObservationsInput!) {
+        deleteObservations(input: $deleteObservationsInput) {
+          observations {
+            id
+          }
+        }
+      }
+    """,
+    expected = json"""
+      {
+        "deleteObservations": {
+          "observations": [
+            {
+              "id": "o-6"
+            }
+          ]
+        }
+      }
+    """,
+    variables = json"""
+      {
+        "deleteObservationsInput": {
+          "WHERE": {
+            "id": { "EQ": "o-6" }
+          }
+        }
+      }
+    """.some,
+    clients = List(ClientOption.Http)
+  )
+
+  // Fetch all observations. o-6 is not included by default in the results
+  // because it was deleted.
+  queryTest(
+    query ="""
+      query AllObservations {
+        observations(WHERE: { programId: { EQ: "p-2" } }) {
+          matches {
+            id
+          }
+        }
+      }
+    """,
+    expected = json"""
+      {
+        "observations": {
+          "matches": [
+            {
+              "id": "o-2"
+            },
+            {
+              "id": "o-3"
+            },
+            {
+              "id": "o-4"
+            },
+            {
+              "id": "o-5"
+            },
+            {
+              "id": "o-7"
+            }
+          ]
+        }
+      }
+    """
+  )
+
+  // Fetch all observations again, but including deleted
+  queryTest(
+    query ="""
+      query AllObservationsIncludeDeleted {
+        observations(WHERE: { programId: { EQ: "p-2" } }, includeDeleted: true) {
+          matches {
+            id
+          }
+        }
+      }
+    """,
+    expected = json"""
+      {
+        "observations": {
+          "matches": [
+            {
+              "id": "o-2"
+            },
+            {
+              "id": "o-3"
+            },
+            {
+              "id": "o-4"
+            },
+            {
+              "id": "o-5"
+            },
+            {
+              "id": "o-6"
+            },
+            {
+              "id": "o-7"
+            }
+          ]
+        }
+      }
+    """
+  )
+
+  // undelete o-6
+  queryTest(
+    query ="""
+      mutation UndeleteObservations($undeleteObservationsInput: UndeleteObservationsInput!) {
+        undeleteObservations(input: $undeleteObservationsInput) {
+          observations {
+            id
+          }
+        }
+      }
+    """,
+    expected = json"""
+      {
+        "undeleteObservations": {
+          "observations": [
+            {
+              "id": "o-6"
+            }
+          ]
+        }
+      }
+    """,
+    variables = json"""
+      {
+        "undeleteObservationsInput": {
+          "WHERE": {
+            "id": { "EQ": "o-6" }
+          }
+        }
+      }
+    """.some,
+    clients = List(ClientOption.Http)
+  )
+
+  // Fetch all observations and o-6 appears again.
+  queryTest(
+    query ="""
+      query AllObservationsAgain {
+        observations(WHERE: { programId: { EQ: "p-2" } }) {
+          matches {
+            id
+          }
+        }
+      }
+    """,
+    expected = json"""
+      {
+        "observations": {
+          "matches": [
+            {
+              "id": "o-2"
+            },
+            {
+              "id": "o-3"
+            },
+            {
+              "id": "o-4"
+            },
+            {
+              "id": "o-5"
+            },
+            {
+              "id": "o-6"
+            },
+            {
+              "id": "o-7"
+            }
+          ]
+        }
+      }
+    """
+  )
+
+
+}

--- a/modules/service/src/test/scala/test/TestInit.scala
+++ b/modules/service/src/test/scala/test/TestInit.scala
@@ -489,7 +489,7 @@ object TestInit {
                     )
                   ).assign
                 ),
-                WhereObservationInput.MatchPresent.withIds(List(o.id)).some,
+                WhereObservationInput.MatchAll.withIds(List(o.id)).some,
                 None
               )
             )

--- a/modules/service/src/test/scala/test/targets/TargetUndeleteSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetUndeleteSuite.scala
@@ -1,0 +1,164 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package test
+package targets
+
+import cats.syntax.option._
+import io.circe.literal._
+
+class TargetUndeleteSuite extends OdbSuite {
+
+  //
+  // Observations and their targets:
+  //
+  // o-2: NGC 5949
+  // o-3: NGC 3312
+  // o-4: NGC 3312
+  // o-5: NGC 3312 (explicit base)
+  // o-6: NGC 5949, NGC 3269, NGC 3312
+  // o-7: <none>
+  //
+
+  // Delete NGC 3269 (t-3)
+  queryTest(
+    query ="""
+      mutation DeleteTarget($deleteTargetInput: DeleteTargetsInput!) {
+        deleteTargets(input: $deleteTargetInput) {
+          targets {
+            id
+          }
+        }
+      }
+    """,
+    expected = json"""
+      {
+        "deleteTargets": {
+          "targets": [
+            {
+              "id": "t-3"
+            }
+          ]
+        }
+      }
+    """,
+    variables = json"""
+      {
+        "deleteTargetInput": {
+          "WHERE": {
+            "id": { "EQ": "t-3" }
+          }
+        }
+      }
+    """.some,
+    clients = List(ClientOption.Http)
+  )
+
+  // Fetch all science targets.  There is a t-6 but for p-3 so we skip it.
+  // t-3 is not included by default in the results because it was deleted.
+  queryTest(
+    query ="""
+      query AllTargets {
+        targets(WHERE: { programId: { EQ: "p-2" } }) {
+          matches {
+            id
+            name
+          }
+        }
+      }
+    """,
+    expected = json"""
+      {
+        "targets": {
+          "matches": [
+            {
+              "id": "t-2",
+              "name": "NGC 5949"
+            },
+            {
+              "id": "t-4",
+              "name": "NGC 3312"
+            },
+            {
+              "id": "t-5",
+              "name": "NGC 4749"
+            }
+          ]
+        }
+      }
+    """
+  )
+
+  // Undelete NGC 3269 (t-3)
+  queryTest(
+    query ="""
+      mutation UndeleteTargets($undeleteTargetsInput: UndeleteTargetsInput!) {
+        undeleteTargets(input: $undeleteTargetsInput) {
+          targets {
+            id
+          }
+        }
+      }
+    """,
+    expected = json"""
+      {
+        "undeleteTargets": {
+          "targets": [
+            {
+              "id": "t-3"
+            }
+          ]
+        }
+      }
+    """,
+    variables = json"""
+      {
+        "undeleteTargetsInput": {
+          "WHERE": {
+            "id": { "EQ": "t-3" },
+            "existence": { "EQ": "DELETED" }
+          }
+        }
+      }
+    """.some,
+    clients = List(ClientOption.Http)
+  )
+
+  // Fetch all science targets.  t-3 appears again.
+  queryTest(
+    query ="""
+      query AllTargets {
+        targets(WHERE: { programId: { EQ: "p-2" } }) {
+          matches {
+            id
+            name
+          }
+        }
+      }
+    """,
+    expected = json"""
+      {
+        "targets": {
+          "matches": [
+            {
+              "id": "t-2",
+              "name": "NGC 5949"
+            },
+            {
+              "id": "t-3",
+              "name": "NGC 3269"
+            },
+            {
+              "id": "t-4",
+              "name": "NGC 3312"
+            },
+            {
+              "id": "t-5",
+              "name": "NGC 4749"
+            }
+          ]
+        }
+      }
+    """
+  )
+}

--- a/modules/service/src/test/scala/test/targets/TargetUndeleteSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetUndeleteSuite.scala
@@ -93,7 +93,7 @@ class TargetUndeleteSuite extends OdbSuite {
   // targets.
   queryTest(
     query ="""
-      query AllTargets {
+      query AllTargetsIncludeDeleted {
         targets(WHERE: { programId: { EQ: "p-2" } }, includeDeleted: true) {
           matches {
             id

--- a/modules/service/src/test/scala/test/targets/TargetUndeleteSuite.scala
+++ b/modules/service/src/test/scala/test/targets/TargetUndeleteSuite.scala
@@ -89,6 +89,45 @@ class TargetUndeleteSuite extends OdbSuite {
     """
   )
 
+  // Fetch all science targets again, but make a point of including deleted
+  // targets.
+  queryTest(
+    query ="""
+      query AllTargets {
+        targets(WHERE: { programId: { EQ: "p-2" } }, includeDeleted: true) {
+          matches {
+            id
+            name
+          }
+        }
+      }
+    """,
+    expected = json"""
+      {
+        "targets": {
+          "matches": [
+            {
+              "id": "t-2",
+              "name": "NGC 5949"
+            },
+            {
+              "id": "t-3",
+              "name": "NGC 3269"
+            },
+            {
+              "id": "t-4",
+              "name": "NGC 3312"
+            },
+            {
+              "id": "t-5",
+              "name": "NGC 4749"
+            }
+          ]
+        }
+      }
+    """
+  )
+
   // Undelete NGC 3269 (t-3)
   queryTest(
     query ="""
@@ -115,8 +154,7 @@ class TargetUndeleteSuite extends OdbSuite {
       {
         "undeleteTargetsInput": {
           "WHERE": {
-            "id": { "EQ": "t-3" },
-            "existence": { "EQ": "DELETED" }
+            "id": { "EQ": "t-3" }
           }
         }
       }


### PR DESCRIPTION
The PR adjusts the API to

* Move the `existence` property from the `Program`, `Observation`, and `Target` `WHERE` clauses to the update input itself, but expressed as a boolean `includeDeleted` flag.
* Remove the `includeDeleted` flag from simple one-value-by-id `program`, `observation` and `target` queries since presumably if you're searching for a particular id you want it whether or not it is deleted.
* Make `deleteObservation`, `undeleteObservation`, `deleteTarget` and `undeleteTarget` not offer an `includeDeleted` argument because it is now implied  by the nature of the operation itself.

Moving the `existence` flag was done to

* Provide just one way to indicate whether or not to include deleted values throughout the API.  Previously it was via the `includeDeleted` flag in some queries and via the `existence` property in `WHERE` clauses elsewhere.  Now it is consistently via the `includeDeleted` flag.
* Fix a bug that was introduced by trying to default the value of the `existence` property to remove deleted values.  This was problematic because of the possibility of nesting clauses with their own default `existence` properties.

## Example

Query all targets, including deleted values

```
      query AllTargets {
        targets(WHERE: { programId: { EQ: "p-2" } }, includeDeleted: true) {
          matches {
            id
            name
          }
        }
      }
```

Query a particular target, whether or not it is deleted.

```
      query OneTarget {
        target(targetId: "t-2") {
          id
          name
        }
      }
```