### PR TITLE
Remove duplicate  enum

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProgramSchema.scala
@@ -9,8 +9,8 @@ import cats.syntax.foldable._
 import cats.syntax.option._
 import cats.syntax.functor._
 import lucuma.core.enums.{TacCategory, ToOActivation}
-import lucuma.core.model.{Partner, Program}
-import lucuma.odb.api.model.{PlannedTimeSummaryModel, ProgramModel, ProposalClassInput, ProposalInput, WhereProgramInput}
+import lucuma.core.model.Program
+import lucuma.odb.api.model.{PlannedTimeSummaryModel, ProgramModel, ProposalClassInput, WhereProgramInput}
 import lucuma.odb.api.model.ProposalClassInput._
 import lucuma.odb.api.model.query.{SizeLimitedResult, WhereOrderInput}
 import lucuma.odb.api.repo.OdbCtx
@@ -23,7 +23,7 @@ object ProgramSchema {
 
   import GeneralSchema.{ArgumentIncludeDeleted, EnumTypeExistence, PlannedTimeSummaryType}
   import ObservationSchema.{ArgumentOptionOffsetObservation, ObservationSelectResult}
-  import ProposalSchema.{ProposalType, InputObjectWhereProposal}
+  import ProposalSchema.{InputObjectProposalInput, InputObjectWhereProposal, ProposalType}
   import RefinedSchema.{IntPercentType, NonEmptyStringType, NonNegIntType}
   import QuerySchema._
   import TimeSchema.InputObjectTypeNonNegDuration
@@ -273,32 +273,6 @@ object ProgramSchema {
     EnumType.fromEnumerated(
       "toOActivation",
       "Target of opportunity activation"
-    )
-
-  implicit val EnumTypePartner: EnumType[Partner] =
-    EnumType.fromEnumerated(
-      "partner",
-      "Partner"
-    )
-
-  implicit val InputObjectTypePartnerSplitInput: InputObjectType[ProposalInput.PartnerSplitInput] =
-    deriveInputObjectType[ProposalInput.PartnerSplitInput](
-      InputObjectTypeName("PartnerSplitsInput"),
-      InputObjectTypeDescription("Partner time allocation: must be empty or sum to 100%"),
-      ReplaceInputField("partner", EnumTypePartner.notNullableField("partner")),
-      ReplaceInputField("percent", IntPercentType.notNullableField("percent"))
-    )
-
-  implicit val InputObjectProposalInput: InputObjectType[ProposalInput] =
-    deriveInputObjectType[ProposalInput](
-      InputObjectTypeName("ProposalInput"),
-      InputObjectTypeDescription("Program proposal"),
-      ReplaceInputField("title",         NonEmptyStringType.nullableField("title")),
-      ReplaceInputField("proposalClass", InputObjectTypeProposalClassInput.createRequiredEditOptional("proposalClass", "proposal")),
-      ReplaceInputField("category",      EnumTypeTacCategory.nullableField("category")),
-      ReplaceInputField("toOActivation", EnumTypeToOActivation.createRequiredEditOptional("toOActivation", "proposal")),
-      ReplaceInputField("abstrakt",      NonEmptyStringType.nullableField("abstract")),
-      ReplaceInputField("partnerSplits", ListInputType(InputObjectTypePartnerSplitInput).createRequiredEditOptional("partnerSplits", "proposal"))
     )
 
   implicit val InputObjectTypeProgramProperties: InputObjectType[ProgramModel.PropertiesInput] =

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/ProposalSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/ProposalSchema.scala
@@ -5,8 +5,10 @@ package lucuma.odb.api.schema
 
 import lucuma.core.enums.{TacCategory, ToOActivation}
 import lucuma.core.model.{Partner, Proposal}
-import lucuma.odb.api.model.{PartnerSplit, ProposalClassEnum, WhereProposalInput, WhereProposalClassInput, WhereProposalPartnerEntryInput, WhereProposalPartnersInput}
+import lucuma.odb.api.model.{PartnerSplit, ProposalClassEnum, ProposalInput, WhereProposalClassInput, WhereProposalInput, WhereProposalPartnerEntryInput, WhereProposalPartnersInput}
 import lucuma.odb.api.model.query.{WhereEqInput, WhereOptionEqInput}
+import lucuma.odb.api.schema.ProgramSchema.InputObjectTypeProposalClassInput
+import sangria.macros.derive.{InputObjectTypeDescription, InputObjectTypeName, ReplaceInputField, deriveInputObjectType}
 import sangria.schema._
 
 object ProposalSchema {
@@ -88,6 +90,26 @@ object ProposalSchema {
             InputObjectWhereOptionString.optionField("abstract", "Matches the proposal abstract."), // abstrakt
             InputObjectWhereProposalPartners.optionField("partners", "Matches proposal partners.")
           )
+    )
+
+  implicit val InputObjectTypePartnerSplitInput: InputObjectType[ProposalInput.PartnerSplitInput] =
+    deriveInputObjectType[ProposalInput.PartnerSplitInput](
+      InputObjectTypeName("PartnerSplitsInput"),
+      InputObjectTypeDescription("Partner time allocation: must be empty or sum to 100%"),
+      ReplaceInputField("partner", EnumTypePartner.notNullableField("partner")),
+      ReplaceInputField("percent", IntPercentType.notNullableField("percent"))
+    )
+
+  implicit val InputObjectProposalInput: InputObjectType[ProposalInput] =
+    deriveInputObjectType[ProposalInput](
+      InputObjectTypeName("ProposalInput"),
+      InputObjectTypeDescription("Program proposal"),
+      ReplaceInputField("title",         NonEmptyStringType.nullableField("title")),
+      ReplaceInputField("proposalClass", InputObjectTypeProposalClassInput.createRequiredEditOptional("proposalClass", "proposal")),
+      ReplaceInputField("category",      EnumTypeTacCategory.nullableField("category")),
+      ReplaceInputField("toOActivation", EnumTypeToOActivation.createRequiredEditOptional("toOActivation", "proposal")),
+      ReplaceInputField("abstrakt",      NonEmptyStringType.nullableField("abstract")),
+      ReplaceInputField("partnerSplits", ListInputType(InputObjectTypePartnerSplitInput).createRequiredEditOptional("partnerSplits", "proposal"))
     )
 
   implicit val PartnerSplitType: ObjectType[Any, PartnerSplit] =


### PR DESCRIPTION
The schema defined both `Partner` and `partner` enums and they were identical. This removes `partner` and moves some proposal stuff over from `ProgramSchema` over to where it belongs in `ProposalSchema`.

The only visible difference should be that `partner` goes away and `PartnerSplitsInput` `partner` field is now type `Partner` instead of `partner`.

![Screen Shot 2022-07-21 at 15 03 12](https://user-images.githubusercontent.com/4906023/180295795-1f987d7d-a040-4b5b-abe6-9f31d79a24d1.png)
![Screen Shot 2022-07-21 at 15 01 28](https://user-images.githubusercontent.com/4906023/180295817-ef7b3c53-61d0-430d-ad43-e2c2db953087.png)

