### PR TITLE
Set a default SED

### DIFF
--- a/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SourceProfileModel.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/model/targetModel/SourceProfileModel.scala
@@ -303,10 +303,14 @@ object SourceProfileModel {
 
     import lucuma.odb.api.model.targetModel.SourceProfileModel.BandNormalizedInput._
 
-    override val create: ValidatedInput[BandNormalized[T]] =
-      (sed.notMissingAndThen("sed")(_.toUnnormalizedSed),
-       brightnesses.notMissingAndThen("brightnesses")(brightnessCreator[T])
-      ).mapN { (sed, bright) => BandNormalized(sed, bright) }
+    override val create: ValidatedInput[BandNormalized[T]] = {
+      // we can't update lucuma-core thus we need to default to somthing
+      val modelSed = sed.toOption.map(_.toUnnormalizedSed)
+        .getOrElse(UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.O5V).validNec)
+      (modelSed, brightnesses.notMissingAndThen("brightnesses")(brightnessCreator[T])).mapN { (sed, bright) =>
+        BandNormalized(sed, bright)
+      }
+    }
 
     override val edit: StateT[EitherInput, BandNormalized[T], Unit] =
       for {

--- a/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
+++ b/modules/core/src/main/scala/lucuma/odb/api/schema/SourceProfileSchema.scala
@@ -583,7 +583,7 @@ object SourceProfileSchema {
   )(implicit ev: InputType[BandBrightnessInput[T]]): InputObjectType[BandNormalizedInput[T]] =
     InputObjectType[BandNormalizedInput[T]](
       s"BandNormalized${groupName.capitalize}Input",
-      s"""Create or edit a band normalized value with $groupName magnitude units.  Specify both "sed" and "brightnesses" when creating a new BandNormalized${groupName.capitalize}.""",
+      s"""Create or edit a band normalized value with $groupName magnitude units.  Specify "brightnesses" and an optional "sed" parameter when creating a new BandNormalized${groupName.capitalize}.""",
       List(
         InputObjectUnnormalizedSed.createRequiredEditOptional("sed", s"BandNormalized${groupName.capitalize}"),
         ListInputType(ev).createRequiredEditOptional("brightnesses", s"BandNormalized${groupName.capitalize}"),


### PR DESCRIPTION
I did a naive fix to support empty SED but it was too naive
Turns out we can't update `lucuma-core` is it is scala-3 only now. Given this project is going to be short lived we may as well just assign a default SED until `lucuma-odb` proper can solve it
This is working with explore and the latest `lucuma-core`